### PR TITLE
Add ACL create pages and dialogs for ACL management

### DIFF
--- a/app/Http/Controllers/Admin/ACLController.php
+++ b/app/Http/Controllers/Admin/ACLController.php
@@ -29,7 +29,10 @@ class ACLController extends Controller
             ->paginate($perPage)
             ->withQueryString();
 
-        return inertia('acp/AccessControlLayer', compact('roles','permissions'));
+        $availablePermissions = Permission::orderBy('name')
+            ->get(['id', 'name', 'guard_name']);
+
+        return inertia('acp/AccessControlLayer', compact('roles', 'permissions', 'availablePermissions'));
     }
 
     /**
@@ -37,7 +40,17 @@ class ACLController extends Controller
      */
     public function createRole()
     {
-        return inertia('acp/ACLRoleCreate');
+        $permissions = Permission::orderBy('name')->get(['id', 'name', 'guard_name']);
+
+        return inertia('acp/ACLRoleCreate', compact('permissions'));
+    }
+
+    /**
+     * Show the form for creating a new permission.
+     */
+    public function createPermission()
+    {
+        return inertia('acp/ACLPermissionCreate');
     }
 
     /**
@@ -47,7 +60,8 @@ class ACLController extends Controller
     {
         $role = Role::create($request->validated());
         $role->syncPermissions($request->permissions ?? []);
-        return back()->with('success', 'Role created.');
+
+        return redirect()->route('acp.acl.index')->with('success', 'Role created.');
     }
 
     /**
@@ -75,7 +89,8 @@ class ACLController extends Controller
     public function storePermission(StorePermissionRequest $request)
     {
         Permission::create($request->validated());
-        return back()->with('success', 'Permission created.');
+
+        return redirect()->route('acp.acl.index')->with('success', 'Permission created.');
     }
 
     /**

--- a/resources/js/pages/acp/ACLPermissionCreate.vue
+++ b/resources/js/pages/acp/ACLPermissionCreate.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { Head, Link, useForm } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import InputError from '@/components/InputError.vue';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Access Control', href: route('acp.acl.index') },
+    { title: 'Create permission', href: route('acp.acl.permissions.create') },
+];
+
+const form = useForm({
+    name: '',
+    guard_name: 'web',
+});
+
+const handleSubmit = () => {
+    form.post(route('acp.acl.permissions.store'), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Create permission" />
+
+        <AdminLayout>
+            <form class="flex flex-1 flex-col gap-6 w-full" @submit.prevent="handleSubmit">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">Create permission</h1>
+                        <p class="text-sm text-muted-foreground">
+                            Register a new permission that can be assigned to roles.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2">
+                        <Button variant="outline" as-child>
+                            <Link :href="route('acp.acl.index')">Cancel</Link>
+                        </Button>
+                        <Button type="submit" :disabled="form.processing">Create permission</Button>
+                    </div>
+                </div>
+
+                <div class="grid gap-6 lg:grid-cols-[minmax(0,_1fr)_320px]">
+                    <Card>
+                        <CardHeader class="relative overflow-hidden">
+                            <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                            <div class="relative space-y-1">
+                                <CardTitle>Permission details</CardTitle>
+                                <CardDescription>
+                                    Permission names should be unique and describe the capability clearly.
+                                </CardDescription>
+                            </div>
+                        </CardHeader>
+                        <CardContent class="space-y-4">
+                            <div class="grid gap-2">
+                                <Label for="name">Name</Label>
+                                <Input id="name" v-model="form.name" type="text" autocomplete="off" required />
+                                <InputError :message="form.errors.name" />
+                            </div>
+
+                            <div class="grid gap-2">
+                                <Label for="guard_name">Guard name</Label>
+                                <Input id="guard_name" v-model="form.guard_name" type="text" required />
+                                <InputError :message="form.errors.guard_name" />
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Need a reminder?</CardTitle>
+                            <CardDescription>Permissions can be combined into roles for easier management.</CardDescription>
+                        </CardHeader>
+                        <CardContent class="space-y-4 text-sm text-muted-foreground">
+                            <p>Choose a guard that matches where the permission will be checked, such as web or api.</p>
+                            <p>After creating permissions, assign them to roles from the Access Control panel.</p>
+                        </CardContent>
+                        <CardFooter class="justify-end">
+                            <Button type="submit" :disabled="form.processing">Create permission</Button>
+                        </CardFooter>
+                    </Card>
+                </div>
+            </form>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/ACLRoleCreate.vue
+++ b/resources/js/pages/acp/ACLRoleCreate.vue
@@ -1,0 +1,162 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Head, Link, useForm } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import InputError from '@/components/InputError.vue';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+import { Checkbox } from '@/components/ui/checkbox';
+
+const props = defineProps<{
+    permissions: Array<{
+        id: number;
+        name: string;
+        guard_name: string;
+    }>;
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Access Control', href: route('acp.acl.index') },
+    { title: 'Create role', href: route('acp.acl.roles.create') },
+];
+
+const guardNames = computed(() => {
+    const guards = new Set(['web']);
+    props.permissions.forEach(permission => guards.add(permission.guard_name));
+    return Array.from(guards);
+});
+
+const form = useForm({
+    name: '',
+    guard_name: 'web',
+    permissions: [] as string[],
+});
+
+const togglePermission = (permissionName: string, checked: boolean | string) => {
+    const isChecked = checked === true || checked === 'indeterminate';
+
+    if (isChecked) {
+        if (!form.permissions.includes(permissionName)) {
+            form.permissions.push(permissionName);
+        }
+    } else {
+        form.permissions = form.permissions.filter(name => name !== permissionName);
+    }
+};
+
+const handleSubmit = () => {
+    form.post(route('acp.acl.roles.store'), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Create role" />
+
+        <AdminLayout>
+            <form class="flex flex-1 flex-col gap-6 w-full" @submit.prevent="handleSubmit">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">Create role</h1>
+                        <p class="text-sm text-muted-foreground">
+                            Define a new role and assign permissions that control what it can access.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2">
+                        <Button variant="outline" as-child>
+                            <Link :href="route('acp.acl.index')">Cancel</Link>
+                        </Button>
+                        <Button type="submit" :disabled="form.processing">Create role</Button>
+                    </div>
+                </div>
+
+                <div class="grid gap-6 lg:grid-cols-[minmax(0,_1fr)_320px]">
+                    <div class="flex flex-col gap-6">
+                        <Card>
+                            <CardHeader class="relative overflow-hidden">
+                                <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                                <div class="relative space-y-1">
+                                    <CardTitle>Role details</CardTitle>
+                                    <CardDescription>Give the role a name and assign a guard.</CardDescription>
+                                </div>
+                            </CardHeader>
+                            <CardContent class="space-y-4">
+                                <div class="grid gap-2">
+                                    <Label for="name">Name</Label>
+                                    <Input id="name" v-model="form.name" type="text" autocomplete="off" required />
+                                    <InputError :message="form.errors.name" />
+                                </div>
+
+                                <div class="grid gap-2">
+                                    <Label for="guard_name">Guard name</Label>
+                                    <Input id="guard_name" v-model="form.guard_name" type="text" list="guards" required />
+                                    <datalist id="guards">
+                                        <option v-for="guard in guardNames" :key="guard" :value="guard">{{ guard }}</option>
+                                    </datalist>
+                                    <InputError :message="form.errors.guard_name" />
+                                </div>
+                            </CardContent>
+                        </Card>
+
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Permissions</CardTitle>
+                                <CardDescription>Select the permissions this role should include.</CardDescription>
+                            </CardHeader>
+                            <CardContent class="space-y-4">
+                                <div v-if="props.permissions.length === 0" class="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                                    No permissions are currently defined. Create permissions first to assign them to this role.
+                                </div>
+                                <div v-else class="grid gap-3">
+                                    <div
+                                        v-for="permission in props.permissions"
+                                        :key="permission.id"
+                                        class="flex items-start gap-3 rounded-md border p-3"
+                                    >
+                                        <Checkbox
+                                            :id="`permission-${permission.id}`"
+                                            :checked="form.permissions.includes(permission.name)"
+                                            @update:checked="value => togglePermission(permission.name, value)"
+                                        />
+                                        <div class="grid gap-1">
+                                            <Label :for="`permission-${permission.id}`" class="font-medium leading-none">
+                                                {{ permission.name }}
+                                            </Label>
+                                            <p class="text-xs text-muted-foreground">Guard: {{ permission.guard_name }}</p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <InputError :message="form.errors.permissions" />
+                            </CardContent>
+                        </Card>
+                    </div>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Tips</CardTitle>
+                            <CardDescription>Keep permissions focused so roles stay easy to manage.</CardDescription>
+                        </CardHeader>
+                        <CardContent class="space-y-4 text-sm text-muted-foreground">
+                            <p>Use guards to separate access between application contexts (such as web or api).</p>
+                            <p>
+                                Combine roles with user assignments in the Users ACP to grant access to individuals or teams.
+                            </p>
+                        </CardContent>
+                        <CardFooter class="justify-end">
+                            <Button type="submit" :disabled="form.processing">Create role</Button>
+                        </CardFooter>
+                    </Card>
+                </div>
+            </form>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/AccessControlLayer.vue
+++ b/resources/js/pages/acp/AccessControlLayer.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
-import { Head, Link } from '@inertiajs/vue3';
+import { Head, Link, useForm } from '@inertiajs/vue3';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import AppLayout from '@/layouts/AppLayout.vue';
 import AdminLayout from '@/layouts/acp/AdminLayout.vue';
 import { type BreadcrumbItem } from '@/types';
 import Input from '@/components/ui/input/Input.vue';
 import Button from '@/components/ui/button/Button.vue';
+import InputError from '@/components/InputError.vue';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -18,6 +21,14 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
 import { Ellipsis, Trash2, Pencil } from 'lucide-vue-next';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
 import {
     Pagination,
     PaginationEllipsis,
@@ -34,11 +45,26 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 
 dayjs.extend(relativeTime);
 
-// Permission checks
-const { hasPermission } = usePermissions();
-const createRoles = computed(() => hasPermission('acl.acp.create'));
-const editRoles = computed(() => hasPermission('acl.acp.edit'));
-const deleteRoles = computed(() => hasPermission('acl.acp.delete'));
+type RolePermission = {
+    id: number;
+    name: string;
+    guard_name: string;
+};
+
+type RoleItem = {
+    id: number;
+    name: string;
+    guard_name: string;
+    created_at: string;
+    permissions: RolePermission[];
+};
+
+type PermissionItem = {
+    id: number;
+    name: string;
+    guard_name: string;
+    created_at: string;
+};
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -49,28 +75,109 @@ const breadcrumbs: BreadcrumbItem[] = [
 
 const props = defineProps<{
     roles: {
-        data: Array<{
-            id: number;
-            name: string;
-            guard_name: string;
-            created_at: string
-        }>;
+        data: RoleItem[];
         current_page: number;
         per_page: number;
         total: number;
     };
     permissions: {
-        data: Array<{
-            id: number;
-            name: string;
-            guard_name: string;
-            created_at: string
-        }>;
+        data: PermissionItem[];
         current_page: number;
         per_page: number;
         total: number;
     };
+    availablePermissions: RolePermission[];
 }>();
+
+// Permission checks
+const { hasPermission } = usePermissions();
+const canCreate = computed(() => hasPermission('acl.acp.create'));
+const canEdit = computed(() => hasPermission('acl.acp.edit'));
+const canDelete = computed(() => hasPermission('acl.acp.delete'));
+
+const roleDialogOpen = ref(false);
+const permissionDialogOpen = ref(false);
+
+const selectedRole = ref<RoleItem | null>(null);
+const selectedPermission = ref<PermissionItem | null>(null);
+
+const roleForm = useForm({
+    name: '',
+    guard_name: 'web',
+    permissions: [] as string[],
+});
+
+const permissionForm = useForm({
+    name: '',
+    guard_name: 'web',
+});
+
+const handleRoleDialogChange = (open: boolean) => {
+    roleDialogOpen.value = open;
+
+    if (!open) {
+        roleForm.reset();
+        roleForm.clearErrors();
+        selectedRole.value = null;
+    }
+};
+
+const handlePermissionDialogChange = (open: boolean) => {
+    permissionDialogOpen.value = open;
+
+    if (!open) {
+        permissionForm.reset();
+        permissionForm.clearErrors();
+        selectedPermission.value = null;
+    }
+};
+
+const toggleRolePermission = (permissionName: string, checked: boolean | string) => {
+    const isChecked = checked === true || checked === 'indeterminate';
+
+    if (isChecked) {
+        if (!roleForm.permissions.includes(permissionName)) {
+            roleForm.permissions.push(permissionName);
+        }
+    } else {
+        roleForm.permissions = roleForm.permissions.filter(name => name !== permissionName);
+    }
+};
+
+const openRoleDialog = (role: RoleItem) => {
+    selectedRole.value = role;
+    roleForm.clearErrors();
+    roleForm.name = role.name;
+    roleForm.guard_name = role.guard_name;
+    roleForm.permissions = (role.permissions ?? []).map(permission => permission.name);
+    handleRoleDialogChange(true);
+};
+
+const submitRoleUpdate = () => {
+    if (!selectedRole.value) return;
+
+    roleForm.put(route('acp.acl.roles.update', { role: selectedRole.value.id }), {
+        preserveScroll: true,
+        onSuccess: () => handleRoleDialogChange(false),
+    });
+};
+
+const openPermissionDialog = (permission: PermissionItem) => {
+    selectedPermission.value = permission;
+    permissionForm.clearErrors();
+    permissionForm.name = permission.name;
+    permissionForm.guard_name = permission.guard_name;
+    handlePermissionDialogChange(true);
+};
+
+const submitPermissionUpdate = () => {
+    if (!selectedPermission.value) return;
+
+    permissionForm.put(route('acp.acl.permissions.update', { permission: selectedPermission.value.id }), {
+        preserveScroll: true,
+        onSuccess: () => handlePermissionDialogChange(false),
+    });
+};
 
 // Search queries for each section
 const roleSearchQuery = ref('');
@@ -120,7 +227,7 @@ const filteredPermissions = computed(() => {
                                         placeholder="Search Roles..."
                                         class="w-full pr-10 max-w-sm"
                                     />
-                                    <Link v-if="createRoles" :href="route('acp.acl.roles.create')">
+                                    <Link v-if="canCreate" :href="route('acp.acl.roles.create')">
                                         <Button variant="secondary" class="text-sm text-white bg-green-500 hover:bg-green-600">
                                             Create Role
                                         </Button>
@@ -147,30 +254,31 @@ const filteredPermissions = computed(() => {
                                             <TableCell class="text-center">{{ role.guard_name }}</TableCell>
                                             <TableCell class="text-center">{{ dayjs(role.created_at).fromNow() }}</TableCell>
                                             <TableCell class="text-center">
-                                                <DropdownMenu>
-                                                    <DropdownMenuTrigger as-child>
-                                                        <Button variant="outline" size="icon">
-                                                            <Ellipsis class="h-8 w-8" />
-                                                        </Button>
-                                                    </DropdownMenuTrigger>
-                                                    <DropdownMenuContent>
-                                                        <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                                                        <DropdownMenuSeparator v-if="editRoles" />
-                                                        <DropdownMenuGroup v-if="editRoles">
-                                                            <Link v-if="editRoles" :href="route('acp.acl.roles.update', { role: role.id })">
-                                                                <DropdownMenuItem class="text-blue-500">
+                                                <template v-if="canEdit || canDelete">
+                                                    <DropdownMenu>
+                                                        <DropdownMenuTrigger as-child>
+                                                            <Button variant="outline" size="icon">
+                                                                <Ellipsis class="h-8 w-8" />
+                                                            </Button>
+                                                        </DropdownMenuTrigger>
+                                                        <DropdownMenuContent>
+                                                            <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                                                            <DropdownMenuSeparator v-if="canEdit" />
+                                                            <DropdownMenuGroup v-if="canEdit">
+                                                                <DropdownMenuItem class="text-blue-500" @click="openRoleDialog(role)">
                                                                     <Pencil class="mr-2"/> Edit
                                                                 </DropdownMenuItem>
-                                                            </Link>
-                                                        </DropdownMenuGroup>
-                                                        <DropdownMenuSeparator v-if="deleteRoles" />
-                                                        <DropdownMenuItem v-if="deleteRoles" class="text-red-500"
-                                                            @click="$inertia.delete(route('acp.acl.roles.destroy', { role: role.id }))"
-                                                        >
-                                                            <Trash2 class="mr-2" /> Delete
-                                                        </DropdownMenuItem>
-                                                    </DropdownMenuContent>
-                                                </DropdownMenu>
+                                                            </DropdownMenuGroup>
+                                                            <DropdownMenuSeparator v-if="canDelete" />
+                                                            <DropdownMenuItem v-if="canDelete" class="text-red-500"
+                                                                @click="$inertia.delete(route('acp.acl.roles.destroy', { role: role.id }))"
+                                                            >
+                                                                <Trash2 class="mr-2" /> Delete
+                                                            </DropdownMenuItem>
+                                                        </DropdownMenuContent>
+                                                    </DropdownMenu>
+                                                </template>
+                                                <span v-else class="text-sm text-muted-foreground">—</span>
                                             </TableCell>
                                         </TableRow>
                                         <TableRow v-if="filteredRoles.length === 0">
@@ -225,12 +333,17 @@ const filteredPermissions = computed(() => {
                         <div class="rounded-xl border border-sidebar-border/70 dark:border-sidebar-border p-4 mb-4">
                             <div class="flex flex-col md:flex-row md:items-center md:justify-between mb-4">
                                 <h2 class="text-lg font-semibold mb-2 md:mb-0">Permission Management</h2>
-                                <div class="flex space-x-2">
+                                <div class="relative flex justify-end space-x-2">
                                     <Input
                                         v-model="permissionSearchQuery"
                                         placeholder="Search Permissions..."
-                                        class="w-full rounded-md"
+                                        class="w-full rounded-md max-w-sm"
                                     />
+                                    <Link v-if="canCreate" :href="route('acp.acl.permissions.create')">
+                                        <Button variant="secondary" class="text-sm text-white bg-green-500 hover:bg-green-600">
+                                            Create Permission
+                                        </Button>
+                                    </Link>
                                 </div>
                             </div>
                             <!-- Permissions Table using Table Components -->
@@ -242,6 +355,7 @@ const filteredPermissions = computed(() => {
                                             <TableHead>Name</TableHead>
                                             <TableHead class="text-center">Guard Name</TableHead>
                                             <TableHead class="text-center">Created At</TableHead>
+                                            <TableHead class="text-center"></TableHead>
                                         </TableRow>
                                     </TableHeader>
                                     <TableBody>
@@ -250,6 +364,33 @@ const filteredPermissions = computed(() => {
                                             <TableCell>{{ permission.name }}</TableCell>
                                             <TableCell class="text-center">{{ permission.guard_name }}</TableCell>
                                             <TableCell class="text-center">{{ dayjs(permission.created_at).fromNow() }}</TableCell>
+                                            <TableCell class="text-center">
+                                                <template v-if="canEdit || canDelete">
+                                                    <DropdownMenu>
+                                                        <DropdownMenuTrigger as-child>
+                                                            <Button variant="outline" size="icon">
+                                                                <Ellipsis class="h-8 w-8" />
+                                                            </Button>
+                                                        </DropdownMenuTrigger>
+                                                        <DropdownMenuContent>
+                                                            <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                                                            <DropdownMenuSeparator v-if="canEdit" />
+                                                            <DropdownMenuGroup v-if="canEdit">
+                                                                <DropdownMenuItem class="text-blue-500" @click="openPermissionDialog(permission)">
+                                                                    <Pencil class="mr-2" /> Edit
+                                                                </DropdownMenuItem>
+                                                            </DropdownMenuGroup>
+                                                            <DropdownMenuSeparator v-if="canDelete" />
+                                                            <DropdownMenuItem v-if="canDelete" class="text-red-500"
+                                                                @click="$inertia.delete(route('acp.acl.permissions.destroy', { permission: permission.id }))"
+                                                            >
+                                                                <Trash2 class="mr-2" /> Delete
+                                                            </DropdownMenuItem>
+                                                        </DropdownMenuContent>
+                                                    </DropdownMenu>
+                                                </template>
+                                                <span v-else class="text-sm text-muted-foreground">—</span>
+                                            </TableCell>
                                         </TableRow>
                                         <TableRow v-if="filteredPermissions.length === 0">
                                             <TableCell colspan="5" class="text-center text-sm text-gray-600 dark:text-gray-300">
@@ -299,6 +440,108 @@ const filteredPermissions = computed(() => {
                     </TabsContent>
                 </Tabs>
             </div>
+
+            <Dialog :open="roleDialogOpen" @update:open="handleRoleDialogChange">
+                <DialogContent class="sm:max-w-[520px]">
+                    <form class="space-y-6" @submit.prevent="submitRoleUpdate">
+                        <DialogHeader>
+                            <DialogTitle>Edit role</DialogTitle>
+                            <DialogDescription v-if="selectedRole">
+                                Update the details for <span class="font-medium">{{ selectedRole.name }}</span>.
+                            </DialogDescription>
+                        </DialogHeader>
+
+                        <div class="grid gap-4">
+                            <div class="grid gap-2">
+                                <Label for="role-name">Name</Label>
+                                <Input id="role-name" v-model="roleForm.name" type="text" autocomplete="off" required />
+                                <InputError :message="roleForm.errors.name" />
+                            </div>
+
+                            <div class="grid gap-2">
+                                <Label for="role-guard">Guard name</Label>
+                                <Input id="role-guard" v-model="roleForm.guard_name" type="text" required />
+                                <InputError :message="roleForm.errors.guard_name" />
+                            </div>
+
+                            <div class="grid gap-3">
+                                <Label>Permissions</Label>
+                                <div
+                                    v-if="props.availablePermissions.length === 0"
+                                    class="rounded-md border border-dashed p-3 text-sm text-muted-foreground"
+                                >
+                                    No permissions are currently defined. Create permissions before assigning them to roles.
+                                </div>
+                                <div v-else class="grid gap-2 max-h-60 overflow-y-auto pr-1">
+                                    <div
+                                        v-for="permission in props.availablePermissions"
+                                        :key="permission.id"
+                                        class="flex items-start gap-3 rounded-md border p-3"
+                                    >
+                                        <Checkbox
+                                            :id="`dialog-permission-${permission.id}`"
+                                            :checked="roleForm.permissions.includes(permission.name)"
+                                            @update:checked="value => toggleRolePermission(permission.name, value)"
+                                        />
+                                        <div class="grid gap-1">
+                                            <Label :for="`dialog-permission-${permission.id}`" class="font-medium leading-none">
+                                                {{ permission.name }}
+                                            </Label>
+                                            <p class="text-xs text-muted-foreground">Guard: {{ permission.guard_name }}</p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <InputError :message="roleForm.errors.permissions" />
+                            </div>
+                        </div>
+
+                        <DialogFooter class="gap-2">
+                            <Button type="button" variant="secondary" @click="handleRoleDialogChange(false)">
+                                Cancel
+                            </Button>
+                            <Button type="submit" :disabled="roleForm.processing">
+                                Save changes
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </DialogContent>
+            </Dialog>
+
+            <Dialog :open="permissionDialogOpen" @update:open="handlePermissionDialogChange">
+                <DialogContent class="sm:max-w-[480px]">
+                    <form class="space-y-6" @submit.prevent="submitPermissionUpdate">
+                        <DialogHeader>
+                            <DialogTitle>Edit permission</DialogTitle>
+                            <DialogDescription v-if="selectedPermission">
+                                Update the details for <span class="font-medium">{{ selectedPermission.name }}</span>.
+                            </DialogDescription>
+                        </DialogHeader>
+
+                        <div class="grid gap-4">
+                            <div class="grid gap-2">
+                                <Label for="permission-name">Name</Label>
+                                <Input id="permission-name" v-model="permissionForm.name" type="text" autocomplete="off" required />
+                                <InputError :message="permissionForm.errors.name" />
+                            </div>
+
+                            <div class="grid gap-2">
+                                <Label for="permission-guard">Guard name</Label>
+                                <Input id="permission-guard" v-model="permissionForm.guard_name" type="text" required />
+                                <InputError :message="permissionForm.errors.guard_name" />
+                            </div>
+                        </div>
+
+                        <DialogFooter class="gap-2">
+                            <Button type="button" variant="secondary" @click="handlePermissionDialogChange(false)">
+                                Cancel
+                            </Button>
+                            <Button type="submit" :disabled="permissionForm.processing">
+                                Save changes
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </DialogContent>
+            </Dialog>
         </AdminLayout>
     </AppLayout>
 </template>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -29,6 +29,7 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
 
     // Admin Access Control Management Routes
     Route::get('acp/acl', [AdminACLController::class, 'index'])->name('acp.acl.index');
+    Route::get('acp/acl/permissions/create', [AdminACLController::class, 'createPermission'])->name('acp.acl.permissions.create');
     Route::post('acp/acl/permissions', [AdminACLController::class, 'storePermission'])->name('acp.acl.permissions.store');
     Route::put('acp/acl/permissions/{permission}', [AdminACLController::class, 'updatePermission'])->name('acp.acl.permissions.update');
     Route::delete('acp/acl/permissions/{permission}', [AdminACLController::class, 'destroyPermission'])->name('acp.acl.permissions.destroy');


### PR DESCRIPTION
## Summary
- add dedicated create forms for roles and permissions in the ACP
- update the access control index to use dialogs for editing and consistent action handling
- expose available permissions and the create-permission route through the controller

## Testing
- npm run lint *(fails: existing unused import violations in unrelated pages)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f02d13fc832c8ddba5b7217ba596