### PR TITLE
Paginate public support center listings

### DIFF
--- a/app/Http/Controllers/SupportCenterController.php
+++ b/app/Http/Controllers/SupportCenterController.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Http\Controllers\Concerns\InteractsWithInertiaPagination;
+use App\Http\Requests\StorePublicSupportTicketMessageRequest;
 use App\Http\Requests\StorePublicSupportTicketRequest;
 use App\Models\Faq;
 use App\Models\SupportTicket;
+use App\Models\SupportTicketMessage;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -45,6 +47,7 @@ class SupportCenterController extends Controller
                             'status' => $ticket->status,
                             'priority' => $ticket->priority,
                             'created_at' => optional($ticket->created_at)->toIso8601String(),
+                            'updated_at' => optional($ticket->updated_at)->toIso8601String(),
                             'assignee' => $ticket->assignee ? [
                                 'id' => $ticket->assignee->id,
                                 'nickname' => $ticket->assignee->nickname,
@@ -87,15 +90,109 @@ class SupportCenterController extends Controller
     {
         $validated = $request->validated();
 
-        SupportTicket::create([
+        $ticket = SupportTicket::create([
             'user_id' => $validated['user_id'],
             'subject' => $validated['subject'],
             'body' => $validated['body'],
             'priority' => $validated['priority'] ?? 'medium',
         ]);
 
+        $ticket->messages()->create([
+            'user_id' => $ticket->user_id,
+            'body' => $ticket->body,
+        ]);
+
         return redirect()
             ->route('support')
             ->with('success', 'Support ticket submitted successfully.');
+    }
+
+    public function show(Request $request, SupportTicket $ticket): Response
+    {
+        $user = $request->user();
+
+        abort_unless($user && $ticket->user_id === $user->id, 403);
+
+        $ticket->load([
+            'assignee:id,nickname,email',
+            'user:id,nickname,email',
+            'messages.author:id,nickname,email',
+        ]);
+
+        $messages = $ticket->messages
+            ->map(function (SupportTicketMessage $message) use ($ticket) {
+                return [
+                    'id' => $message->id,
+                    'body' => $message->body,
+                    'created_at' => optional($message->created_at)->toIso8601String(),
+                    'author' => $message->author ? [
+                        'id' => $message->author->id,
+                        'nickname' => $message->author->nickname,
+                        'email' => $message->author->email,
+                    ] : null,
+                    'is_from_support' => $message->author
+                        ? $message->author->id !== $ticket->user_id
+                        : false,
+                ];
+            })
+            ->values()
+            ->all();
+
+        if (count($messages) === 0) {
+            $messages[] = [
+                'id' => -$ticket->id,
+                'body' => $ticket->body,
+                'created_at' => optional($ticket->created_at)->toIso8601String(),
+                'author' => $ticket->user ? [
+                    'id' => $ticket->user->id,
+                    'nickname' => $ticket->user->nickname,
+                    'email' => $ticket->user->email,
+                ] : null,
+                'is_from_support' => false,
+            ];
+        }
+
+        return Inertia::render('SupportTicketView', [
+            'ticket' => [
+                'id' => $ticket->id,
+                'subject' => $ticket->subject,
+                'body' => $ticket->body,
+                'status' => $ticket->status,
+                'priority' => $ticket->priority,
+                'created_at' => optional($ticket->created_at)->toIso8601String(),
+                'updated_at' => optional($ticket->updated_at)->toIso8601String(),
+                'assignee' => $ticket->assignee ? [
+                    'id' => $ticket->assignee->id,
+                    'nickname' => $ticket->assignee->nickname,
+                    'email' => $ticket->assignee->email,
+                ] : null,
+                'user' => $ticket->user ? [
+                    'id' => $ticket->user->id,
+                    'nickname' => $ticket->user->nickname,
+                    'email' => $ticket->user->email,
+                ] : null,
+            ],
+            'messages' => $messages,
+            'canReply' => $ticket->status !== 'closed',
+        ]);
+    }
+
+    public function storeMessage(
+        StorePublicSupportTicketMessageRequest $request,
+        SupportTicket $ticket
+    ): RedirectResponse {
+        $validated = $request->validated();
+
+        $message = $ticket->messages()->create([
+            'user_id' => $request->user()->id,
+            'body' => $validated['body'],
+        ]);
+
+        $ticket->touch();
+        $message->touch();
+
+        return redirect()
+            ->route('support.tickets.show', $ticket)
+            ->with('success', 'Your message has been sent.');
     }
 }

--- a/app/Http/Controllers/SupportCenterController.php
+++ b/app/Http/Controllers/SupportCenterController.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\InteractsWithInertiaPagination;
+use App\Http\Requests\StorePublicSupportTicketRequest;
+use App\Models\Faq;
+use App\Models\SupportTicket;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class SupportCenterController extends Controller
+{
+    use InteractsWithInertiaPagination;
+
+    public function index(Request $request): Response
+    {
+        $user = $request->user();
+
+        $ticketsPerPage = max(1, (int) $request->query('tickets_per_page', 10));
+        $faqsPerPage = max(1, (int) $request->query('faqs_per_page', 10));
+
+        $ticketsPayload = [
+            'data' => [],
+            'meta' => null,
+            'links' => null,
+        ];
+
+        if ($user) {
+            $tickets = SupportTicket::query()
+                ->where('user_id', $user->id)
+                ->with(['assignee:id,nickname,email'])
+                ->orderByDesc('created_at')
+                ->paginate($ticketsPerPage, ['*'], 'tickets_page')
+                ->withQueryString();
+
+            $ticketsPayload = array_merge([
+                'data' => $tickets->getCollection()
+                    ->map(function (SupportTicket $ticket) {
+                        return [
+                            'id' => $ticket->id,
+                            'subject' => $ticket->subject,
+                            'status' => $ticket->status,
+                            'priority' => $ticket->priority,
+                            'created_at' => optional($ticket->created_at)->toIso8601String(),
+                            'assignee' => $ticket->assignee ? [
+                                'id' => $ticket->assignee->id,
+                                'nickname' => $ticket->assignee->nickname,
+                                'email' => $ticket->assignee->email,
+                            ] : null,
+                        ];
+                    })
+                    ->values()
+                    ->all(),
+            ], $this->inertiaPagination($tickets));
+        }
+
+        $faqs = Faq::query()
+            ->where('published', true)
+            ->orderBy('order')
+            ->paginate($faqsPerPage, ['*'], 'faqs_page')
+            ->withQueryString();
+
+        $faqItems = $faqs->getCollection()
+            ->map(function (Faq $faq) {
+                return [
+                    'id' => $faq->id,
+                    'question' => $faq->question,
+                    'answer' => $faq->answer,
+                ];
+            })
+            ->values()
+            ->all();
+
+        return Inertia::render('Support', [
+            'tickets' => $ticketsPayload,
+            'faqs' => array_merge([
+                'data' => $faqItems,
+            ], $this->inertiaPagination($faqs)),
+            'canSubmitTicket' => (bool) $user,
+        ]);
+    }
+
+    public function store(StorePublicSupportTicketRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        SupportTicket::create([
+            'user_id' => $validated['user_id'],
+            'subject' => $validated['subject'],
+            'body' => $validated['body'],
+            'priority' => $validated['priority'] ?? 'medium',
+        ]);
+
+        return redirect()
+            ->route('support')
+            ->with('success', 'Support ticket submitted successfully.');
+    }
+}

--- a/app/Http/Requests/StorePublicSupportTicketMessageRequest.php
+++ b/app/Http/Requests/StorePublicSupportTicketMessageRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\SupportTicket;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePublicSupportTicketMessageRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $ticket = $this->route('ticket');
+
+        return $ticket instanceof SupportTicket
+            && $this->user()
+            && $ticket->user_id === $this->user()->id;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'body' => ['required', 'string', 'min:3', 'max:5000'],
+        ];
+    }
+}

