### PR TITLE
Create reusable Inertia pagination composable

### DIFF
--- a/resources/js/composables/useInertiaPagination.ts
+++ b/resources/js/composables/useInertiaPagination.ts
@@ -1,0 +1,145 @@
+import { computed, ref, unref, watch, type ComputedRef, type MaybeRefOrGetter, type Ref } from 'vue';
+
+export interface PaginationMeta {
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+    from: number | null;
+    to: number | null;
+}
+
+export interface UseInertiaPaginationOptions {
+    meta: MaybeRefOrGetter<Partial<PaginationMeta> | null | undefined>;
+    itemsLength?: MaybeRefOrGetter<number | null | undefined>;
+    defaultPerPage?: number;
+    itemLabel?: string;
+    itemLabelPlural?: string;
+    emptyLabel?: string;
+    onNavigate?: (page: number) => void;
+}
+
+export interface SetPageOptions {
+    emitNavigate?: boolean;
+}
+
+export interface UseInertiaPaginationResult {
+    meta: ComputedRef<PaginationMeta>;
+    page: Ref<number>;
+    setPage: (page: number, options?: SetPageOptions) => void;
+    pageCount: ComputedRef<number>;
+    rangeLabel: ComputedRef<string>;
+}
+
+function normalizeNumber(value: unknown, fallback: number): number {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+export function useInertiaPagination(options: UseInertiaPaginationOptions): UseInertiaPaginationResult {
+    const {
+        meta: metaSource,
+        itemsLength = 0,
+        defaultPerPage = 15,
+        itemLabel = 'item',
+        itemLabelPlural,
+        emptyLabel,
+        onNavigate,
+    } = options;
+
+    const itemsCount = computed(() => Math.max(0, normalizeNumber(unref(itemsLength), 0)));
+
+    const meta = computed<PaginationMeta>(() => {
+        const raw = unref(metaSource) ?? {};
+
+        const total = normalizeNumber(raw.total, itemsCount.value);
+        const perPageDefault = itemsCount.value > 0 ? itemsCount.value : defaultPerPage;
+        const perPage = Math.max(1, normalizeNumber(raw.per_page, perPageDefault) || perPageDefault);
+        const currentPage = Math.max(1, normalizeNumber(raw.current_page, 1));
+        const derivedLastPage = Math.max(Math.ceil(total / Math.max(perPage, 1)), 1);
+        const lastPage = Math.max(1, normalizeNumber(raw.last_page, derivedLastPage));
+
+        const hasItems = total > 0;
+        const from = raw.from ?? (hasItems ? (currentPage - 1) * perPage + 1 : null);
+        const to = raw.to ?? (hasItems ? Math.min(currentPage * perPage, total) : null);
+
+        return {
+            current_page: currentPage,
+            last_page: lastPage,
+            per_page: perPage,
+            total,
+            from,
+            to,
+        };
+    });
+
+    const page = ref(meta.value.current_page);
+
+    const pageCount = computed(() => {
+        const derived = Math.ceil(meta.value.total / Math.max(meta.value.per_page, 1));
+        return Math.max(meta.value.last_page, derived || 1, 1);
+    });
+
+    const pluralLabel = computed(() => itemLabelPlural ?? `${itemLabel}s`);
+    const emptyMessage = computed(() => emptyLabel ?? `No ${pluralLabel.value} to display`);
+
+    const rangeLabel = computed(() => {
+        if (meta.value.total === 0) {
+            return emptyMessage.value;
+        }
+
+        const from = meta.value.from ?? (meta.value.current_page - 1) * meta.value.per_page + 1;
+        const to = meta.value.to ?? Math.min(meta.value.current_page * meta.value.per_page, meta.value.total);
+        const label = meta.value.total === 1 ? itemLabel : pluralLabel.value;
+
+        return `Showing ${from}-${to} of ${meta.value.total} ${label}`;
+    });
+
+    watch(
+        () => meta.value.current_page,
+        (newPage) => {
+            if (page.value !== newPage) {
+                page.value = newPage;
+            }
+        },
+    );
+
+    let skipNextNavigate = false;
+
+    watch(
+        page,
+        (newPage) => {
+            const safePage = Math.min(Math.max(newPage, 1), pageCount.value);
+
+            if (safePage !== newPage) {
+                page.value = safePage;
+                skipNextNavigate = false;
+                return;
+            }
+
+            if (skipNextNavigate) {
+                skipNextNavigate = false;
+                return;
+            }
+
+            if (safePage === meta.value.current_page) {
+                return;
+            }
+
+            onNavigate?.(safePage);
+        },
+    );
+
+    const setPage = (value: number, options: SetPageOptions = {}) => {
+        skipNextNavigate = options.emitNavigate === false;
+        page.value = value;
+    };
+
+    return {
+        meta,
+        page,
+        setPage,
+        pageCount,
+        rangeLabel,
+    };
+}

--- a/resources/js/pages/ForumThreadView.vue
+++ b/resources/js/pages/ForumThreadView.vue
@@ -7,7 +7,6 @@ import { type BreadcrumbItem } from '@/types';
 // Import shadcn‑vue components
 import Avatar from '@/components/ui/avatar/Avatar.vue';
 import Button from '@/components/ui/button/Button.vue';
-import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
 import {
     Pagination,
     PaginationEllipsis,
@@ -28,12 +27,7 @@ import {
     DropdownMenuGroup,
     DropdownMenuItem,
     DropdownMenuLabel,
-    DropdownMenuPortal,
     DropdownMenuSeparator,
-    DropdownMenuShortcut,
-    DropdownMenuSub,
-    DropdownMenuSubContent,
-    DropdownMenuSubTrigger,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import {
@@ -50,6 +44,7 @@ import {
     MessageSquareLock,
 } from 'lucide-vue-next';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { useInertiaPagination, type PaginationMeta } from '@/composables/useInertiaPagination';
 
 interface BoardSummary {
     title: string;
@@ -108,15 +103,6 @@ interface ThreadPost {
     permissions: PostPermissions;
 }
 
-interface PaginationMeta {
-    current_page: number;
-    last_page: number;
-    per_page: number;
-    total: number;
-    from: number | null;
-    to: number | null;
-}
-
 interface PostsPayload {
     data: ThreadPost[];
     meta?: PaginationMeta | null;
@@ -156,47 +142,31 @@ const reportReasons = computed(() => props.reportReasons ?? []);
 const defaultReportReason = computed(() => reportReasons.value[0]?.value ?? '');
 const hasReportReasons = computed(() => reportReasons.value.length > 0);
 
-const postsMetaFallback = computed<PaginationMeta>(() => {
-    const total = props.posts.data.length;
-
-    return {
-        current_page: 1,
-        last_page: 1,
-        per_page: total > 0 ? total : 10,
-        total,
-        from: total > 0 ? 1 : null,
-        to: total > 0 ? total : null,
-    };
+const {
+    meta: postsMeta,
+    page: paginationPage,
+    rangeLabel: postsRangeLabel,
+} = useInertiaPagination({
+    meta: computed(() => props.posts.meta ?? null),
+    itemsLength: computed(() => props.posts.data.length),
+    defaultPerPage: 10,
+    itemLabel: 'post',
+    itemLabelPlural: 'posts',
+    emptyLabel: 'No posts to display',
+    onNavigate: (page) => {
+        router.get(
+            route('forum.threads.show', { board: props.board.slug, thread: props.thread.slug }),
+            {
+                page,
+            },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                replace: true,
+            },
+        );
+    },
 });
-
-const postsMeta = computed<PaginationMeta>(() => {
-    return {
-        ...postsMetaFallback.value,
-        ...(props.posts.meta ?? {}),
-    };
-});
-
-const postsPageCount = computed(() => {
-    const meta = postsMeta.value;
-    const derived = Math.ceil(meta.total / Math.max(meta.per_page, 1));
-    return Math.max(meta.last_page, derived || 1, 1);
-});
-
-const postsRangeLabel = computed(() => {
-    const meta = postsMeta.value;
-
-    if (meta.total === 0) {
-        return 'No posts to display';
-    }
-
-    const from = meta.from ?? ((meta.current_page - 1) * meta.per_page + 1);
-    const to = meta.to ?? Math.min(meta.current_page * meta.per_page, meta.total);
-    const postWord = meta.total === 1 ? 'post' : 'posts';
-
-    return `Showing ${from}-${to} of ${meta.total} ${postWord}`;
-});
-
-const paginationPage = ref(postsMeta.value.current_page);
 const threadActionLoading = ref(false);
 const activePostActionId = ref<number | null>(null);
 const threadReportDialogOpen = ref(false);
@@ -228,29 +198,14 @@ const selectedPostReason = computed(() =>
 watch(
     () => postsMeta.value.current_page,
     (page) => {
-        paginationPage.value = page;
         threadReportForm.page = page;
         postReportForm.page = page;
     },
 );
 
 watch(paginationPage, (page) => {
-    const safePage = Math.min(Math.max(page, 1), postsPageCount.value);
-
-    if (safePage !== page) {
-        paginationPage.value = safePage;
-        return;
-    }
-
-    if (safePage === postsMeta.value.current_page) return;
-
-    router.get(route('forum.threads.show', { board: props.board.slug, thread: props.thread.slug }), {
-        page: safePage,
-    }, {
-        preserveScroll: true,
-        preserveState: true,
-        replace: true,
-    });
+    threadReportForm.page = page;
+    postReportForm.page = page;
 });
 
 watch(threadReportDialogOpen, (open) => {

--- a/resources/js/pages/ForumThreads.vue
+++ b/resources/js/pages/ForumThreads.vue
@@ -11,12 +11,7 @@ import {
     DropdownMenuGroup,
     DropdownMenuItem,
     DropdownMenuLabel,
-    DropdownMenuPortal,
     DropdownMenuSeparator,
-    DropdownMenuShortcut,
-    DropdownMenuSub,
-    DropdownMenuSubContent,
-    DropdownMenuSubTrigger,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
@@ -33,6 +28,7 @@ import {
 import { Textarea } from '@/components/ui/textarea'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Label } from '@/components/ui/label'
+import { useInertiaPagination, type PaginationMeta } from '@/composables/useInertiaPagination';
 import {
     Pin,
     Ellipsis,
@@ -77,15 +73,6 @@ interface ThreadSummary {
     last_reply_author: string | null;
     last_reply_at: string | null;
     permissions: ThreadPermissions;
-}
-
-interface PaginationMeta {
-    current_page: number;
-    last_page: number;
-    per_page: number;
-    total: number;
-    from: number | null;
-    to: number | null;
 }
 
 interface ThreadsPayload {
@@ -136,48 +123,33 @@ const hasReportReasons = computed(() => reportReasons.value.length > 0);
 
 const canStartThread = computed(() => Boolean(page.props.auth?.user));
 
-const threadsMetaFallback = computed<PaginationMeta>(() => {
-    const total = props.threads.data?.length ?? 0;
-
-    return {
-        current_page: 1,
-        last_page: 1,
-        per_page: total > 0 ? total : 15,
-        total,
-        from: total > 0 ? 1 : null,
-        to: total > 0 ? total : null,
-    };
+const {
+    meta: threadsMeta,
+    page: paginationPage,
+    setPage: setThreadsPage,
+    rangeLabel: threadsRangeLabel,
+} = useInertiaPagination({
+    meta: computed(() => props.threads.meta ?? null),
+    itemsLength: computed(() => props.threads.data?.length ?? 0),
+    defaultPerPage: 15,
+    itemLabel: 'thread',
+    itemLabelPlural: 'threads',
+    emptyLabel: 'No threads to display',
+    onNavigate: (page) => {
+        router.get(
+            route('forum.boards.show', { board: props.board.slug }),
+            {
+                search: searchQuery.value || undefined,
+                page,
+            },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                replace: true,
+            },
+        );
+    },
 });
-
-const threadsMeta = computed<PaginationMeta>(() => {
-    return {
-        ...threadsMetaFallback.value,
-        ...(props.threads.meta ?? {}),
-    };
-});
-
-const threadsPageCount = computed(() => {
-    const meta = threadsMeta.value;
-    const derived = Math.ceil(meta.total / Math.max(meta.per_page, 1));
-    return Math.max(meta.last_page, derived || 1, 1);
-});
-
-const threadsRangeLabel = computed(() => {
-    const meta = threadsMeta.value;
-
-    if (meta.total === 0) {
-        return 'No threads to display';
-    }
-
-    const from = meta.from ?? ((meta.current_page - 1) * meta.per_page + 1);
-    const to = meta.to ?? Math.min(meta.current_page * meta.per_page, meta.total);
-
-    const threadWord = meta.total === 1 ? 'thread' : 'threads';
-
-    return `Showing ${from}-${to} of ${meta.total} ${threadWord}`;
-});
-
-const paginationPage = ref(threadsMeta.value.current_page);
 const activeActionThreadId = ref<number | null>(null);
 const threadReportDialogOpen = ref(false);
 const threadReportTarget = ref<ThreadSummary | null>(null);
@@ -204,10 +176,12 @@ const showActionColumn = computed(() =>
     ),
 );
 
-watch(() => threadsMeta.value.current_page, (page) => {
-    paginationPage.value = page;
-    threadReportForm.page = page;
-});
+watch(
+    () => threadsMeta.value.current_page,
+    (page) => {
+        threadReportForm.page = page;
+    },
+);
 
 let searchTimeout: ReturnType<typeof setTimeout> | undefined;
 
@@ -216,7 +190,7 @@ watch(searchQuery, (value) => {
         clearTimeout(searchTimeout);
     }
     searchTimeout = setTimeout(() => {
-        paginationPage.value = 1;
+        setThreadsPage(1, { emitNavigate: false });
         threadReportForm.page = 1;
         router.get(route('forum.boards.show', { board: props.board.slug }), {
             search: value || undefined,
@@ -229,24 +203,7 @@ watch(searchQuery, (value) => {
 });
 
 watch(paginationPage, (page) => {
-    const safePage = Math.min(Math.max(page, 1), threadsPageCount.value);
-
-    if (safePage !== page) {
-        paginationPage.value = safePage;
-        return;
-    }
-
-    if (safePage === threadsMeta.value.current_page) return;
-
-    threadReportForm.page = safePage;
-    router.get(route('forum.boards.show', { board: props.board.slug }), {
-        search: searchQuery.value || undefined,
-        page: safePage,
-    }, {
-        preserveScroll: true,
-        preserveState: true,
-        replace: true,
-    });
+    threadReportForm.page = page;
 });
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
## Summary
- add a `useInertiaPagination` composable that normalizes pagination metadata, builds range labels, and coordinates Inertia navigation
- refactor `ForumThreads.vue` to use the new composable for page state, range messaging, and search resets without duplicate requests
- refactor `ForumThreadView.vue` to adopt the composable and keep reporting forms in sync with the current page

## Testing
- npm run lint *(fails: existing unused import violations in Support.vue and several acp pages)*

------
https://chatgpt.com/codex/tasks/task_e_68da3e091c20832c90c79386838d5de6