### PR TITLE
Implement ACP support create/edit pages and fix stats

### DIFF
--- a/app/Http/Requests/Admin/UpdateSupportTicketRequest.php
+++ b/app/Http/Requests/Admin/UpdateSupportTicketRequest.php
@@ -16,7 +16,7 @@ class UpdateSupportTicketRequest extends FormRequest
         return [
             'subject'    => 'sometimes|required|string|max:255',
             'body'       => 'sometimes|required|string',
-            'status'     => 'sometimes|required|in:open,closed',
+            'status'     => 'sometimes|required|in:open,pending,closed',
             'priority'   => 'in:low,medium,high',
             'assigned_to'=> 'nullable|exists:users,id',
             // etc...

--- a/resources/js/pages/acp/Support.vue
+++ b/resources/js/pages/acp/Support.vue
@@ -261,7 +261,7 @@ console.log(fromNow(new Date()));
                                                         </DropdownMenuGroup>
                                                         <DropdownMenuSeparator v-if="editSupport" />
                                                         <DropdownMenuGroup v-if="editSupport">
-                                                            <Link :href="route('acp.support.tickets.update', { ticket: t.id })">
+                                                            <Link :href="route('acp.support.tickets.edit', { ticket: t.id })">
                                                                 <DropdownMenuItem>
                                                                     <Pencil class="mr-2" /> Edit
                                                                 </DropdownMenuItem>
@@ -377,7 +377,7 @@ console.log(fromNow(new Date()));
                                                         <DropdownMenuGroup v-if="editSupport||deleteSupport">
                                                             <Link
                                                                 v-if="editSupport"
-                                                                :href="route('acp.support.faqs.update', { faq: f.id })"
+                                                                :href="route('acp.support.faqs.edit', { faq: f.id })"
                                                             >
                                                                 <DropdownMenuItem>
                                                                     <Pencil class="mr-2" /> Edit

--- a/resources/js/pages/acp/SupportFaqCreate.vue
+++ b/resources/js/pages/acp/SupportFaqCreate.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { Head, Link, useForm } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
+import InputError from '@/components/InputError.vue';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Support ACP', href: route('acp.support.index') },
+    { title: 'Create FAQ', href: route('acp.support.faqs.create') },
+];
+
+const form = useForm({
+    question: '',
+    answer: '',
+    order: 0,
+    published: false,
+});
+
+const handleSubmit = () => {
+    form.post(route('acp.support.faqs.store'), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Create FAQ" />
+
+        <AdminLayout>
+            <form class="flex flex-1 flex-col gap-6" @submit.prevent="handleSubmit">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">Create FAQ</h1>
+                        <p class="text-sm text-muted-foreground">
+                            Draft a helpful answer for common support questions to deflect future tickets.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2">
+                        <Button variant="outline" as-child>
+                            <Link :href="route('acp.support.index')">Cancel</Link>
+                        </Button>
+                        <Button type="submit" :disabled="form.processing">Save FAQ</Button>
+                    </div>
+                </div>
+
+                <div class="grid gap-6 lg:grid-cols-[minmax(0,_1fr)_320px]">
+                    <Card>
+                        <CardHeader class="relative overflow-hidden">
+                            <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                            <div class="relative space-y-1">
+                                <CardTitle>Question &amp; answer</CardTitle>
+                                <CardDescription>
+                                    Write concise, friendly guidance that is easy for readers to follow.
+                                </CardDescription>
+                            </div>
+                        </CardHeader>
+                        <CardContent class="space-y-6">
+                            <div class="grid gap-2">
+                                <Label for="question">Question</Label>
+                                <Input id="question" v-model="form.question" type="text" autocomplete="off" required />
+                                <InputError :message="form.errors.question" />
+                            </div>
+
+                            <div class="grid gap-2">
+                                <Label for="answer">Answer</Label>
+                                <Textarea
+                                    id="answer"
+                                    v-model="form.answer"
+                                    class="min-h-48"
+                                    placeholder="Provide a clear answer and include any helpful links or steps."
+                                    required
+                                />
+                                <InputError :message="form.errors.answer" />
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Publishing options</CardTitle>
+                            <CardDescription>Set the display order and choose whether the FAQ is visible.</CardDescription>
+                        </CardHeader>
+                        <CardContent class="space-y-4">
+                            <div class="grid gap-2">
+                                <Label for="order">Display order</Label>
+                                <Input id="order" v-model.number="form.order" type="number" min="0" />
+                                <InputError :message="form.errors.order" />
+                            </div>
+
+                            <div class="flex items-center space-x-2">
+                                <Checkbox id="published" v-model:checked="form.published" />
+                                <Label for="published">Publish immediately</Label>
+                            </div>
+                            <InputError :message="form.errors.published" />
+                        </CardContent>
+                        <CardFooter class="justify-end">
+                            <Button type="submit" :disabled="form.processing">Save FAQ</Button>
+                        </CardFooter>
+                    </Card>
+                </div>
+            </form>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/SupportFaqEdit.vue
+++ b/resources/js/pages/acp/SupportFaqEdit.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+import { Head, Link, useForm } from '@inertiajs/vue3';
+import { computed } from 'vue';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
+import InputError from '@/components/InputError.vue';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { useUserTimezone } from '@/composables/useUserTimezone';
+
+const props = defineProps<{
+    faq: {
+        id: number;
+        question: string;
+        answer: string;
+        order: number;
+        published: boolean;
+        created_at: string;
+        updated_at: string;
+    };
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Support ACP', href: route('acp.support.index') },
+    { title: `FAQ #${props.faq.id}`, href: route('acp.support.faqs.edit', { faq: props.faq.id }) },
+];
+
+const form = useForm({
+    question: props.faq.question,
+    answer: props.faq.answer,
+    order: props.faq.order,
+    published: props.faq.published,
+});
+
+const { formatDate, fromNow } = useUserTimezone();
+
+const createdAt = computed(() => formatDate(props.faq.created_at));
+const updatedAt = computed(() => formatDate(props.faq.updated_at));
+
+const handleSubmit = () => {
+    form.put(route('acp.support.faqs.update', { faq: props.faq.id }), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head :title="`Edit FAQ #${props.faq.id}`" />
+
+        <AdminLayout>
+            <form class="flex flex-1 flex-col gap-6" @submit.prevent="handleSubmit">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">Update FAQ #{{ props.faq.id }}</h1>
+                        <p class="text-sm text-muted-foreground">
+                            Refresh the answer content or adjust its visibility in the support centre.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2">
+                        <Button variant="outline" as-child>
+                            <Link :href="route('acp.support.index')">Back to Support</Link>
+                        </Button>
+                        <Button type="submit" :disabled="form.processing">Save changes</Button>
+                    </div>
+                </div>
+
+                <div class="grid gap-6 lg:grid-cols-[minmax(0,_1fr)_320px]">
+                    <Card>
+                        <CardHeader class="relative overflow-hidden">
+                            <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                            <div class="relative space-y-1">
+                                <CardTitle>FAQ content</CardTitle>
+                                <CardDescription>
+                                    Provide clear, concise instructions that resolve the question quickly.
+                                </CardDescription>
+                            </div>
+                        </CardHeader>
+                        <CardContent class="space-y-6">
+                            <div class="grid gap-2">
+                                <Label for="question">Question</Label>
+                                <Input id="question" v-model="form.question" type="text" autocomplete="off" required />
+                                <InputError :message="form.errors.question" />
+                            </div>
+
+                            <div class="grid gap-2">
+                                <Label for="answer">Answer</Label>
+                                <Textarea id="answer" v-model="form.answer" class="min-h-48" required />
+                                <InputError :message="form.errors.answer" />
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    <div class="grid gap-6">
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Display settings</CardTitle>
+                                <CardDescription>Control ordering and publish state for this entry.</CardDescription>
+                            </CardHeader>
+                            <CardContent class="space-y-4">
+                                <div class="grid gap-2">
+                                    <Label for="order">Display order</Label>
+                                    <Input id="order" v-model.number="form.order" type="number" min="0" />
+                                    <InputError :message="form.errors.order" />
+                                </div>
+
+                                <div class="flex items-center space-x-2">
+                                    <Checkbox id="published" v-model:checked="form.published" />
+                                    <Label for="published">Published</Label>
+                                </div>
+                                <InputError :message="form.errors.published" />
+                            </CardContent>
+                            <CardFooter class="justify-end">
+                                <Button type="submit" :disabled="form.processing">Save changes</Button>
+                            </CardFooter>
+                        </Card>
+
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>History</CardTitle>
+                                <CardDescription>Reference for when the FAQ was created and last touched.</CardDescription>
+                            </CardHeader>
+                            <CardContent class="space-y-4 text-sm text-muted-foreground">
+                                <div>
+                                    <span class="font-medium text-foreground">Created</span>
+                                    <p>{{ createdAt }} ({{ fromNow(props.faq.created_at) }})</p>
+                                </div>
+                                <div>
+                                    <span class="font-medium text-foreground">Last updated</span>
+                                    <p>{{ updatedAt }} ({{ fromNow(props.faq.updated_at) }})</p>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    </div>
+                </div>
+            </form>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/SupportTicketCreate.vue
+++ b/resources/js/pages/acp/SupportTicketCreate.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import { Head, Link, useForm } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import InputError from '@/components/InputError.vue';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Support ACP', href: route('acp.support.index') },
+    { title: 'Create ticket', href: route('acp.support.tickets.create') },
+];
+
+const priorityOptions = [
+    { label: 'Low', value: 'low' },
+    { label: 'Medium', value: 'medium' },
+    { label: 'High', value: 'high' },
+];
+
+const form = useForm({
+    subject: '',
+    body: '',
+    priority: 'medium',
+});
+
+const handleSubmit = () => {
+    form.post(route('acp.support.tickets.store'), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Create support ticket" />
+
+        <AdminLayout>
+            <form class="flex flex-1 flex-col gap-6" @submit.prevent="handleSubmit">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">Create support ticket</h1>
+                        <p class="text-sm text-muted-foreground">
+                            Log a new request on behalf of the community and prioritise it for the support team.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2">
+                        <Button variant="outline" as-child>
+                            <Link :href="route('acp.support.index')">Cancel</Link>
+                        </Button>
+                        <Button type="submit" :disabled="form.processing">Save ticket</Button>
+                    </div>
+                </div>
+
+                <div class="grid gap-6 lg:grid-cols-[minmax(0,_1fr)_320px]">
+                    <Card>
+                        <CardHeader class="relative overflow-hidden">
+                            <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                            <div class="relative space-y-1">
+                                <CardTitle>Ticket details</CardTitle>
+                                <CardDescription>
+                                    Provide a clear subject and description so agents can act quickly.
+                                </CardDescription>
+                            </div>
+                        </CardHeader>
+                        <CardContent class="space-y-6">
+                            <div class="grid gap-2">
+                                <Label for="subject">Subject</Label>
+                                <Input
+                                    id="subject"
+                                    v-model="form.subject"
+                                    type="text"
+                                    autocomplete="off"
+                                    required
+                                />
+                                <InputError :message="form.errors.subject" />
+                            </div>
+
+                            <div class="grid gap-2">
+                                <Label for="body">Description</Label>
+                                <Textarea
+                                    id="body"
+                                    v-model="form.body"
+                                    placeholder="Describe the issue or request in detail."
+                                    class="min-h-48"
+                                    required
+                                />
+                                <InputError :message="form.errors.body" />
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Classification</CardTitle>
+                            <CardDescription>Set the ticket priority to help the triage process.</CardDescription>
+                        </CardHeader>
+                        <CardContent class="space-y-4">
+                            <div class="grid gap-2">
+                                <Label for="priority">Priority</Label>
+                                <select
+                                    id="priority"
+                                    v-model="form.priority"
+                                    class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                                >
+                                    <option v-for="option in priorityOptions" :key="option.value" :value="option.value">
+                                        {{ option.label }}
+                                    </option>
+                                </select>
+                                <InputError :message="form.errors.priority" />
+                            </div>
+
+                            <p class="text-sm text-muted-foreground">
+                                Tickets marked as high priority appear at the top of work queues for faster response times.
+                            </p>
+                        </CardContent>
+                        <CardFooter class="justify-end">
+                            <Button type="submit" :disabled="form.processing">Save ticket</Button>
+                        </CardFooter>
+                    </Card>
+                </div>
+            </form>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/SupportTicketEdit.vue
+++ b/resources/js/pages/acp/SupportTicketEdit.vue
@@ -1,0 +1,216 @@
+<script setup lang="ts">
+import { Head, Link, useForm } from '@inertiajs/vue3';
+import { computed } from 'vue';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import InputError from '@/components/InputError.vue';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { useUserTimezone } from '@/composables/useUserTimezone';
+
+const props = defineProps<{
+    ticket: {
+        id: number;
+        subject: string;
+        body: string;
+        status: 'open' | 'pending' | 'closed';
+        priority: 'low' | 'medium' | 'high';
+        assigned_to: number | null;
+        assignee: { id: number; nickname: string; email: string } | null;
+        user: { id: number; nickname: string; email: string };
+        created_at: string;
+        updated_at: string;
+    };
+    agents: Array<{ id: number; nickname: string; email: string }>;
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Support ACP', href: route('acp.support.index') },
+    { title: `Ticket #${props.ticket.id}`, href: route('acp.support.tickets.edit', { ticket: props.ticket.id }) },
+];
+
+const statusOptions = [
+    { label: 'Open', value: 'open' },
+    { label: 'Pending', value: 'pending' },
+    { label: 'Closed', value: 'closed' },
+];
+
+const priorityOptions = [
+    { label: 'Low', value: 'low' },
+    { label: 'Medium', value: 'medium' },
+    { label: 'High', value: 'high' },
+];
+
+const form = useForm({
+    subject: props.ticket.subject,
+    body: props.ticket.body,
+    status: props.ticket.status,
+    priority: props.ticket.priority,
+    assigned_to: props.ticket.assignee?.id ?? null,
+});
+
+const { fromNow, formatDate } = useUserTimezone();
+
+const lastUpdated = computed(() => formatDate(props.ticket.updated_at));
+const createdAt = computed(() => formatDate(props.ticket.created_at));
+
+const handleSubmit = () => {
+    form.put(route('acp.support.tickets.update', { ticket: props.ticket.id }), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head :title="`Edit ticket #${props.ticket.id}`" />
+
+        <AdminLayout>
+            <form class="flex flex-1 flex-col gap-6" @submit.prevent="handleSubmit">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">Update ticket #{{ props.ticket.id }}</h1>
+                        <p class="text-sm text-muted-foreground">
+                            Fine tune the ticket details, update its status or hand it to a different agent.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2">
+                        <Button variant="outline" as-child>
+                            <Link :href="route('acp.support.index')">Back to Support</Link>
+                        </Button>
+                        <Button type="submit" :disabled="form.processing">Save changes</Button>
+                    </div>
+                </div>
+
+                <div class="grid gap-6 lg:grid-cols-[minmax(0,_1fr)_320px]">
+                    <Card>
+                        <CardHeader class="relative overflow-hidden">
+                            <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                            <div class="relative space-y-1">
+                                <CardTitle>Ticket content</CardTitle>
+                                <CardDescription>
+                                    Keep the summary concise and the body detailed so the resolution history stays clear.
+                                </CardDescription>
+                            </div>
+                        </CardHeader>
+                        <CardContent class="space-y-6">
+                            <div class="grid gap-2">
+                                <Label for="subject">Subject</Label>
+                                <Input
+                                    id="subject"
+                                    v-model="form.subject"
+                                    type="text"
+                                    autocomplete="off"
+                                    required
+                                />
+                                <InputError :message="form.errors.subject" />
+                            </div>
+
+                            <div class="grid gap-2">
+                                <Label for="body">Description</Label>
+                                <Textarea
+                                    id="body"
+                                    v-model="form.body"
+                                    class="min-h-48"
+                                    required
+                                />
+                                <InputError :message="form.errors.body" />
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    <div class="grid gap-6">
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Workflow</CardTitle>
+                                <CardDescription>Adjust the status, priority and ownership of this ticket.</CardDescription>
+                            </CardHeader>
+                            <CardContent class="space-y-4">
+                                <div class="grid gap-2">
+                                    <Label for="status">Status</Label>
+                                    <select
+                                        id="status"
+                                        v-model="form.status"
+                                        class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                                    >
+                                        <option v-for="option in statusOptions" :key="option.value" :value="option.value">
+                                            {{ option.label }}
+                                        </option>
+                                    </select>
+                                    <InputError :message="form.errors.status" />
+                                </div>
+
+                                <div class="grid gap-2">
+                                    <Label for="priority">Priority</Label>
+                                    <select
+                                        id="priority"
+                                        v-model="form.priority"
+                                        class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                                    >
+                                        <option v-for="option in priorityOptions" :key="option.value" :value="option.value">
+                                            {{ option.label }}
+                                        </option>
+                                    </select>
+                                    <InputError :message="form.errors.priority" />
+                                </div>
+
+                                <div class="grid gap-2">
+                                    <Label for="assigned_to">Assigned agent</Label>
+                                    <select
+                                        id="assigned_to"
+                                        v-model="form.assigned_to"
+                                        class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                                    >
+                                        <option :value="null">Unassigned</option>
+                                        <option v-for="agent in props.agents" :key="agent.id" :value="agent.id">
+                                            {{ agent.nickname }} ({{ agent.email }})
+                                        </option>
+                                    </select>
+                                    <InputError :message="form.errors.assigned_to" />
+                                </div>
+                            </CardContent>
+                            <CardFooter class="justify-end">
+                                <Button type="submit" :disabled="form.processing">Save changes</Button>
+                            </CardFooter>
+                        </Card>
+
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Ticket history</CardTitle>
+                                <CardDescription>Quick reference for who opened the ticket and when it was updated.</CardDescription>
+                            </CardHeader>
+                            <CardContent class="space-y-4 text-sm text-muted-foreground">
+                                <div>
+                                    <span class="font-medium text-foreground">Created</span>
+                                    <p>{{ createdAt }} ({{ fromNow(props.ticket.created_at) }})</p>
+                                </div>
+                                <div>
+                                    <span class="font-medium text-foreground">Last updated</span>
+                                    <p>{{ lastUpdated }} ({{ fromNow(props.ticket.updated_at) }})</p>
+                                </div>
+                                <div class="space-y-1">
+                                    <span class="font-medium text-foreground">Requester</span>
+                                    <p>{{ props.ticket.user.nickname }}</p>
+                                    <p>{{ props.ticket.user.email }}</p>
+                                </div>
+                                <div class="space-y-1">
+                                    <span class="font-medium text-foreground">Current status</span>
+                                    <span class="inline-flex items-center rounded-full bg-secondary px-2.5 py-0.5 text-xs font-medium text-secondary-foreground">
+                                        {{ form.status }}
+                                    </span>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    </div>
+                </div>
+            </form>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -61,12 +61,14 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
 
     // Tickets
     Route::get('acp/support/tickets/create', [SupportController::class,'createTicket'])->name('acp.support.tickets.create');
+    Route::get('acp/support/tickets/{ticket}/edit', [SupportController::class,'editTicket'])->name('acp.support.tickets.edit');
     Route::post('acp/support/tickets', [SupportController::class,'storeTicket'])->name('acp.support.tickets.store');
     Route::put('acp/support/tickets/{ticket}', [SupportController::class,'updateTicket'])->name('acp.support.tickets.update');
     Route::delete('acp/support/tickets/{ticket}', [SupportController::class,'destroyTicket'])->name('acp.support.tickets.destroy');
 
     // FAQs
     Route::get('acp/support/faqs/create', [SupportController::class,'createFaq'])->name('acp.support.faqs.create');
+    Route::get('acp/support/faqs/{faq}/edit', [SupportController::class,'editFaq'])->name('acp.support.faqs.edit');
     Route::post('acp/support/faqs', [SupportController::class,'storeFaq'])->name('acp.support.faqs.store');
     Route::put('acp/support/faqs/{faq}', [SupportController::class,'updateFaq'])->name('acp.support.faqs.update');
     Route::delete('acp/support/faqs/{faq}', [SupportController::class,'destroyFaq'])->name('acp.support.faqs.destroy');


### PR DESCRIPTION
## Summary
- add Inertia pages for creating and editing support tickets and FAQs
- wire controller routes to deliver the new forms, include assignment data, and redirect after saves
- switch support dashboard stats to paginator totals and link edit actions to the new pages

## Testing
- `php artisan test` *(fails: vendor autoload not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8fef00370832ca0e6414888ff0ad0