### PR TITLE
feat: wire acp dashboard to live metrics

### DIFF
--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -3,21 +3,162 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\RedirectResponse;
+use App\Models\Blog;
+use App\Models\SupportTicket;
+use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class AdminController extends Controller
 {
     /**
-     * Show the user's profile settings page.
+     * Show the ACP dashboard with live metrics.
      */
     public function get(Request $request): Response
     {
-        return Inertia::render('acp/Dashboard', []);
+        $metrics = $this->buildMetricSnapshot();
+
+        return Inertia::render('acp/Dashboard', [
+            'metrics' => $metrics,
+            'chartData' => $this->buildChartData(),
+            'recentActivities' => $this->recentActivities(),
+        ]);
     }
 
+    /**
+     * Compile the headline metrics for the dashboard cards.
+     */
+    protected function buildMetricSnapshot(): array
+    {
+        $userTotals = [
+            'total' => User::count(),
+            'new_this_week' => User::where('created_at', '>=', now()->startOfWeek())->count(),
+        ];
 
+        $blogTotals = [
+            'total' => Blog::count(),
+            'published' => Blog::where('status', 'published')->count(),
+        ];
+
+        $ticketCounts = SupportTicket::select([
+                DB::raw('status'),
+                DB::raw('COUNT(*) as aggregate'),
+            ])
+            ->groupBy('status')
+            ->pluck('aggregate', 'status');
+
+        $tickets = [
+            'total' => SupportTicket::count(),
+            'open' => (int) ($ticketCounts['open'] ?? 0),
+            'closed' => (int) ($ticketCounts['closed'] ?? 0),
+            'pending' => (int) ($ticketCounts['pending'] ?? 0),
+            'new_this_week' => SupportTicket::where('created_at', '>=', now()->startOfWeek())->count(),
+        ];
+
+        return [
+            'users' => $userTotals,
+            'blogs' => $blogTotals,
+            'tickets' => $tickets,
+        ];
+    }
+
+    /**
+     * Build the chart payload showing monthly registrations and ticket volume.
+     */
+    protected function buildChartData(): array
+    {
+        $start = now()->startOfMonth()->subMonths(11);
+
+        $userRegistrationsByMonth = User::select([
+                DB::raw("DATE_FORMAT(created_at, '%Y-%m') as month"),
+                DB::raw('COUNT(*) as total'),
+            ])
+            ->where('created_at', '>=', $start)
+            ->groupBy('month')
+            ->orderBy('month')
+            ->pluck('total', 'month');
+
+        $supportTicketsByMonth = SupportTicket::select([
+                DB::raw("DATE_FORMAT(created_at, '%Y-%m') as month"),
+                DB::raw('COUNT(*) as total'),
+            ])
+            ->where('created_at', '>=', $start)
+            ->groupBy('month')
+            ->orderBy('month')
+            ->pluck('total', 'month');
+
+        return collect(range(0, 11))
+            ->map(fn (int $offset) => $start->copy()->addMonths($offset))
+            ->map(function (Carbon $month) use ($userRegistrationsByMonth, $supportTicketsByMonth) {
+                $key = $month->format('Y-m');
+
+                return [
+                    'period' => $month->format('M Y'),
+                    'Support Tickets' => (int) ($supportTicketsByMonth[$key] ?? 0),
+                    'New User Registrations' => (int) ($userRegistrationsByMonth[$key] ?? 0),
+                ];
+            })
+            ->toArray();
+    }
+
+    /**
+     * Gather a concise feed of recent platform activity.
+     */
+    protected function recentActivities(): array
+    {
+        $userActivity = User::latest('created_at')
+            ->take(5)
+            ->get()
+            ->map(function (User $user) {
+                return [
+                    'id' => "user-{$user->id}",
+                    'activity' => sprintf('User %s registered', $user->nickname ?? $user->name ?? 'unknown user'),
+                    'time' => optional($user->created_at)->diffForHumans(),
+                    'timestamp' => $user->created_at,
+                ];
+            });
+
+        $blogActivity = Blog::latest('published_at')
+            ->take(5)
+            ->get()
+            ->map(function (Blog $blog) {
+                $timestamp = $blog->published_at ?? $blog->created_at;
+                $status = $blog->status === 'published' ? 'published' : 'created';
+
+                return [
+                    'id' => "blog-{$blog->id}",
+                    'activity' => sprintf('Blog "%s" %s', $blog->title, $status),
+                    'time' => optional($timestamp)->diffForHumans(),
+                    'timestamp' => $timestamp,
+                ];
+            });
+
+        $ticketActivity = SupportTicket::latest('updated_at')
+            ->take(5)
+            ->get()
+            ->map(function (SupportTicket $ticket) {
+                $timestamp = $ticket->updated_at ?? $ticket->created_at;
+                $status = $ticket->status ?? 'updated';
+
+                return [
+                    'id' => "ticket-{$ticket->id}",
+                    'activity' => sprintf('Ticket "%s" %s', $ticket->subject, $status),
+                    'time' => optional($timestamp)->diffForHumans(),
+                    'timestamp' => $timestamp,
+                ];
+            });
+
+        return collect([$userActivity, $blogActivity, $ticketActivity])
+            ->flatten(1)
+            ->filter(fn ($activity) => $activity['timestamp'])
+            ->sortByDesc('timestamp')
+            ->take(8)
+            ->map(fn ($activity) => Arr::except($activity, 'timestamp'))
+            ->values()
+            ->all();
+    }
 }