--- a/app/Http/Requests/StorePublicSupportTicketRequest.php
+++ b/app/Http/Requests/StorePublicSupportTicketRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePublicSupportTicketRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return (bool) $this->user();
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->user()) {
+            $this->merge([
+                'user_id' => $this->user()->id,
+            ]);
+        }
+    }
+
+    public function rules(): array
+    {
+        return [
+            'subject' => ['required', 'string', 'max:255'],
+            'body' => ['required', 'string'],
+            'priority' => ['nullable', 'in:low,medium,high'],
+            'user_id' => ['required', 'exists:users,id'],
+        ];
+    }
+}

--- a/app/Models/SupportTicket.php
+++ b/app/Models/SupportTicket.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class SupportTicket extends Model
 {
@@ -24,5 +25,10 @@ class SupportTicket extends Model
     public function assignee(): BelongsTo
     {
         return $this->belongsTo(User::class, 'assigned_to');
+    }
+
+    public function messages(): HasMany
+    {
+        return $this->hasMany(SupportTicketMessage::class)->orderBy('created_at');
     }
 }

--- a/app/Models/SupportTicketMessage.php
+++ b/app/Models/SupportTicketMessage.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SupportTicketMessage extends Model
+{
+    protected $fillable = [
+        'support_ticket_id',
+        'user_id',
+        'body',
+    ];
+
+    public function ticket(): BelongsTo
+    {
+        return $this->belongsTo(SupportTicket::class);
+    }
+
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/database/migrations/2025_05_01_000000_create_support_ticket_messages_table.php
+++ b/database/migrations/2025_05_01_000000_create_support_ticket_messages_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\\Database\\Migrations\\Migration;
-use Illuminate\\Database\\Schema\\Blueprint;
-use Illuminate\\Support\\Facades\\Schema;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration {
     public function up(): void

--- a/database/migrations/2025_05_01_000000_create_support_ticket_messages_table.php
+++ b/database/migrations/2025_05_01_000000_create_support_ticket_messages_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('support_ticket_messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('support_ticket_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->text('body');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('support_ticket_messages');
+    }
+};

--- a/database/seeders/AcpDashboardDemoSeeder.php
+++ b/database/seeders/AcpDashboardDemoSeeder.php
@@ -265,6 +265,29 @@ class AcpDashboardDemoSeeder extends Seeder
                 'created_at' => $createdAt,
                 'updated_at' => $updatedAt,
             ])->saveQuietly();
+
+            if ($ticketModel->messages()->count() === 0) {
+                $initialMessage = $ticketModel->messages()->create([
+                    'user_id' => $requestor->id,
+                    'body' => "Hi team, I wanted to follow up on an issue I noticed during the demo walkthrough. Could you take a look?",
+                ]);
+                $initialMessage->forceFill([
+                    'created_at' => $createdAt,
+                    'updated_at' => $createdAt,
+                ])->saveQuietly();
+
+                if ($assigneeId) {
+                    $reply = $ticketModel->messages()->create([
+                        'user_id' => $assigneeId,
+                        'body' => "Thanks for flagging this! I'm reviewing the details now and will circle back shortly.",
+                    ]);
+                    $replyTimestamp = $createdAt->copy()->addHours(6);
+                    $reply->forceFill([
+                        'created_at' => $replyTimestamp,
+                        'updated_at' => $replyTimestamp,
+                    ])->saveQuietly();
+                }
+            }
         }
 
         $recentTickets = [
@@ -300,6 +323,27 @@ class AcpDashboardDemoSeeder extends Seeder
                 'created_at' => $createdAt,
                 'updated_at' => $ticket['status'] === 'pending' ? $createdAt->copy()->addDay() : $now->copy()->subHours(6),
             ])->saveQuietly();
+
+            if ($ticketModel->messages()->count() === 0) {
+                $initialMessage = $ticketModel->messages()->create([
+                    'user_id' => $requestor->id,
+                    'body' => "Hello support, we noticed some behaviour that might need investigation. Let us know what you find!",
+                ]);
+                $initialMessage->forceFill([
+                    'created_at' => $createdAt,
+                    'updated_at' => $createdAt,
+                ])->saveQuietly();
+
+                $reply = $ticketModel->messages()->create([
+                    'user_id' => $admin->id,
+                    'body' => "Appreciate the heads up—we're running diagnostics and will keep you updated with next steps.",
+                ]);
+                $replyTimestamp = $createdAt->copy()->addHours(4);
+                $reply->forceFill([
+                    'created_at' => $replyTimestamp,
+                    'updated_at' => $replyTimestamp,
+                ])->saveQuietly();
+            }
         }
     }
 

--- a/resources/js/pages/Support.vue
+++ b/resources/js/pages/Support.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import AppLayout from '@/layouts/AppLayout.vue';
-import { Head } from '@inertiajs/vue3';
+import { Head, Link, router, useForm } from '@inertiajs/vue3';
 import { type BreadcrumbItem } from '@/types';
 
 // Import shadcn‑vue components
