### PR TITLE
Guard shared layout auth access and fix nav routes

### DIFF
--- a/resources/js/components/AppHeader.vue
+++ b/resources/js/components/AppHeader.vue
@@ -16,9 +16,9 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/co
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import UserMenuContent from '@/components/UserMenuContent.vue';
 import { getInitials } from '@/composables/useInitials';
-import type { BreadcrumbItem, NavItem } from '@/types';
+import type { BreadcrumbItem, NavItem, SharedData, User } from '@/types';
 import { Link, usePage } from '@inertiajs/vue3';
-import { BookOpen, Folder, LayoutGrid, Menu, Search, Newspaper, Megaphone, Shield, LifeBuoy } from 'lucide-vue-next';
+import { BookOpen, Folder, LayoutGrid, Menu, Search, Megaphone, Shield, LifeBuoy } from 'lucide-vue-next';
 import { computed } from 'vue';
 
 interface Props {
@@ -29,8 +29,8 @@ const props = withDefaults(defineProps<Props>(), {
     breadcrumbs: () => [],
 });
 
-const page = usePage();
-const auth = computed(() => page.props.auth);
+const page = usePage<SharedData>();
+const user = computed<User | undefined>(() => page.props.auth?.user ?? undefined);
 
 const isCurrentRoute = computed(() => (url: string) => page.url === url);
 
@@ -178,7 +178,7 @@ const rightNavItems: NavItem[] = [
                         </div>
                     </div>
 
-                    <DropdownMenu>
+                    <DropdownMenu v-if="user">
                         <DropdownMenuTrigger :as-child="true">
                             <Button
                                 variant="ghost"
@@ -187,18 +187,18 @@ const rightNavItems: NavItem[] = [
                             >
                                 <Avatar class="size-8 overflow-hidden rounded-full">
                                     <AvatarImage
-                                        v-if="auth.user.avatar"
-                                        :src="auth.user.avatar"
-                                        :alt="auth.user.nickname"
+                                        v-if="user?.avatar"
+                                        :src="user.avatar"
+                                        :alt="user?.nickname ?? ''"
                                     />
                                     <AvatarFallback class="rounded-lg bg-neutral-200 font-semibold text-black dark:bg-neutral-700 dark:text-white">
-                                        {{ getInitials(auth.user?.nickname) }}
+                                        {{ getInitials(user?.nickname ?? '') }}
                                     </AvatarFallback>
                                 </Avatar>
                             </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end" class="w-56">
-                            <UserMenuContent :user="auth.user" />
+                            <UserMenuContent :user="user" />
                         </DropdownMenuContent>
                     </DropdownMenu>
                 </div>

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -5,7 +5,7 @@ import NavUser from '@/components/NavUser.vue';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/vue3';
-import { BookOpen, Folder, LayoutGrid, Newspaper } from 'lucide-vue-next';
+import { BookOpen, Folder, LayoutGrid } from 'lucide-vue-next';
 import AppLogo from './AppLogo.vue';
 
 const mainNavItems: NavItem[] = [
@@ -15,9 +15,9 @@ const mainNavItems: NavItem[] = [
         icon: LayoutGrid,
     },
     {
-        title: 'News',
-        href: '/news',
-        icon: Newspaper,
+        title: 'Blog',
+        href: '/blogs',
+        icon: BookOpen,
     },
 ];
 

--- a/resources/js/components/NavUser.vue
+++ b/resources/js/components/NavUser.vue
@@ -6,14 +6,15 @@ import { type SharedData, type User } from '@/types';
 import { usePage } from '@inertiajs/vue3';
 import { ChevronsUpDown } from 'lucide-vue-next';
 import UserMenuContent from './UserMenuContent.vue';
+import { computed } from 'vue';
 
 const page = usePage<SharedData>();
-const user = page.props.auth.user as User;
+const user = computed<User | undefined>(() => page.props.auth?.user ?? undefined);
 const { isMobile, state } = useSidebar();
 </script>
 
 <template>
-    <SidebarMenu>
+    <SidebarMenu v-if="user">
         <SidebarMenuItem>
             <DropdownMenu>
                 <DropdownMenuTrigger as-child>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -3,7 +3,8 @@ import type { LucideIcon } from 'lucide-vue-next';
 import type { Config } from 'ziggy-js';
 
 export interface Auth {
-    user: User;
+    user: User | null;
+    permissions: string[];
 }
 
 export interface BreadcrumbItem {


### PR DESCRIPTION
## Summary
- guard the header avatar and dropdown against missing auth data so guest sessions do not crash
- align the shared Auth typings with the backend payload
- update the sidebar navigation to link to the existing blog route instead of a missing news page

## Testing
- npm run lint *(fails: existing unused import violations in untouched forum/support views)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e5b5aca8832cac078e47630347ad