--- a/database/seeders/AcpDashboardDemoSeeder.php
+++ b/database/seeders/AcpDashboardDemoSeeder.php
@@ -1,0 +1,288 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Blog;
+use App\Models\SupportTicket;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class AcpDashboardDemoSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::transaction(function () {
+            [$admin, $users] = $this->seedUsers();
+
+            $this->seedBlogs($admin, $users);
+            $this->seedSupportTickets($admin, $users);
+        });
+
+        $this->command?->info('ACP dashboard demo data seeded. You can now open the dashboard to verify live metrics.');
+    }
+
+    /**
+     * Seed a predictable set of users covering the last year of activity.
+     *
+     * @return array{0: User, 1: Collection<int, User>}
+     */
+    protected function seedUsers(): array
+    {
+        $now = now();
+        $password = Hash::make('password');
+
+        $adminCreatedAt = $now->copy()->subMonths(11)->startOfMonth()->addDays(2);
+
+        $admin = User::updateOrCreate(
+            ['email' => 'acp-dashboard-admin@example.com'],
+            [
+                'nickname' => 'Dashboard Admin',
+                'password' => $password,
+                'email_verified_at' => $adminCreatedAt,
+                'last_activity_at' => $now->copy()->subDay(),
+            ]
+        );
+        $admin->forceFill([
+            'created_at' => $adminCreatedAt,
+            'updated_at' => $now,
+        ])->saveQuietly();
+
+        $users = collect();
+
+        foreach (range(0, 11) as $offset) {
+            $monthStart = $now->copy()->startOfMonth()->subMonths($offset);
+
+            foreach (range(1, 3) as $sequence) {
+                $createdAt = $monthStart->copy()->addDays($sequence * 5);
+                $email = sprintf('acp-dashboard-user-%02d-%d@example.com', $offset + 1, $sequence);
+
+                $user = User::updateOrCreate(
+                    ['email' => $email],
+                    [
+                        'nickname' => sprintf('Demo User %02d-%d', $offset + 1, $sequence),
+                        'password' => $password,
+                        'email_verified_at' => $createdAt,
+                        'last_activity_at' => $createdAt->copy()->addDays(10),
+                    ]
+                );
+                $user->forceFill([
+                    'created_at' => $createdAt,
+                    'updated_at' => $createdAt,
+                ])->saveQuietly();
+
+                $users->push($user);
+            }
+        }
+
+        $recentUserDefinitions = [
+            ['suffix' => 'alpha', 'daysAgo' => 1],
+            ['suffix' => 'beta', 'daysAgo' => 3],
+            ['suffix' => 'gamma', 'daysAgo' => 5],
+        ];
+
+        foreach ($recentUserDefinitions as $definition) {
+            $createdAt = $now->copy()->subDays($definition['daysAgo']);
+            $email = sprintf('acp-dashboard-user-this-week-%s@example.com', $definition['suffix']);
+
+            $user = User::updateOrCreate(
+                ['email' => $email],
+                [
+                    'nickname' => Str::title(str_replace('-', ' ', $definition['suffix'])) . ' Tester',
+                    'password' => $password,
+                    'email_verified_at' => $createdAt,
+                    'last_activity_at' => $createdAt->copy()->addHours(6),
+                ]
+            );
+            $user->forceFill([
+                'created_at' => $createdAt,
+                'updated_at' => $createdAt,
+            ])->saveQuietly();
+
+            $users->push($user);
+        }
+
+        return [$admin, $users->values()];
+    }
+
+    /**
+     * Seed a mix of published, draft, and archived blogs for dashboard metrics.
+     */
+    protected function seedBlogs(User $admin, Collection $users): void
+    {
+        $now = now();
+        $authors = $users->shuffle()->take(4)->prepend($admin)->values();
+
+        $blogDefinitions = [
+            [
+                'slug' => 'demo-welcome-to-the-dashboard',
+                'title' => 'Welcome to the Live ACP Dashboard',
+                'status' => 'published',
+                'published_at' => $now->copy()->subDays(9),
+                'created_at' => $now->copy()->subDays(12),
+                'author' => $admin,
+            ],
+            [
+                'slug' => 'demo-monthly-product-recap',
+                'title' => 'Monthly Product Recap',
+                'status' => 'published',
+                'published_at' => $now->copy()->subDays(37),
+                'created_at' => $now->copy()->subDays(40),
+            ],
+            [
+                'slug' => 'demo-community-highlights',
+                'title' => 'Community Highlights to Share',
+                'status' => 'draft',
+                'published_at' => null,
+                'created_at' => $now->copy()->subDays(18),
+            ],
+            [
+                'slug' => 'demo-support-efficiency-wins',
+                'title' => 'Support Efficiency Wins for Q2',
+                'status' => 'published',
+                'published_at' => $now->copy()->subDays(65),
+                'created_at' => $now->copy()->subDays(70),
+            ],
+            [
+                'slug' => 'demo-archived-roadmap-update',
+                'title' => 'Archived: Roadmap Update from Last Year',
+                'status' => 'archived',
+                'published_at' => $now->copy()->subMonths(8),
+                'created_at' => $now->copy()->subMonths(9),
+            ],
+        ];
+
+        foreach ($blogDefinitions as $index => $definition) {
+            $author = $definition['author'] ?? $authors[$index % $authors->count()];
+            $body = $definition['body'] ?? $this->demoBodyCopy($definition['title']);
+            $createdAt = $definition['created_at'];
+            $updatedAt = $definition['updated_at'] ?? $definition['published_at'] ?? $createdAt;
+
+            $blog = Blog::updateOrCreate(
+                ['slug' => $definition['slug']],
+                [
+                    'title' => $definition['title'],
+                    'excerpt' => $definition['excerpt'] ?? Str::limit(strip_tags($body), 160),
+                    'body' => $body,
+                    'user_id' => $author->id,
+                    'status' => $definition['status'],
+                    'published_at' => $definition['published_at'],
+                ]
+            );
+            $blog->forceFill([
+                'created_at' => $createdAt,
+                'updated_at' => $updatedAt,
+            ])->saveQuietly();
+        }
+    }
+
+    /**
+     * Seed a variety of support tickets to drive the dashboard counts and activity feed.
+     */
+    protected function seedSupportTickets(User $admin, Collection $users): void
+    {
+        $now = now();
+        $userPool = $users->shuffle()->values();
+
+        $subjects = [
+            'Onboarding question about team invites',
+            'Billing discrepancy on annual invoice',
+            'Analytics dashboard showing blank state',
+            'Request for bulk user import assistance',
+            'Feature request: Saved dashboard filters',
+            'Bug: Notifications not sending',
+            'Clarification on permissions model',
+            'API key rotation best practices',
+            'Mobile layout spacing feedback',
+            'Localization strings missing',
+            'Unable to upload hero images',
+            'Two-factor authentication reset',
+        ];
+
+        foreach (range(0, 11) as $offset) {
+            $subject = sprintf('Demo Ticket %02d: %s', $offset + 1, $subjects[$offset]);
+            $createdAt = $now->copy()->startOfMonth()->subMonths($offset)->addDays(6);
+            $status = match (true) {
+                $offset === 0 => 'open',
+                $offset === 1 => 'pending',
+                $offset <= 4 => 'closed',
+                $offset % 3 === 0 => 'pending',
+                default => 'closed',
+            };
+            $priority = ['high', 'medium', 'low'][$offset % 3];
+            $assigneeId = in_array($status, ['open', 'pending'], true) ? $admin->id : null;
+            $updatedAt = match ($status) {
+                'closed' => $createdAt->copy()->addDays(4),
+                'pending' => $now->copy()->subDays($offset + 2),
+                default => $now->copy()->subDay(),
+            };
+
+            $requestor = $userPool[$offset % $userPool->count()];
+
+            $ticketModel = SupportTicket::updateOrCreate(
+                ['subject' => $subject],
+                [
+                    'user_id' => $requestor->id,
+                    'body' => 'This is seeded sample data to validate the ACP dashboard metrics. No action is required.',
+                    'status' => $status,
+                    'priority' => $priority,
+                    'assigned_to' => $assigneeId,
+                ]
+            );
+            $ticketModel->forceFill([
+                'created_at' => $createdAt,
+                'updated_at' => $updatedAt,
+            ])->saveQuietly();
+        }
+
+        $recentTickets = [
+            [
+                'subject' => 'Demo Ticket: API latency reported by customer',
+                'priority' => 'high',
+                'status' => 'open',
+                'daysAgo' => 2,
+            ],
+            [
+                'subject' => 'Demo Ticket: Styling regression on billing page',
+                'priority' => 'medium',
+                'status' => 'pending',
+                'daysAgo' => 4,
+            ],
+        ];
+
+        foreach ($recentTickets as $index => $ticket) {
+            $createdAt = $now->copy()->subDays($ticket['daysAgo']);
+            $requestor = $userPool[($index + 3) % $userPool->count()];
+
+            $ticketModel = SupportTicket::updateOrCreate(
+                ['subject' => $ticket['subject']],
+                [
+                    'user_id' => $requestor->id,
+                    'body' => 'Seeded ticket opened this week to validate "new" counts and recent activity ordering.',
+                    'status' => $ticket['status'],
+                    'priority' => $ticket['priority'],
+                    'assigned_to' => $admin->id,
+                ]
+            );
+            $ticketModel->forceFill([
+                'created_at' => $createdAt,
+                'updated_at' => $ticket['status'] === 'pending' ? $createdAt->copy()->addDay() : $now->copy()->subHours(6),
+            ])->saveQuietly();
+        }
+    }
+
+    /**
+     * Provide a reusable block of content for demo blog posts.
+     */
+    protected function demoBodyCopy(string $title): string
+    {
+        return <<<HTML
+<p><strong>{$title}</strong> is part of the ACP dashboard demo dataset.</p>
+<p>Use this seeded content to confirm that the live metrics, trend chart, and activity feed render as expected once real data flows into the system.</p>
+<p>After validating the experience you can safely remove or archive this post.</p>
+HTML;
+    }
+}