@@ -16,88 +16,240 @@ import {
     DropdownMenuGroup,
     DropdownMenuItem,
     DropdownMenuLabel,
-    DropdownMenuPortal,
     DropdownMenuSeparator,
-    DropdownMenuShortcut,
-    DropdownMenuSub,
-    DropdownMenuSubContent,
-    DropdownMenuSubTrigger,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Ellipsis, TicketX, LifeBuoy } from 'lucide-vue-next';
+import InputError from '@/components/InputError.vue';
 import {
-    Pin, PinOff, Ellipsis, Eye, EyeOff, Pencil, Trash2, Lock, LockOpen, TicketX, LifeBuoy
-} from 'lucide-vue-next';
+    Pagination,
+    PaginationEllipsis,
+    PaginationFirst,
+    PaginationLast,
+    PaginationList,
+    PaginationListItem,
+    PaginationNext,
+    PaginationPrev,
+} from '@/components/ui/pagination';
+import { useInertiaPagination, type PaginationMeta } from '@/composables/useInertiaPagination';
 
-const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Support', href: '/support' },
-];
+interface TicketAssignee {
+    id: number;
+    nickname: string;
+    email: string;
+}
 
-// ===================
-// MY TICKETS SECTION
-// ===================
 interface Ticket {
     id: number;
     subject: string;
-    status: 'Open' | 'Closed';
-    created_at: string;
+    status: 'open' | 'pending' | 'closed';
+    priority: 'low' | 'medium' | 'high';
+    created_at: string | null;
+    assignee: TicketAssignee | null;
 }
 
-const tickets = ref<Ticket[]>([
-    { id: 1, subject: 'Unable to login', status: 'Open', created_at: '2023-07-20' },
-    { id: 2, subject: 'Bug in payment module', status: 'Closed', created_at: '2023-07-22' },
-    { id: 3, subject: 'Feature request: dark mode', status: 'Open', created_at: '2023-07-25' },
-]);
-
-const ticketSearchQuery = ref('');
-const filteredTickets = computed(() => {
-    if (!ticketSearchQuery.value) return tickets.value;
-    const q = ticketSearchQuery.value.toLowerCase();
-    return tickets.value.filter(ticket =>
-        ticket.subject.toLowerCase().includes(q) ||
-        ticket.status.toLowerCase().includes(q)
-    );
-});
-
-// For new ticket submission
-const newTicketSubject = ref("");
-const newTicketDescription = ref("");
-function submitTicket() {
-    if (!newTicketSubject.value.trim() || !newTicketDescription.value.trim()) return;
-    const newTicket: Ticket = {
-        id: Date.now(),
-        subject: newTicketSubject.value,
-        status: 'Open',
-        created_at: new Date().toLocaleDateString(),
-    };
-    tickets.value.push(newTicket);
-    newTicketSubject.value = "";
-    newTicketDescription.value = "";
-    alert("Ticket submitted (dummy implementation)!");
-}
-
-// ===================
-// FAQ SECTION
-// ===================
 interface FAQ {
     id: number;
     question: string;
     answer: string;
 }
 
-const faqs = ref<FAQ[]>([
-    { id: 1, question: 'How do I reset my password?', answer: 'Click on "Forgot Password" on the login page and follow the instructions.' },
-    { id: 2, question: 'Where can I view my ticket history?', answer: 'You can view your ticket history in the "My Tickets" tab on this page.' },
-    { id: 3, question: 'How do I contact support?', answer: 'You can submit a new support ticket using the form in the "My Tickets" tab.' },
-]);
+interface PaginationLinks {
+    first: string | null;
+    last: string | null;
+    prev: string | null;
+    next: string | null;
+}
+
+interface PaginatedResource<T> {
+    data: T[];
+    meta?: PaginationMeta | null;
+    links?: PaginationLinks | null;
+}
+
+const props = defineProps<{
+    tickets: PaginatedResource<Ticket>;
+    faqs: PaginatedResource<FAQ>;
+    canSubmitTicket: boolean;
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Support', href: '/support' },
+];
+
+const ticketSearchQuery = ref('');
+const ticketsMetaSource = computed(() => props.tickets.meta ?? null);
+const ticketItems = computed(() => props.tickets.data ?? []);
+const filteredTickets = computed(() => {
+    if (!props.canSubmitTicket) {
+        return [];
+    }
+
+    if (!ticketSearchQuery.value) {
+        return ticketItems.value;
+    }
+
+    const q = ticketSearchQuery.value.toLowerCase();
+
+    return ticketItems.value.filter(ticket => {
+        return [
+            ticket.subject,
+            ticket.status,
+            ticket.priority,
+            ticket.assignee?.nickname ?? '',
+        ]
+            .join(' ')
+            .toLowerCase()
+            .includes(q);
+    });
+});
 
 const faqSearchQuery = ref('');
