### PR TITLE
Connect token creation and status logic

### DIFF
--- a/app/Http/Controllers/Admin/TokenController.php
+++ b/app/Http/Controllers/Admin/TokenController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\StoreTokenRequest;
 use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Inertia\Inertia;
 use Laravel\Sanctum\PersonalAccessToken;
@@ -67,16 +68,18 @@ class TokenController extends Controller
      */
     public function store(StoreTokenRequest $request)
     {
-        $user = User::findOrFail($request->user_id);
+        $data = $request->validated();
 
-        $token = $user->createToken(
-            $request->name,
-            $request->abilities ?? ['*'],
-            $request->expires_at ? now()->parse($request->expires_at) : null
+        $user = User::findOrFail($data['user_id']);
+
+        $user->createToken(
+            $data['name'],
+            $data['abilities'] ?? ['*'],
+            $data['expires_at'] ? Carbon::parse($data['expires_at']) : null
         );
 
         return redirect()->route('acp.tokens.index')
-            ->with('success','Token created.');
+            ->with('success', 'Token created.');
     }
 
     /**

--- a/app/Http/Controllers/Admin/TokenController.php
+++ b/app/Http/Controllers/Admin/TokenController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\StoreTokenRequest;
 use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
 use Inertia\Inertia;
 use Laravel\Sanctum\PersonalAccessToken;
 
@@ -19,18 +20,41 @@ class TokenController extends Controller
         $perPage = $request->get('per_page', 10);
 
         // eager‐load owner
-        $tokens = PersonalAccessToken::with('tokenable')
+        $tokens = PersonalAccessToken::with('tokenable:id,nickname,email')
             ->orderBy('created_at', 'desc')
             ->paginate($perPage)
-            ->withQueryString();
+            ->withQueryString()
+            ->through(function (PersonalAccessToken $token) {
+                $user = $token->tokenable;
+
+                return [
+                    'id'          => $token->id,
+                    'name'        => $token->name,
+                    'created_at'  => $token->created_at,
+                    'last_used_at'=> $token->last_used_at,
+                    'expires_at'  => $token->expires_at,
+                    'revoked_at'  => $token->revoked_at ?? null,
+                    'user'        => $user ? [
+                        'id'       => $user->id,
+                        'nickname' => $user->nickname,
+                        'email'    => $user->email,
+                    ] : null,
+                ];
+            });
+
+        $revokedCount = Schema::hasColumn('personal_access_tokens', 'revoked_at')
+            ? PersonalAccessToken::whereNotNull('revoked_at')->count()
+            : 0;
 
         $tokenStats = [
             'total'   => PersonalAccessToken::count(),
-            'active'  => PersonalAccessToken::whereNull('expires_at')->count(),
+            'active'  => PersonalAccessToken::where(function ($query) {
+                $query->whereNull('expires_at')
+                    ->orWhere('expires_at', '>', now());
+            })->count(),
             'expired' => PersonalAccessToken::whereNotNull('expires_at')
-                ->where('expires_at', '<', now())->count(),
-            'revoked' => PersonalAccessToken::whereNotNull('expires_at')
-                ->where('expires_at', '>=', now())->count(),
+                ->where('expires_at', '<=', now())->count(),
+            'revoked' => $revokedCount,
         ];
 
         $userList = User::select('id','nickname','email')->get();

--- a/app/Http/Requests/Admin/StoreTokenRequest.php
+++ b/app/Http/Requests/Admin/StoreTokenRequest.php
@@ -6,11 +6,6 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class StoreTokenRequest extends FormRequest
 {
-    public mixed $name;
-    public mixed $abilities;
-    public mixed $expires_at;
-    public mixed $user_id;
-
     public function authorize(): bool
     {
         // only admins (or whoever) may create tokens


### PR DESCRIPTION
## Summary
- add an ACP modal to create tokens via the store endpoint and clean up deletion handling
- derive token badge styling from expiry/revocation timestamps and show safe fallbacks
- expose personal access token metadata from the controller while fixing active/expired stats

## Testing
- php artisan test *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68d903412f08832cb8366de8cf25012b