--- a/resources/js/pages/acp/Dashboard.vue
+++ b/resources/js/pages/acp/Dashboard.vue
@@ -1,12 +1,55 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed } from 'vue';
 import AppLayout from '@/layouts/AppLayout.vue';
 import AdminLayout from '@/layouts/acp/AdminLayout.vue';
 import { type BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/vue3';
 import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
-import { Users, BookOpen, MessageSquare, LifeBuoy } from 'lucide-vue-next';
+import { Users, UserPlus, BookOpen, LifeBuoy } from 'lucide-vue-next';
 import { LineChart } from '@/components/ui/chart-line';
+
+type MetricGroup = {
+    total: number;
+    new_this_week?: number;
+    open?: number;
+    closed?: number;
+    pending?: number;
+    published?: number;
+};
+
+type DashboardMetrics = {
+    users: MetricGroup & { new_this_week: number };
+    blogs: MetricGroup & { published: number };
+    tickets: MetricGroup & { open: number; new_this_week: number };
+};
+
+type DashboardChartDatum = {
+    period: string;
+    'Support Tickets': number;
+    'New User Registrations': number;
+};
+
+type DashboardActivity = {
+    id: string | number;
+    activity: string;
+    time: string | null;
+};
+
+interface DashboardProps {
+    metrics: DashboardMetrics;
+    chartData: DashboardChartDatum[];
+    recentActivities: DashboardActivity[];
+}
+
+const props = withDefaults(defineProps<DashboardProps>(), {
+    metrics: () => ({
+        users: { total: 0, new_this_week: 0 },
+        blogs: { total: 0, published: 0 },
+        tickets: { total: 0, open: 0, closed: 0, pending: 0, new_this_week: 0 },
+    }),
+    chartData: () => [],
+    recentActivities: () => [],
+});
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -15,286 +58,23 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
-// Dummy data for stats cards with Lucide icons
-const stats = [
-    { title: 'Total Users', value: '1,234', icon: Users },
-    { title: 'Total Blogs', value: '56', icon: BookOpen },
-    { title: 'Total Threads', value: '78', icon: MessageSquare },
-    { title: 'Open Tickets', value: '20', icon: LifeBuoy },
-];
+const numberFormatter = new Intl.NumberFormat();
 
-// Dummy data for recent activity
-const recentActivities = [
-    { id: 1, activity: 'User John Doe registered', time: '2 mins ago' },
-    { id: 2, activity: 'Blog "How to Code" published', time: '10 mins ago' },
-    { id: 3, activity: 'User Jane updated profile', time: '1 hour ago' },
-    { id: 4, activity: 'Permission "Edit Posts" assigned to Editor role', time: '2 hours ago' },
-];
+const formatNumber = (value: number | null | undefined) => numberFormatter.format(value ?? 0);
 
-// Dummy data for the line chart (User Signups Over Time)
-// The keys have been updated: "Support Tickets" and "New User Registrations"
-const chartData = ref([
-    {
-        year: 1970,
-        'Support Tickets': 2.04,
-        'New User Registrations': 1.53,
-    },
-    {
-        year: 1971,
-        'Support Tickets': 1.96,
-        'New User Registrations': 1.58,
-    },
-    {
-        year: 1972,
-        'Support Tickets': 1.96,
-        'New User Registrations': 1.61,
-    },
-    {
-        year: 1973,
-        'Support Tickets': 1.93,
-        'New User Registrations': 1.61,
-    },
-    {
-        year: 1974,
-        'Support Tickets': 1.88,
-        'New User Registrations': 1.67,
-    },
-    {
-        year: 1975,
-        'Support Tickets': 1.79,
-        'New User Registrations': 1.64,
-    },
-    {
-        year: 1976,
-        'Support Tickets': 1.77,
-        'New User Registrations': 1.62,
-    },
-    {
-        year: 1977,
-        'Support Tickets': 1.74,
-        'New User Registrations': 1.69,
-    },
-    {
-        year: 1978,
-        'Support Tickets': 1.74,
-        'New User Registrations': 1.7,
-    },
-    {
-        year: 1979,
-        'Support Tickets': 1.77,
-        'New User Registrations': 1.67,
-    },
-    {
-        year: 1980,
-        'Support Tickets': 1.79,
-        'New User Registrations': 1.7,
-    },
-    {
-        year: 1981,
-        'Support Tickets': 1.81,
-        'New User Registrations': 1.72,
-    },
-    {
-        year: 1982,
-        'Support Tickets': 1.84,
-        'New User Registrations': 1.73,
-    },
-    {
-        year: 1983,
-        'Support Tickets': 1.77,
-        'New User Registrations': 1.73,
-    },
-    {
-        year: 1984,
-        'Support Tickets': 1.78,
-        'New User Registrations': 1.78,
-    },
-    {
-        year: 1985,
-        'Support Tickets': 1.78,
-        'New User Registrations': 1.81,
-    },
-    {
-        year: 1986,
-        'Support Tickets': 1.82,
-        'New User Registrations': 1.89,
-    },
-    {
-        year: 1987,
-        'Support Tickets': 1.82,
-        'New User Registrations': 1.91,
-    },
-    {
-        year: 1988,
-        'Support Tickets': 1.77,
-        'New User Registrations': 1.94,
-    },
-    {
-        year: 1989,
-        'Support Tickets': 1.76,
-        'New User Registrations': 1.94,
-    },
-    {
-        year: 1990,
-        'Support Tickets': 1.75,
-        'New User Registrations': 1.97,
-    },
-    {
-        year: 1991,
-        'Support Tickets': 1.62,
-        'New User Registrations': 1.99,
-    },
-    {
-        year: 1992,
-        'Support Tickets': 1.56,
-        'New User Registrations': 2.12,
-    },
-    {
-        year: 1993,
-        'Support Tickets': 1.5,
-        'New User Registrations': 2.13,
-    },
-    {
-        year: 1994,
-        'Support Tickets': 1.46,
-        'New User Registrations': 2.15,
-    },
-    {
-        year: 1995,
-        'Support Tickets': 1.43,
-        'New User Registrations': 2.17,
-    },
-    {
-        year: 1996,
-        'Support Tickets': 1.4,
-        'New User Registrations': 2.2,
-    },
-    {
-        year: 1997,
-        'Support Tickets': 1.37,
-        'New User Registrations': 2.15,
-    },
-    {
-        year: 1998,
-        'Support Tickets': 1.34,
-        'New User Registrations': 2.07,
-    },
-    {
-        year: 1999,
-        'Support Tickets': 1.32,
-        'New User Registrations': 2.05,
-    },
-    {
-        year: 2000,
-        'Support Tickets': 1.33,
-        'New User Registrations': 2.07,
-    },
-    {
-        year: 2001,
-        'Support Tickets': 1.31,
-        'New User Registrations': 2.08,
-    },
-    {
-        year: 2002,
-        'Support Tickets': 1.29,
-        'New User Registrations': 2.1,
-    },
-    {
-        year: 2003,
-        'Support Tickets': 1.27,
-        'New User Registrations': 2.15,
-    },
-    {
-        year: 2004,
-        'Support Tickets': 1.27,
-        'New User Registrations': 2.21,
-    },
-    {
-        year: 2005,
-        'Support Tickets': 1.26,
-        'New User Registrations': 2.23,
-    },
-    {
-        year: 2006,
-        'Support Tickets': 1.26,
-        'New User Registrations': 2.29,
-    },
-    {
-        year: 2007,
-        'Support Tickets': 1.27,
-        'New User Registrations': 2.34,
-    },
-    {
-        year: 2008,
-        'Support Tickets': 1.26,
-        'New User Registrations': 2.36,
-    },
-    {
-        year: 2009,
-        'Support Tickets': 1.26,
-        'New User Registrations': 2.36,
-    },
-    {
-        year: 2010,
-        'Support Tickets': 1.25,
-        'New User Registrations': 2.35,
-    },
-    {
-        year: 2011,
-        'Support Tickets': 1.24,
-        'New User Registrations': 2.34,
-    },
-    {
-        year: 2012,
-        'Support Tickets': 1.25,
-        'New User Registrations': 2.39,
-    },
-    {
-        year: 2013,
-        'Support Tickets': 1.22,
-        'New User Registrations': 2.3,
-    },
-    {
-        year: 2014,
-        'Support Tickets': 1.2,
-        'New User Registrations': 2.35,
-    },
-    {
-        year: 2015,
-        'Support Tickets': 1.17,
-        'New User Registrations': 2.39,
-    },
-    {
-        year: 2016,
-        'Support Tickets': 1.16,
-        'New User Registrations': 2.41,
-    },
-    {
-        year: 2017,
-        'Support Tickets': 1.13,
-        'New User Registrations': 2.44,
-    },
-    {
-        year: 2018,
-        'Support Tickets': 1.07,
-        'New User Registrations': 2.45,
-    },
-    {
-        year: 2019,
-        'Support Tickets': 1.03,
-        'New User Registrations': 2.47,
-    },
-    {
-        year: 2020,
-        'Support Tickets': 0.92,
-        'New User Registrations': 2.48,
-    },
-    {
-        year: 2021,
-        'Support Tickets': 0.82,
-        'New User Registrations': 2.51,
-    },
+const statCards = computed(() => [
+    { title: 'Total Users', value: props.metrics.users.total, icon: Users },
+    { title: 'New Users (This Week)', value: props.metrics.users.new_this_week, icon: UserPlus },
+    { title: 'Published Blogs', value: props.metrics.blogs.published ?? props.metrics.blogs.total, icon: BookOpen },
+    { title: 'Open Tickets', value: props.metrics.tickets.open, icon: LifeBuoy },
 ]);
+
+const chartSeries = ['Support Tickets', 'New User Registrations'] as const;
+
+const chartData = computed(() => props.chartData ?? []);
+const hasChartData = computed(() => chartData.value.length > 0);
+
+const recentActivities = computed(() => props.recentActivities ?? []);
 </script>
 
 <template>
@@ -302,56 +82,50 @@ const chartData = ref([
         <Head title="Dashboard ACP" />
         <AdminLayout>
             <div class="flex h-full flex-1 flex-col gap-4 rounded-xl pb-4">
-                <!-- Stats Cards Section -->
                 <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
                     <div
-                        v-for="(stat, index) in stats"
+                        v-for="(stat, index) in statCards"
                         :key="index"
-                        class="relative overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border p-4 flex items-center"
+                        class="relative flex items-center overflow-hidden rounded-xl border border-sidebar-border/70 p-4 dark:border-sidebar-border"
                     >
                         <div class="mr-4">
-                            <!-- Render the Lucide icon -->
                             <component :is="stat.icon" class="h-8 w-8 text-gray-600" />
                         </div>
                         <div>
                             <div class="text-sm text-gray-500">{{ stat.title }}</div>
-                            <div class="text-xl font-bold">{{ stat.value }}</div>
+                            <div class="text-xl font-bold">{{ formatNumber(stat.value) }}</div>
                         </div>
                         <PlaceholderPattern />
                     </div>
                 </div>
 
-                <!-- Chart Section -->
-                <div class="rounded-xl border border-sidebar-border/70 dark:border-sidebar-border p-4">
-                    <h2 class="text-lg font-semibold mb-2">User Signups & Support Tickets</h2>
-                    <!-- Use the LineChart component with the updated chartData -->
+                <div class="rounded-xl border border-sidebar-border/70 p-4 dark:border-sidebar-border">
+                    <h2 class="mb-2 text-lg font-semibold">User Signups &amp; Support Tickets</h2>
                     <LineChart
+                        v-if="hasChartData"
                         :data="chartData"
-                        index="year"
-                        :categories="['Support Tickets', 'New User Registrations']"
-                        :y-formatter="(tick, i) => {
-              return typeof tick === 'number'
-                ? `${new Intl.NumberFormat('us').format(tick).toString()}k`
-                : ''
-            }"
+                        index="period"
+                        :categories="chartSeries"
+                        :y-formatter="(tick) => (typeof tick === 'number' ? formatNumber(tick) : '')"
                     />
+                    <p v-else class="text-sm text-muted-foreground">Not enough data to show trends yet.</p>
                 </div>
 
-                <!-- Recent Activity Section -->
-                <div class="rounded-xl border border-sidebar-border/70 dark:border-sidebar-border p-4">
-                    <h2 class="text-lg font-semibold mb-2">Recent Activity</h2>
-                    <ul>
+                <div class="rounded-xl border border-sidebar-border/70 p-4 dark:border-sidebar-border">
+                    <h2 class="mb-2 text-lg font-semibold">Recent Activity</h2>
+                    <ul v-if="recentActivities.length">
                         <li
                             v-for="activity in recentActivities"
                             :key="activity.id"
-                            class="py-2 border-b border-gray-200 last:border-b-0"
+                            class="border-b border-gray-200 py-2 last:border-b-0"
                         >
                             <div class="flex justify-between">
                                 <span>{{ activity.activity }}</span>
-                                <span class="text-xs text-gray-500">{{ activity.time }}</span>
+                                <span class="text-xs text-gray-500">{{ activity.time ?? '—' }}</span>
                             </div>
                         </li>
                     </ul>
+                    <p v-else class="text-sm text-muted-foreground">No recent activity yet.</p>
                 </div>
             </div>
         </AdminLayout>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -12,9 +12,7 @@ use Inertia\Inertia;
 Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
     Route::redirect('acp', '/acp/dashboard');
 
-    Route::get('acp/dashboard', function () {
-        return Inertia::render('acp/Dashboard');
-    })->name('acp.dashboard');
+    Route::get('acp/dashboard', [AdminController::class, 'get'])->name('acp.dashboard');
 
     Route::get('acp/users', function () {
         return Inertia::render('acp/Users');


### PR DESCRIPTION
## Summary
- replace the ACP dashboard placeholders with real user, blog, and ticket aggregates from the server
- expose monthly registration and support ticket trends for the line chart
- surface a recent activity feed sourced from the latest users, blogs, and tickets

## Testing
- npm run lint *(fails: existing unused import lint errors in unrelated pages)*

------
https://chatgpt.com/codex/tasks/task_e_68d909de0be4832c8b2aa0ac3a447b63