+const faqsMetaSource = computed(() => props.faqs.meta ?? null);
+const faqItems = computed(() => props.faqs.data ?? []);
 const filteredFaqs = computed(() => {
-    if (!faqSearchQuery.value) return faqs.value;
+    if (!faqSearchQuery.value) {
+        return faqItems.value;
+    }
+
     const q = faqSearchQuery.value.toLowerCase();
-    return faqs.value.filter(faq =>
-        faq.question.toLowerCase().includes(q) ||
-        faq.answer.toLowerCase().includes(q)
+
+    return faqItems.value.filter(faq =>
+        faq.question.toLowerCase().includes(q) || faq.answer.toLowerCase().includes(q),
     );
+});
+
+const {
+    meta: ticketsMeta,
+    page: ticketsPage,
+    setPage: setTicketsPage,
+    rangeLabel: ticketsRangeLabel,
+} = useInertiaPagination({
+    meta: ticketsMetaSource,
+    itemsLength: computed(() => ticketItems.value.length),
+    defaultPerPage: 10,
+    itemLabel: 'ticket',
+    itemLabelPlural: 'tickets',
+    emptyLabel: 'No tickets to display',
+    onNavigate: (page) => {
+        router.get(
+            route('support'),
+            {
+                tickets_page: page,
+                faqs_page:
+                    faqsMetaSource.value?.current_page && faqsMetaSource.value.current_page > 1
+                        ? faqsMetaSource.value.current_page
+                        : undefined,
+            },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                replace: true,
+            },
+        );
+    },
+});
+
+const {
+    meta: faqsMeta,
+    page: faqsPage,
+    setPage: setFaqsPage,
+    rangeLabel: faqsRangeLabel,
+} = useInertiaPagination({
+    meta: faqsMetaSource,
+    itemsLength: computed(() => faqItems.value.length),
+    defaultPerPage: 10,
+    itemLabel: 'FAQ',
+    itemLabelPlural: 'FAQs',
+    emptyLabel: "No FAQs to display",
+    onNavigate: (page) => {
+        router.get(
+            route('support'),
+            {
+                faqs_page: page,
+                tickets_page:
+                    ticketsMetaSource.value?.current_page && ticketsMetaSource.value.current_page > 1
+                        ? ticketsMetaSource.value.current_page
+                        : undefined,
+            },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                replace: true,
+            },
+        );
+    },
+});
+
+const showTicketPagination = computed(() => ticketsMeta.value.total > ticketsMeta.value.per_page);
+const showFaqPagination = computed(() => faqsMeta.value.total > faqsMeta.value.per_page);
+
+const form = useForm({
+    subject: '',
+    body: '',
+});
+
+const submitTicket = () => {
+    form.post(route('support.tickets.store'), {
+        preserveScroll: true,
+        onSuccess: () => {
+            form.reset();
+        },
+    });
+};
+
+const statusClass = (status: Ticket['status']) => {
+    const classes: Record<Ticket['status'], string> = {
+        pending: 'text-blue-500',
+        open: 'text-green-500',
+        closed: 'text-red-500',
+    };
+
+    return classes[status] ?? '';
+};
+
+const priorityClass = (priority: Ticket['priority']) => {
+    const classes: Record<Ticket['priority'], string> = {
+        low: 'text-blue-500',
+        medium: 'text-yellow-500',
+        high: 'text-red-500',
+    };
+
+    return classes[priority] ?? '';
+};
+
+const formatStatus = (status: Ticket['status']) =>
+    status.charAt(0).toUpperCase() + status.slice(1);
+
+const formatPriority = (priority: Ticket['priority']) =>
+    priority.charAt(0).toUpperCase() + priority.slice(1);
+
+const formatDate = (value: string | null) => {
+    if (!value) {
+        return '—';
+    }
+
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+        return '—';
+    }
+
+    return new Intl.DateTimeFormat(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+    }).format(date);
+};
+
+watch(ticketSearchQuery, () => {
+    setTicketsPage(1, { emitNavigate: false });
+});
+
+watch(faqSearchQuery, () => {
+    setFaqsPage(1, { emitNavigate: false });
 });
 </script>
 
@@ -125,104 +277,227 @@ const filteredFaqs = computed(() => {
                             v-model="ticketSearchQuery"
                             placeholder="Search your tickets..."
                             class="w-full md:w-1/3 md:ml-auto"
+                            :disabled="!props.canSubmitTicket"
                         />
-                        <a href="#create_ticket">
-                            <Button variant="secondary" class="md:ml-auto cursor-pointer">
-                                Create New Ticket
-                            </Button>
-                        </a>
+                        <Button
+                            v-if="props.canSubmitTicket"
+                            variant="secondary"
+                            class="md:ml-auto cursor-pointer"
+                            as-child
+                        >
+                            <a href="#create_ticket">Create New Ticket</a>
+                        </Button>
+                        <Button
+                            v-else
+                            variant="secondary"
+                            class="md:ml-auto cursor-pointer"
+                            as-child
+                        >
+                            <Link :href="route('login')">Sign in to submit</Link>
+                        </Button>
                     </div>
 
-                    <!-- Tickets Table -->
-                    <div class="overflow-x-auto rounded-xl border p-4 shadow-sm">
-                        <Table>
-                            <TableHeader class="bg-neutral-900">
-                                <TableRow>
-                                    <TableHead>ID</TableHead>
-                                    <TableHead>Subject</TableHead>
-                                    <TableHead class="text-center">Status</TableHead>
-                                    <TableHead class="text-center">Priority</TableHead>
-                                    <TableHead class="text-center">Assigned</TableHead>
-                                    <TableHead class="text-center">Created At</TableHead>
-                                    <TableHead class="text-center">Actions</TableHead>
-                                </TableRow>
-                            </TableHeader>
-                            <TableBody>
-                                <TableRow
-                                    v-for="ticket in filteredTickets"
-                                    :key="ticket.id"
-                                    class="hover:bg-gray-50 dark:hover:bg-gray-900"
-                                >
-                                    <TableCell>{{ ticket.id }}</TableCell>
-                                    <TableCell>{{ ticket.subject }}</TableCell>
-                                    <TableCell class="text-center">
-                                        <span :class="{
-                                            'text-blue-500': ticket.status === 'pending',
-                                            'text-green-500': ticket.status === 'open',
-                                            'text-red-500': ticket.status === 'closed'
-                                          }">
-                                            {{ ticket.status }}
-                                        </span>
-                                    </TableCell>
-                                    <TableCell class="text-center">
-                                        <span :class="{
-                                            'text-blue-500': ticket.priority === 'low',
-                                            'text-yellow-500': ticket.priority === 'medium',
-                                            'text-red-500': ticket.priority === 'high'
-                                          }">
-                                            {{ ticket.priority }}
-                                        </span>
-                                    </TableCell>
-                                    <TableCell class="text-center">{{ ticket.assignee?.nickname || '—' }}</TableCell>
-                                    <TableCell class="text-center">{{ ticket.created_at }}</TableCell>
-                                    <TableCell class="text-center">
-                                        <DropdownMenu>
-                                            <DropdownMenuTrigger as-child>
-                                                <Button variant="outline" size="icon">
-                                                    <Ellipsis class="h-8 w-8" />
+                    <template v-if="props.canSubmitTicket">
+                        <div class="flex flex-col items-center justify-between gap-4 md:flex-row">
+                            <div class="text-sm text-muted-foreground text-center md:text-left">
+                                {{ ticketsRangeLabel }}
+                            </div>
+                            <Pagination
+                                v-if="showTicketPagination"
+                                v-slot="{ page, pageCount }"
+                                v-model:page="ticketsPage"
+                                :items-per-page="Math.max(ticketsMeta.per_page, 1)"
+                                :total="ticketsMeta.total"
+                                :sibling-count="1"
+                                show-edges
+                            >
+                                <div class="flex flex-col items-center gap-2 md:flex-row md:items-center md:gap-3">
+                                    <span class="text-sm text-muted-foreground">
+                                        Page {{ page }} of {{ pageCount }}
+                                    </span>
+                                    <PaginationList v-slot="{ items }" class="flex items-center gap-1">
+                                        <PaginationFirst />
+                                        <PaginationPrev />
+
+                                        <template v-for="(item, index) in items" :key="index">
+                                            <PaginationListItem
+                                                v-if="item.type === 'page'"
+                                                :value="item.value"
+                                                as-child
+                                            >
+                                                <Button
+                                                    class="w-9 h-9 p-0"
+                                                    :variant="item.value === page ? 'default' : 'outline'"
+                                                >
+                                                    {{ item.value }}
                                                 </Button>
