### PR TITLE
Wire blog detail page to backend data

### DIFF
--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -25,12 +25,24 @@ class BlogController extends Controller
      */
     public function show($slug)
     {
-        $blog = Blog::where('slug', $slug)
+        $blog = Blog::with(['user:id,name'])
+            ->where('slug', $slug)
             ->where('status', 'published')
             ->firstOrFail();
 
         return inertia('BlogView', [
-            'blog' => $blog,
+            'blog' => [
+                'id' => $blog->id,
+                'title' => $blog->title,
+                'slug' => $blog->slug,
+                'excerpt' => $blog->excerpt,
+                'body' => $blog->body,
+                'published_at' => optional($blog->published_at)->toIso8601String(),
+                'user' => $blog->user ? [
+                    'id' => $blog->user->id,
+                    'name' => $blog->user->name,
+                ] : null,
+            ],
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- include the blog author relationship when serving the detail endpoint and shape the payload for Inertia
- render the incoming blog content on the BlogView page with formatted metadata and remove placeholder comments

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68d8c8d5de54832ca74760d338d96042