### PR TITLE
Deduplicate admin routes and align stats with paginator totals

### DIFF
--- a/app/Http/Controllers/Admin/BlogController.php
+++ b/app/Http/Controllers/Admin/BlogController.php
@@ -18,17 +18,20 @@ class BlogController extends Controller
     {
         $perPage = $request->get('per_page', 15);
 
+        $blogQuery = Blog::query();
+
         // Retrieve blogs with their associated author information.
-        $blogs = Blog::with('user')
+        $blogs = (clone $blogQuery)
+            ->with('user')
             ->orderBy('created_at', 'desc')
             ->paginate($perPage)
             ->withQueryString();
 
         $blogStats = [
-            'total'      => Blog::count(),
-            'published'  => Blog::where('status', 'published')->count(),
-            'draft'      => Blog::where('status', 'draft')->count(),
-            'archived'   => Blog::where('status', 'archived')->count(),
+            'total'      => $blogs->total(),
+            'published'  => (clone $blogQuery)->where('status', 'published')->count(),
+            'draft'      => (clone $blogQuery)->where('status', 'draft')->count(),
+            'archived'   => (clone $blogQuery)->where('status', 'archived')->count(),
         ];
 
         return inertia('acp/Blogs', compact('blogs', 'blogStats'));

--- a/app/Http/Controllers/Admin/UsersController.php
+++ b/app/Http/Controllers/Admin/UsersController.php
@@ -19,16 +19,19 @@ class UsersController extends Controller
     {
         $perPage = $request->get('per_page', 15);
 
-        $users = User::with('roles')
+        $userQuery = User::query();
+
+        $users = (clone $userQuery)
+            ->with('roles')
             ->orderBy('created_at', 'desc')
             ->paginate($perPage)
             ->withQueryString();
 
         $userStats = [
-            'total'      => User::count(),
-            'unverified' => User::whereNull('email_verified_at')->count(),
-            'banned'     => User::where('is_banned', true)->count(),
-            'online'     => User::where('last_activity_at', '>=', now()->subMinutes(5))->count(),
+            'total'      => $users->total(),
+            'unverified' => (clone $userQuery)->whereNull('email_verified_at')->count(),
+            'banned'     => (clone $userQuery)->where('is_banned', true)->count(),
+            'online'     => (clone $userQuery)->where('last_activity_at', '>=', now()->subMinutes(5))->count(),
         ];
 
         return inertia('acp/Users', compact('users','userStats'));

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -14,10 +14,6 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
 
     Route::get('acp/dashboard', [AdminController::class, 'get'])->name('acp.dashboard');
 
-    Route::get('acp/users', function () {
-        return Inertia::render('acp/Users');
-    })->name('acp.users');
-
     // Admin User Management Routes
     Route::get('acp/users', [AdminUserController::class, 'index'])->name('acp.users.index');
     Route::get('acp/users/{user}/edit', [AdminUserController::class, 'edit'])->name('acp.users.edit');
@@ -49,10 +45,6 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
     Route::get('acp/forums', function () {
         return Inertia::render('acp/Forums');
     })->name('acp.forums');
-
-    Route::get('acp/support', function () {
-        return Inertia::render('acp/Support');
-    })->name('acp.support');
 
     // Support ACP
     Route::get('acp/support', [SupportController::class,'index'])->name('acp.support.index');


### PR DESCRIPTION
## Summary
- remove redundant closure definitions for admin support and user routes so each endpoint is declared once
- base admin list statistics on the paginator totals and shared query builders to keep counts consistent with applied filters

## Testing
- php artisan test *(fails: vendor directory missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d91c8fe3a8832ca5484da4d2a5eb35