-                                            </DropdownMenuTrigger>
-                                            <DropdownMenuContent>
-                                                <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                                                <DropdownMenuSeparator />
-                                                <DropdownMenuGroup>
-                                                    <DropdownMenuItem class="text-red-500">
-                                                        <TicketX class="h-8 w-8" />
-                                                        <span>Close Ticket</span>
-                                                    </DropdownMenuItem>
-                                                </DropdownMenuGroup>
-                                            </DropdownMenuContent>
-                                        </DropdownMenu>
-                                    </TableCell>
-                                </TableRow>
-                                <TableRow v-if="filteredTickets.length === 0">
-                                    <TableCell colspan="5" class="text-center text-sm text-gray-600 dark:text-gray-300">
-                                        No tickets found.
-                                    </TableCell>
-                                </TableRow>
-                            </TableBody>
-                        </Table>
-                    </div>
+                                            </PaginationListItem>
+                                            <PaginationEllipsis v-else :key="`tickets-top-ellipsis-${index}`" :index="index" />
+                                        </template>
 
-                    <!-- New Ticket Submission Form -->
-                    <div class="rounded-xl border p-6 shadow">
-                        <h2 class="mb-4 text-xl font-bold" id="create_ticket">Create New Ticket</h2>
-                        <div class="flex flex-col gap-4">
-                            <Input
-                                v-model="newTicketSubject"
-                                placeholder="Ticket Subject"
-                                class="w-full rounded-md"
-                            />
-                            <Textarea
-                                v-model="newTicketDescription"
-                                placeholder="Describe your issue..."
-                                class="w-full rounded-md"
-                            />
-                            <Button variant="primary" @click="submitTicket" class="bg-green-500 hover:bg-green-600">
-                                Submit Ticket
-                            </Button>
+                                        <PaginationNext />
+                                        <PaginationLast />
+                                    </PaginationList>
+                                </div>
+                            </Pagination>
                         </div>
-                    </div>
+                        <!-- Tickets Table -->
+                        <div class="overflow-x-auto rounded-xl border p-4 shadow-sm">
+                            <Table>
+                                <TableHeader class="bg-neutral-900">
+                                    <TableRow>
+                                        <TableHead>ID</TableHead>
+                                        <TableHead>Subject</TableHead>
+                                        <TableHead class="text-center">Status</TableHead>
+                                        <TableHead class="text-center">Priority</TableHead>
+                                        <TableHead class="text-center">Assigned</TableHead>
+                                        <TableHead class="text-center">Created At</TableHead>
+                                        <TableHead class="text-center">Actions</TableHead>
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    <TableRow
+                                        v-for="ticket in filteredTickets"
+                                        :key="ticket.id"
+                                        class="hover:bg-gray-50 dark:hover:bg-gray-900"
+                                    >
+                                        <TableCell>{{ ticket.id }}</TableCell>
+                                        <TableCell>{{ ticket.subject }}</TableCell>
+                                        <TableCell class="text-center">
+                                            <span :class="statusClass(ticket.status)">
+                                                {{ formatStatus(ticket.status) }}
+                                            </span>
+                                        </TableCell>
+                                        <TableCell class="text-center">
+                                            <span :class="priorityClass(ticket.priority)">
+                                                {{ formatPriority(ticket.priority) }}
+                                            </span>
+                                        </TableCell>
+                                        <TableCell class="text-center">{{ ticket.assignee?.nickname || '—' }}</TableCell>
+                                        <TableCell class="text-center">{{ formatDate(ticket.created_at) }}</TableCell>
+                                        <TableCell class="text-center">
+                                            <DropdownMenu>
+                                                <DropdownMenuTrigger as-child>
+                                                    <Button variant="outline" size="icon">
+                                                        <Ellipsis class="h-8 w-8" />
+                                                    </Button>
+                                                </DropdownMenuTrigger>
+                                                <DropdownMenuContent>
+                                                    <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                                                    <DropdownMenuSeparator />
+                                                    <DropdownMenuGroup>
+                                                        <DropdownMenuItem class="text-red-500">
+                                                            <TicketX class="h-8 w-8" />
+                                                            <span>Close Ticket</span>
+                                                        </DropdownMenuItem>
+                                                    </DropdownMenuGroup>
+                                                </DropdownMenuContent>
+                                            </DropdownMenu>
+                                        </TableCell>
+                                    </TableRow>
+                                    <TableRow v-if="filteredTickets.length === 0">
+                                        <TableCell colspan="7" class="text-center text-sm text-gray-600 dark:text-gray-300">
+                                            No tickets found.
+                                        </TableCell>
+                                    </TableRow>
+                                </TableBody>
+                            </Table>
+                        </div>
+
+                        <div
+                            v-if="showTicketPagination"
+                            class="flex flex-col items-center justify-between gap-4 md:flex-row"
+                        >
+                            <div class="text-sm text-muted-foreground text-center md:text-left">
+                                {{ ticketsRangeLabel }}
+                            </div>
+                            <Pagination
+                                v-slot="{ page, pageCount }"
+                                v-model:page="ticketsPage"
+                                :items-per-page="Math.max(ticketsMeta.per_page, 1)"
+                                :total="ticketsMeta.total"
+                                :sibling-count="1"
+                                show-edges
+                            >
+                                <div class="flex flex-col items-center gap-2 md:flex-row md:items-center md:gap-3">
+                                    <span class="text-sm text-muted-foreground">
+                                        Page {{ page }} of {{ pageCount }}
+                                    </span>
+                                    <PaginationList v-slot="{ items }" class="flex items-center gap-1">
+                                        <PaginationFirst />
+                                        <PaginationPrev />
+
+                                        <template v-for="(item, index) in items" :key="index">
+                                            <PaginationListItem
+                                                v-if="item.type === 'page'"
+                                                :value="item.value"
+                                                as-child
+                                            >
+                                                <Button
+                                                    class="w-9 h-9 p-0"
+                                                    :variant="item.value === page ? 'default' : 'outline'"
+                                                >
+                                                    {{ item.value }}
+                                                </Button>
+                                            </PaginationListItem>
+                                            <PaginationEllipsis v-else :key="`tickets-bottom-ellipsis-${index}`" :index="index" />
+                                        </template>
+
+                                        <PaginationNext />
+                                        <PaginationLast />
+                                    </PaginationList>
+                                </div>
+                            </Pagination>
+                        </div>
+
+                        <!-- New Ticket Submission Form -->
+                        <div class="rounded-xl border p-6 shadow">
+                            <h2 class="mb-4 text-xl font-bold" id="create_ticket">Create New Ticket</h2>
+                            <form class="flex flex-col gap-4" @submit.prevent="submitTicket">
+                                <div class="space-y-2">
+                                    <Input
+                                        v-model="form.subject"
+                                        placeholder="Ticket subject"
+                                        class="w-full rounded-md"
+                                        autocomplete="off"
+                                        required
+                                    />
+                                    <InputError :message="form.errors.subject" />
+                                </div>
+                                <div class="space-y-2">
+                                    <Textarea
+                                        v-model="form.body"
+                                        placeholder="Describe your issue..."
+                                        class="w-full rounded-md"
+                                        required
+                                    />
+                                    <InputError :message="form.errors.body" />
+                                </div>
+                                <div class="flex justify-end">
+                                    <Button
+                                        type="submit"
+                                        class="bg-green-500 hover:bg-green-600"
+                                        :disabled="form.processing"
+                                    >
+                                        Submit Ticket
+                                    </Button>
+                                </div>
+                            </form>
+                        </div>
+                    </template>
+                    <template v-else>
+                        <div class="rounded-xl border p-6 shadow space-y-4 text-center">
+                            <p class="text-lg font-semibold">Need personalised help?</p>
+                            <p class="text-sm text-muted-foreground">
+                                Sign in to create support requests and review your ticket history.
+                            </p>
+                            <div class="flex justify-center">
+                                <Button as-child>
+                                    <Link :href="route('login')">Sign in</Link>
+                                </Button>
+                            </div>
+                        </div>
+                    </template>
                 </TabsContent>
 
                 <!-- FAQ Tab -->
