### PR TITLE
Implement Inertia pagination across ACP listings

### DIFF
--- a/app/Http/Controllers/Admin/ACLController.php
+++ b/app/Http/Controllers/Admin/ACLController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Http\Controllers\Concerns\InteractsWithInertiaPagination;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\StorePermissionRequest;
 use App\Http\Requests\Admin\StoreRoleRequest;
@@ -9,30 +10,76 @@ use App\Http\Requests\Admin\UpdatePermissionRequest;
 use App\Http\Requests\Admin\UpdateRoleRequest;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
+use Inertia\Response;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Models\Permission;
 
 class ACLController extends Controller
 {
+    use InteractsWithInertiaPagination;
+
     /**
      * Show the ACP Roles & Permissions index page.
      */
-    public function index(Request $request)
+    public function index(Request $request): Response
     {
-        $perPage = $request->get('per_page', 15);
+        $perPage = (int) $request->get('per_page', 15);
 
-        $roles = Role::with('permissions')->orderBy('name')
-            ->paginate($perPage)
+        $roles = Role::query()
+            ->with(['permissions:id,name,guard_name'])
+            ->orderBy('name')
+            ->paginate($perPage, ['*'], 'roles_page')
             ->withQueryString();
 
-        $permissions = Permission::orderBy('name')
-            ->paginate($perPage)
+        $permissions = Permission::query()
+            ->orderBy('name')
+            ->paginate($perPage, ['*'], 'permissions_page')
             ->withQueryString();
+
+        $roleItems = $roles->getCollection()
+            ->map(function (Role $role) {
+                return [
+                    'id' => $role->id,
+                    'name' => $role->name,
+                    'guard_name' => $role->guard_name,
+                    'created_at' => optional($role->created_at)->toIso8601String(),
+                    'permissions' => $role->permissions
+                        ->map(fn (Permission $permission) => [
+                            'id' => $permission->id,
+                            'name' => $permission->name,
+                            'guard_name' => $permission->guard_name,
+                        ])
+                        ->values()
+                        ->all(),
+                ];
+            })
+            ->values()
+            ->all();
+
+        $permissionItems = $permissions->getCollection()
+            ->map(function (Permission $permission) {
+                return [
+                    'id' => $permission->id,
+                    'name' => $permission->name,
+                    'guard_name' => $permission->guard_name,
+                    'created_at' => optional($permission->created_at)->toIso8601String(),
+                ];
+            })
+            ->values()
+            ->all();
 
         $availablePermissions = Permission::orderBy('name')
             ->get(['id', 'name', 'guard_name']);
 
-        return inertia('acp/AccessControlLayer', compact('roles', 'permissions', 'availablePermissions'));
+        return inertia('acp/AccessControlLayer', [
+            'roles' => array_merge([
+                'data' => $roleItems,
+            ], $this->inertiaPagination($roles)),
+            'permissions' => array_merge([
+                'data' => $permissionItems,
+            ], $this->inertiaPagination($permissions)),
+            'availablePermissions' => $availablePermissions,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Admin/TokenController.php
+++ b/app/Http/Controllers/Admin/TokenController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Http\Controllers\Concerns\InteractsWithInertiaPagination;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\StoreTokenRequest;
 use App\Models\User;
@@ -9,50 +10,57 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Inertia\Inertia;
+use Inertia\Response;
 use Laravel\Sanctum\PersonalAccessToken;
 
 class TokenController extends Controller
 {
+    use InteractsWithInertiaPagination;
+
     /**
      * Show list of tokens + stats.
      */
-    public function index(Request $request)
+    public function index(Request $request): Response
     {
-        $perPage = $request->get('per_page', 10);
+        $perPage = (int) $request->get('per_page', 10);
 
         $tokenQuery = PersonalAccessToken::query();
 
         // eager‐load owner
         $tokens = (clone $tokenQuery)
             ->with('tokenable:id,nickname,email')
-            ->orderBy('created_at', 'desc')
+            ->orderByDesc('created_at')
             ->paginate($perPage)
-            ->withQueryString()
-            ->through(function (PersonalAccessToken $token) {
+            ->withQueryString();
+
+        $tokenItems = $tokens->getCollection()
+            ->map(function (PersonalAccessToken $token) {
                 $user = $token->tokenable;
 
                 return [
-                    'id'          => $token->id,
-                    'name'        => $token->name,
-                    'created_at'  => $token->created_at,
-                    'last_used_at'=> $token->last_used_at,
-                    'expires_at'  => $token->expires_at,
-                    'revoked_at'  => $token->revoked_at ?? null,
-                    'user'        => $user ? [
-                        'id'       => $user->id,
+                    'id' => $token->id,
+                    'name' => $token->name,
+                    'created_at' => optional($token->created_at)->toIso8601String(),
+                    'last_used_at' => optional($token->last_used_at)->toIso8601String(),
+                    'expires_at' => optional($token->expires_at)->toIso8601String(),
+                    'revoked_at' => optional($token->revoked_at)->toIso8601String(),
+                    'user' => $user ? [
+                        'id' => $user->id,
                         'nickname' => $user->nickname,
-                        'email'    => $user->email,
+                        'email' => $user->email,
                     ] : null,
                 ];
-            });
+            })
+            ->values()
+            ->all();
 
         $revokedCount = Schema::hasColumn('personal_access_tokens', 'revoked_at')
             ? (clone $tokenQuery)->whereNotNull('revoked_at')->count()
             : 0;
 
         $tokenStats = [
-            'total'   => $tokens->total(),
-            'active'  => (clone $tokenQuery)->where(function ($query) {
+            'total' => $tokens->total(),
+            'active' => (clone $tokenQuery)->where(function ($query) {
                 $query->whereNull('expires_at')
                     ->orWhere('expires_at', '>', now());
             })->count(),
@@ -63,7 +71,13 @@ class TokenController extends Controller
 
         $userList = User::select('id','nickname','email')->get();
 
-        return inertia('acp/Tokens', compact(['tokens', 'tokenStats', 'userList']));
+        return inertia('acp/Tokens', [
+            'tokens' => array_merge([
+                'data' => $tokenItems,
+            ], $this->inertiaPagination($tokens)),
+            'tokenStats' => $tokenStats,
+            'userList' => $userList,
+        ]);
     }
 
     /**


### PR DESCRIPTION
## Summary
- wire up InteractsWithInertiaPagination across ACP resource controllers so responses include pagination meta/links
- refactor ACP listings to consume paginated payloads via useInertiaPagination and display range-aware pagination controls
- add null-safe mappings for related data while preserving existing management actions

## Testing
- npm run lint *(fails: pre-existing unused import warnings in resources/js/pages/Support.vue and resources/js/pages/acp/Forums.vue)*

------
https://chatgpt.com/codex/tasks/task_e_68da746d962c832c811a1fdb2c07fdce