@@ -255,13 +530,57 @@ const filteredFaqs = computed(() => {
                                     <TableCell>{{ faq.question }}</TableCell>
                                     <TableCell>{{ faq.answer }}</TableCell>
                                 </TableRow>
-                                <TableRow v-if="filteredFaqs.length === 0">
-                                    <TableCell colspan="4" class="text-center text-sm text-gray-600 dark:text-gray-300">
-                                        No FAQs found.
-                                    </TableCell>
-                                </TableRow>
+                                  <TableRow v-if="filteredFaqs.length === 0">
+                                      <TableCell colspan="2" class="text-center text-sm text-gray-600 dark:text-gray-300">
+                                          No FAQs found.
+                                      </TableCell>
+                                  </TableRow>
                             </TableBody>
                         </Table>
+                    </div>
+
+                    <div class="flex flex-col items-center justify-between gap-4 md:flex-row">
+                        <div class="text-sm text-muted-foreground text-center md:text-left">
+                            {{ faqsRangeLabel }}
+                        </div>
+                        <Pagination
+                            v-if="showFaqPagination"
+                            v-slot="{ page, pageCount }"
+                            v-model:page="faqsPage"
+                            :items-per-page="Math.max(faqsMeta.per_page, 1)"
+                            :total="faqsMeta.total"
+                            :sibling-count="1"
+                            show-edges
+                        >
+                            <div class="flex flex-col items-center gap-2 md:flex-row md:items-center md:gap-3">
+                                <span class="text-sm text-muted-foreground">
+                                    Page {{ page }} of {{ pageCount }}
+                                </span>
+                                <PaginationList v-slot="{ items }" class="flex items-center gap-1">
+                                    <PaginationFirst />
+                                    <PaginationPrev />
+
+                                    <template v-for="(item, index) in items" :key="index">
+                                        <PaginationListItem
+                                            v-if="item.type === 'page'"
+                                            :value="item.value"
+                                            as-child
+                                        >
+                                            <Button
+                                                class="w-9 h-9 p-0"
+                                                :variant="item.value === page ? 'default' : 'outline'"
+                                            >
+                                                {{ item.value }}
+                                            </Button>
+                                        </PaginationListItem>
+                                        <PaginationEllipsis v-else :key="`faqs-ellipsis-${index}`" :index="index" />
+                                    </template>
+
+                                    <PaginationNext />
+                                    <PaginationLast />
+                                </PaginationList>
+                            </div>
+                        </Pagination>
                     </div>
                 </TabsContent>
             </Tabs>

--- a/resources/js/pages/Support.vue
+++ b/resources/js/pages/Support.vue
@@ -19,7 +19,7 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Ellipsis, TicketX, LifeBuoy } from 'lucide-vue-next';
+import { Ellipsis, TicketX, LifeBuoy, Eye } from 'lucide-vue-next';
 import InputError from '@/components/InputError.vue';
 import {
     Pagination,
@@ -45,6 +45,7 @@ interface Ticket {
     status: 'open' | 'pending' | 'closed';
     priority: 'low' | 'medium' | 'high';
     created_at: string | null;
+    updated_at: string | null;
     assignee: TicketAssignee | null;
 }
 
@@ -196,6 +197,10 @@ const submitTicket = () => {
             form.reset();
         },
     });
+};
+
+const goToTicket = (ticketId: number) => {
+    router.get(route('support.tickets.show', { ticket: ticketId }));
 };
 
 const statusClass = (status: Ticket['status']) => {
@@ -359,10 +364,27 @@ watch(faqSearchQuery, () => {
                                     <TableRow
                                         v-for="ticket in filteredTickets"
                                         :key="ticket.id"
-                                        class="hover:bg-gray-50 dark:hover:bg-gray-900"
+                                        class="cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-900"
+                                        @click="goToTicket(ticket.id)"
                                     >
-                                        <TableCell>{{ ticket.id }}</TableCell>
-                                        <TableCell>{{ ticket.subject }}</TableCell>
+                                        <TableCell>
+                                            <Link
+                                                :href="route('support.tickets.show', { ticket: ticket.id })"
+                                                class="font-medium text-primary hover:underline"
+                                                @click.stop
+                                            >
+                                                #{{ ticket.id }}
+                                            </Link>
+                                        </TableCell>
+                                        <TableCell>
+                                            <Link
+                                                :href="route('support.tickets.show', { ticket: ticket.id })"
+                                                class="font-medium text-primary hover:underline"
+                                                @click.stop
+                                            >
+                                                {{ ticket.subject }}
+                                            </Link>
+                                        </TableCell>
                                         <TableCell class="text-center">
                                             <span :class="statusClass(ticket.status)">
                                                 {{ formatStatus(ticket.status) }}
@@ -377,7 +399,7 @@ watch(faqSearchQuery, () => {
                                         <TableCell class="text-center">{{ formatDate(ticket.created_at) }}</TableCell>
                                         <TableCell class="text-center">
                                             <DropdownMenu>
-                                                <DropdownMenuTrigger as-child>
+                                                <DropdownMenuTrigger as-child @click.stop>
                                                     <Button variant="outline" size="icon">
                                                         <Ellipsis class="h-8 w-8" />
                                                     </Button>
@@ -386,6 +408,10 @@ watch(faqSearchQuery, () => {
                                                     <DropdownMenuLabel>Actions</DropdownMenuLabel>
                                                     <DropdownMenuSeparator />
                                                     <DropdownMenuGroup>
+                                                        <DropdownMenuItem @select="goToTicket(ticket.id)">
+                                                            <Eye class="h-8 w-8" />
+                                                            <span>View Ticket</span>
+                                                        </DropdownMenuItem>
                                                         <DropdownMenuItem class="text-red-500">
                                                             <TicketX class="h-8 w-8" />
                                                             <span>Close Ticket</span>

--- a/resources/js/pages/SupportTicketView.vue
+++ b/resources/js/pages/SupportTicketView.vue
@@ -1,0 +1,268 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Head, Link, useForm } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import Button from '@/components/ui/button/Button.vue';
+import { Textarea } from '@/components/ui/textarea';
+import InputError from '@/components/InputError.vue';
+import { useUserTimezone } from '@/composables/useUserTimezone';
+
+interface TicketAssignee {
+    id: number;
+    nickname: string;
+    email: string;
+}
+
+interface TicketUser {
+    id: number;
+    nickname: string;
+    email: string;
+}
+
+interface TicketMessage {
+    id: number;
+    body: string;
+    created_at: string | null;
+    author: TicketAssignee | null;
+    is_from_support: boolean;
+}
+
+const props = defineProps<{
+    ticket: {
+        id: number;
+        subject: string;
+        body: string;
+        status: 'open' | 'pending' | 'closed';
+        priority: 'low' | 'medium' | 'high';
+        created_at: string | null;
+        updated_at: string | null;
+        assignee: TicketAssignee | null;
+        user: TicketUser | null;
+    };
+    messages: TicketMessage[];
+    canReply: boolean;
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Support Center', href: route('support') },
+    { title: `Ticket #${props.ticket.id}`, href: route('support.tickets.show', { ticket: props.ticket.id }) },
+];
+
+const statusLabel = computed(() => props.ticket.status.replace(/^[a-z]/, (s) => s.toUpperCase()));
+const priorityLabel = computed(() => props.ticket.priority.replace(/^[a-z]/, (s) => s.toUpperCase()));
+
+const statusClasses = computed(() => {
+    switch (props.ticket.status) {
+        case 'open':
+            return 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300';
+        case 'pending':
+            return 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300';
+        case 'closed':
+            return 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300';
+        default:
+            return 'bg-gray-100 text-gray-700 dark:bg-gray-900/40 dark:text-gray-300';
+    }
+});
+
+const priorityClasses = computed(() => {
+    switch (props.ticket.priority) {
+        case 'high':
+            return 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300';
+        case 'medium':
+            return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300';
+        case 'low':
+            return 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300';
+        default:
+            return 'bg-gray-100 text-gray-700 dark:bg-gray-900/40 dark:text-gray-300';
+    }
+});
+
+const { formatDate, fromNow } = useUserTimezone();
+
+const formattedCreatedAt = computed(() => formatDate(props.ticket.created_at));
+const formattedUpdatedAt = computed(() => formatDate(props.ticket.updated_at));
+
+const replyForm = useForm({
+    body: '',
+});
+
+const submitReply = () => {
+    if (!props.canReply) {
+        return;
+    }
+
+    replyForm.post(route('support.tickets.messages.store', { ticket: props.ticket.id }), {
+        preserveScroll: true,
+        onSuccess: () => {
+            replyForm.reset('body');
+        },
+    });
+};
+
+const sortedMessages = computed(() => {
+    const messages = props.messages ?? [];
+
+    return [...messages].sort((a, b) => {
+        const aTime = a.created_at ? new Date(a.created_at).getTime() : 0;
+        const bTime = b.created_at ? new Date(b.created_at).getTime() : 0;
+
+        return aTime - bTime;
+    });
+});
+
+const resolveAuthorLabel = (message: TicketMessage) => {
+    if (!message.author) {
+        return message.is_from_support ? 'Support Team' : 'You';
+    }
+
+    if (!message.is_from_support) {
+        return 'You';
+    }
+
+    return message.author.nickname ?? message.author.email ?? 'Support Team';
+};
+
+const messageTimestamp = (value: string | null) => {
+    if (!value) {
+        return '';
+    }
+
+    return `${formatDate(value)} · ${fromNow(value)}`;
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head :title="`Ticket #${props.ticket.id}`" />
+
+        <div class="container mx-auto flex flex-1 flex-col gap-6 p-4">
+            <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                    <p class="text-sm text-muted-foreground">Ticket #{{ props.ticket.id }}</p>
+                    <h1 class="text-3xl font-semibold tracking-tight">{{ props.ticket.subject }}</h1>
+                    <p class="mt-2 max-w-2xl text-sm text-muted-foreground">
+                        View the full conversation with our support team and keep the discussion moving forward.
+                    </p>
+                </div>
+                <div class="flex flex-wrap items-center gap-3">
+                    <span class="rounded-full px-3 py-1 text-xs font-medium" :class="statusClasses">
+                        Status: {{ statusLabel }}
+                    </span>
+                    <span class="rounded-full px-3 py-1 text-xs font-medium" :class="priorityClasses">
+                        Priority: {{ priorityLabel }}
+                    </span>
+                    <Button variant="outline" as-child>
+                        <Link :href="route('support')">Back to Support</Link>
+                    </Button>
+                </div>
+            </div>
+
+            <div class="grid gap-6 lg:grid-cols-[minmax(0,_2fr)_minmax(0,_1fr)]">
+                <Card class="flex flex-col">
+                    <CardHeader>
+                        <CardTitle>Conversation</CardTitle>
+                        <CardDescription>Messages between you and our support team.</CardDescription>
+                    </CardHeader>
+                    <CardContent class="flex flex-1 flex-col gap-6">
+                        <div class="flex flex-col gap-4">
+                            <div
+                                v-for="message in sortedMessages"
+                                :key="message.id"
+                                class="flex flex-col gap-1"
+                                :class="message.is_from_support ? 'items-start' : 'items-end'">
+                                <div
+                                    class="max-w-xl rounded-lg px-4 py-3 text-sm leading-relaxed shadow-sm"
+                                    :class="message.is_from_support
+                                        ? 'bg-background border'
+                                        : 'bg-primary text-primary-foreground'
+                                    "
+                                >
+                                    <p class="mb-2 whitespace-pre-line">{{ message.body }}</p>
+                                    <p class="text-xs font-medium opacity-75">
+                                        {{ resolveAuthorLabel(message) }} · {{ messageTimestamp(message.created_at) }}
+                                    </p>
+                                </div>
+                            </div>
+
+                            <p v-if="sortedMessages.length === 0" class="text-sm text-muted-foreground">
+                                There are no messages on this ticket yet.
+                            </p>
+                        </div>
+
+                        <form v-if="props.canReply" class="mt-4 flex flex-col gap-3" @submit.prevent="submitReply">
+                            <label for="message" class="text-sm font-medium">Reply to support</label>
+                            <Textarea
+                                id="message"
+                                v-model="replyForm.body"
+                                placeholder="Share an update or ask a follow-up question..."
+                                class="min-h-32"
+                                :disabled="replyForm.processing"
+                                required
+                            />
+                            <InputError :message="replyForm.errors.body" />
+                            <div class="flex justify-end">
+                                <Button type="submit" :disabled="replyForm.processing">
+                                    Send message
+                                </Button>
+                            </div>
+                        </form>
+                    </CardContent>
+                </Card>
+
+                <div class="flex flex-col gap-6">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Ticket details</CardTitle>
+                            <CardDescription>Key context for this request.</CardDescription>
+                        </CardHeader>
+                        <CardContent class="space-y-4 text-sm">
+                            <div>
+                                <p class="text-xs uppercase text-muted-foreground">Opened by</p>
+                                <p class="font-medium text-foreground">
+                                    {{ props.ticket.user?.nickname ?? 'You' }}
+                                </p>
+                                <p class="text-muted-foreground">
+                                    {{ props.ticket.user?.email ?? '—' }}
+                                </p>
+                            </div>
+                            <div>
+                                <p class="text-xs uppercase text-muted-foreground">Assigned agent</p>
+                                <p class="font-medium text-foreground">
+                                    {{ props.ticket.assignee?.nickname ?? 'Unassigned' }}
+                                </p>
+                                <p class="text-muted-foreground">
+                                    {{ props.ticket.assignee?.email ?? '—' }}
+                                </p>
+                            </div>
+                            <div>
+                                <p class="text-xs uppercase text-muted-foreground">Created</p>
+                                <p class="font-medium text-foreground">{{ formattedCreatedAt }}</p>
+                                <p class="text-muted-foreground">{{ fromNow(props.ticket.created_at) }}</p>
+                            </div>
+                            <div>
+                                <p class="text-xs uppercase text-muted-foreground">Last updated</p>
+                                <p class="font-medium text-foreground">{{ formattedUpdatedAt }}</p>
+                                <p class="text-muted-foreground">{{ fromNow(props.ticket.updated_at) }}</p>
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Original description</CardTitle>
+                            <CardDescription>The initial details you provided.</CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            <p class="whitespace-pre-line text-sm leading-relaxed text-foreground">
+                                {{ props.ticket.body }}
+                            </p>
+                        </CardContent>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    </AppLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -62,9 +62,17 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
 });
 
 Route::get('support', [SupportCenterController::class, 'index'])->name('support');
-Route::post('support/tickets', [SupportCenterController::class, 'store'])
-    ->middleware('auth')
-    ->name('support.tickets.store');
+
+Route::middleware('auth')->group(function () {
+    Route::post('support/tickets', [SupportCenterController::class, 'store'])
+        ->name('support.tickets.store');
+
+    Route::get('support/tickets/{ticket}', [SupportCenterController::class, 'show'])
+        ->name('support.tickets.show');
+
+    Route::post('support/tickets/{ticket}/messages', [SupportCenterController::class, 'storeMessage'])
+        ->name('support.tickets.messages.store');
+});
 
 //AUTH REQUIRED PAGES
 Route::get('dashboard', function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\ForumController;
 use App\Http\Controllers\ForumPostController;
 use App\Http\Controllers\ForumThreadActionController;
 use App\Http\Controllers\ForumThreadModerationController;
+use App\Http\Controllers\SupportCenterController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -60,9 +61,10 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
         ->name('forum.threads.destroy');
 });
 
-Route::get('support', function () {
-    return Inertia::render('Support');
-})->name('support');
+Route::get('support', [SupportCenterController::class, 'index'])->name('support');
+Route::post('support/tickets', [SupportCenterController::class, 'store'])
+    ->middleware('auth')
+    ->name('support.tickets.store');
 
 //AUTH REQUIRED PAGES
 Route::get('dashboard', function () {


### PR DESCRIPTION
## Summary
- paginate support tickets and FAQs in the public support controller using the InteractsWithInertiaPagination concern
- adapt the Support.vue page to consume paginated props and drive navigation with the useInertiaPagination composable
- add pagination UI and range labelling for support tickets and FAQs while preserving existing ticket submission behaviour

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db23b367e8832c941da5f2cd605774