### PR TITLE
Add data-driven metrics to user dashboard

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Blog;
+use App\Models\ForumPost;
+use App\Models\ForumThread;
+use App\Models\SupportTicket;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class DashboardController extends Controller
+{
+    /**
+     * Display the authenticated user dashboard with live insights.
+     */
+    public function __invoke(Request $request): Response
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        return Inertia::render('Dashboard', [
+            'metrics' => $this->buildMetrics($user),
+            'activityChart' => $this->buildActivityChart($user),
+            'recentItems' => $this->recentActivity($user),
+            'recommendedArticles' => $this->recommendedArticles(),
+        ]);
+    }
+
+    /**
+     * Compile summary metrics for the dashboard cards.
+     */
+    protected function buildMetrics(User $user): array
+    {
+        $supportQuery = SupportTicket::query()->where('user_id', $user->id);
+
+        $ticketStatusCounts = (clone $supportQuery)
+            ->select('status', DB::raw('COUNT(*) as aggregate'))
+            ->groupBy('status')
+            ->pluck('aggregate', 'status');
+
+        $support = [
+            'total' => (clone $supportQuery)->count(),
+            'open' => (int) ($ticketStatusCounts['open'] ?? 0),
+            'pending' => (int) ($ticketStatusCounts['pending'] ?? 0),
+            'resolved' => (int) ($ticketStatusCounts['closed'] ?? 0),
+            'new_this_month' => (clone $supportQuery)
+                ->where('created_at', '>=', now()->startOfMonth())
+                ->count(),
+        ];
+
+        $forumThreadQuery = ForumThread::query()->where('user_id', $user->id);
+        $forumPostQuery = ForumPost::query()->where('user_id', $user->id);
+
+        $forum = [
+            'threads' => (clone $forumThreadQuery)->count(),
+            'active_this_month' => (clone $forumThreadQuery)
+                ->where('updated_at', '>=', now()->startOfMonth())
+                ->count(),
+            'replies' => (clone $forumPostQuery)->count(),
+            'replies_this_week' => (clone $forumPostQuery)
+                ->where('created_at', '>=', now()->startOfWeek())
+                ->count(),
+            'unread_threads' => ForumThread::query()
+                ->where('is_published', true)
+                ->whereDoesntHave('reads', function ($query) use ($user) {
+                    $query->where('user_id', $user->id);
+                })
+                ->count(),
+        ];
+
+        $knowledgeBaseQuery = Blog::query()
+            ->where('user_id', $user->id);
+
+        $knowledge = [
+            'published_articles' => (clone $knowledgeBaseQuery)
+                ->where('status', 'published')
+                ->count(),
+            'drafts' => (clone $knowledgeBaseQuery)
+                ->where('status', 'draft')
+                ->count(),
+        ];
+
+        return [
+            'support' => $support,
+            'forum' => $forum,
+            'knowledge' => $knowledge,
+        ];
+    }
+
+    /**
+     * Build a six-month trend of activity for the chart widget.
+     */
+    protected function buildActivityChart(User $user): array
+    {
+        $start = now()->startOfMonth()->subMonths(5);
+
+        $forumPostsByMonth = ForumPost::select([
+                DB::raw("DATE_FORMAT(created_at, '%Y-%m') as month"),
+                DB::raw('COUNT(*) as total'),
+            ])
+            ->where('user_id', $user->id)
+            ->where('created_at', '>=', $start)
+            ->groupBy('month')
+            ->orderBy('month')
+            ->pluck('total', 'month');
+
+        $supportTicketsByMonth = SupportTicket::select([
+                DB::raw("DATE_FORMAT(created_at, '%Y-%m') as month"),
+                DB::raw('COUNT(*) as total'),
+            ])
+            ->where('user_id', $user->id)
+            ->where('created_at', '>=', $start)
+            ->groupBy('month')
+            ->orderBy('month')
+            ->pluck('total', 'month');
+
+        return collect(range(0, 5))
+            ->map(fn (int $offset) => $start->copy()->addMonths($offset))
+            ->map(function (Carbon $month) use ($forumPostsByMonth, $supportTicketsByMonth) {
+                $key = $month->format('Y-m');
+
+                return [
+                    'period' => $month->format('M Y'),
+                    'Forum Replies' => (int) ($forumPostsByMonth[$key] ?? 0),
+                    'Support Tickets' => (int) ($supportTicketsByMonth[$key] ?? 0),
+                ];
+            })
+            ->toArray();
+    }
+
+    /**
+     * Collect the latest items the user interacted with.
+     */
+    protected function recentActivity(User $user): array
+    {
+        $threads = $user->forumThreads()
+            ->with(['board:id,slug'])
+            ->latest('updated_at')
+            ->take(5)
+            ->get()
+            ->map(function (ForumThread $thread) {
+                $timestamp = $thread->updated_at ?? $thread->created_at;
+
+                return [
+                    'id' => "thread-{$thread->id}",
+                    'summary' => sprintf('Updated thread "%s"', $thread->title),
+                    'context' => 'Forum thread',
+                    'time' => optional($timestamp)->diffForHumans(),
+                    'url' => $thread->board
+                        ? route('forum.threads.show', [$thread->board->slug, $thread->slug])
+                        : null,
+                    'timestamp' => $timestamp,
+                ];
+            });
+
+        $posts = $user->forumPosts()
+            ->with(['thread:id,slug,forum_board_id', 'thread.board:id,slug'])
+            ->latest('created_at')
+            ->take(5)
+            ->get()
+            ->map(function (ForumPost $post) {
+                $thread = $post->thread;
+                $board = $thread?->board;
+                $timestamp = $post->created_at;
+
+                return [
+                    'id' => "post-{$post->id}",
+                    'summary' => $thread
+                        ? sprintf('Replied to "%s"', $thread->title)
+                        : 'Posted a forum reply',
+                    'context' => 'Forum reply',
+                    'time' => optional($timestamp)->diffForHumans(),
+                    'url' => $thread && $board
+                        ? route('forum.threads.show', [$board->slug, $thread->slug]) . "#post-{$post->id}"
+                        : null,
+                    'timestamp' => $timestamp,
+                ];
+            });
+
+        $tickets = SupportTicket::query()
+            ->where('user_id', $user->id)
+            ->latest('updated_at')
+            ->take(5)
+            ->get()
+            ->map(function (SupportTicket $ticket) {
+                $timestamp = $ticket->updated_at ?? $ticket->created_at;
+                $status = $ticket->status ?? 'updated';
+
+                return [
+                    'id' => "ticket-{$ticket->id}",
+                    'summary' => sprintf('Ticket "%s" %s', $ticket->subject, $status),
+                    'context' => 'Support',
+                    'time' => optional($timestamp)->diffForHumans(),
+                    'url' => route('support'),
+                    'timestamp' => $timestamp,
+                ];
+            });
+
+        return collect([$threads, $posts, $tickets])
+            ->flatten(1)
+            ->filter(fn ($activity) => $activity['timestamp'])
+            ->sortByDesc('timestamp')
+            ->take(8)
+            ->map(fn ($activity) => Arr::except($activity, 'timestamp'))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Highlight recently published knowledge base articles.
+     */
+    protected function recommendedArticles(): array
+    {
+        return Blog::query()
+            ->where('status', 'published')
+            ->orderByDesc('published_at')
+            ->orderByDesc('created_at')
+            ->take(5)
+            ->get()
+            ->map(function (Blog $blog) {
+                $timestamp = $blog->published_at ?? $blog->created_at;
+
+                return [
+                    'id' => $blog->id,
+                    'title' => $blog->title,
+                    'excerpt' => $blog->excerpt,
+                    'url' => route('blogs.view', $blog->slug),
+                    'published_at' => optional($timestamp)->toIso8601String(),
+                ];
+            })
+            ->all();
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -100,25 +100,21 @@ class DashboardController extends Controller
     {
         $start = now()->startOfMonth()->subMonths(5);
 
-        $forumPostsByMonth = ForumPost::select([
-                DB::raw("DATE_FORMAT(created_at, '%Y-%m') as month"),
-                DB::raw('COUNT(*) as total'),
-            ])
+        $forumPostsByMonth = ForumPost::query()
             ->where('user_id', $user->id)
             ->where('created_at', '>=', $start)
-            ->groupBy('month')
-            ->orderBy('month')
-            ->pluck('total', 'month');
+            ->get(['created_at'])
+            ->filter(fn (ForumPost $post) => $post->created_at)
+            ->groupBy(fn (ForumPost $post) => $post->created_at->format('Y-m'))
+            ->map->count();
 
-        $supportTicketsByMonth = SupportTicket::select([
-                DB::raw("DATE_FORMAT(created_at, '%Y-%m') as month"),
-                DB::raw('COUNT(*) as total'),
-            ])
+        $supportTicketsByMonth = SupportTicket::query()
             ->where('user_id', $user->id)
             ->where('created_at', '>=', $start)
-            ->groupBy('month')
-            ->orderBy('month')
-            ->pluck('total', 'month');
+            ->get(['created_at'])
+            ->filter(fn (SupportTicket $ticket) => $ticket->created_at)
+            ->groupBy(fn (SupportTicket $ticket) => $ticket->created_at->format('Y-m'))
+            ->map->count();
 
         return collect(range(0, 5))
             ->map(fn (int $offset) => $start->copy()->addMonths($offset))

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,10 +1,85 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { type BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/vue3';
-import PlaceholderPattern from '../components/PlaceholderPattern.vue';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
-import { AlertCircle } from 'lucide-vue-next'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { LineChart } from '@/components/ui/chart-line';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import { Activity, CheckCircle2, FileText, LifeBuoy, MessageSquare } from 'lucide-vue-next';
+
+type SupportMetrics = {
+    total: number;
+    open: number;
+    pending: number;
+    resolved: number;
+    new_this_month: number;
+};
+
+type ForumMetrics = {
+    threads: number;
+    active_this_month: number;
+    replies: number;
+    replies_this_week: number;
+    unread_threads: number;
+};
+
+type KnowledgeMetrics = {
+    published_articles: number;
+    drafts: number;
+};
+
+interface DashboardMetrics {
+    support: SupportMetrics;
+    forum: ForumMetrics;
+    knowledge: KnowledgeMetrics;
+}
+
+type ActivityChartDatum = {
+    period: string;
+    'Forum Replies': number;
+    'Support Tickets': number;
+};
+
+type ActivityItem = {
+    id: string | number;
+    summary: string;
+    context: string;
+    time: string | null;
+    url?: string | null;
+};
+
+type RecommendedArticle = {
+    id: number | string;
+    title: string;
+    excerpt: string | null;
+    url: string;
+    published_at: string | null;
+};
+
+interface DashboardProps {
+    metrics: DashboardMetrics;
+    activityChart: ActivityChartDatum[];
+    recentItems: ActivityItem[];
+    recommendedArticles: RecommendedArticle[];
+}
+
+const props = withDefaults(defineProps<DashboardProps>(), {
+    metrics: () => ({
+        support: { total: 0, open: 0, pending: 0, resolved: 0, new_this_month: 0 },
+        forum: { threads: 0, active_this_month: 0, replies: 0, replies_this_week: 0, unread_threads: 0 },
+        knowledge: { published_articles: 0, drafts: 0 },
+    }),
+    activityChart: () => [],
+    recentItems: () => [],
+    recommendedArticles: () => [],
+});
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -12,33 +87,185 @@ const breadcrumbs: BreadcrumbItem[] = [
         href: '/dashboard',
     },
 ];
+
+const numberFormatter = new Intl.NumberFormat();
+const dateFormatter = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' });
+
+const formatNumber = (value: number | null | undefined) => numberFormatter.format(value ?? 0);
+const formatDate = (value: string | null | undefined) => (value ? dateFormatter.format(new Date(value)) : '—');
+const pluralize = (count: number, singular: string, plural: string) => (count === 1 ? singular : plural);
+
+const statCards = computed(() => [
+    {
+        title: 'Open support tickets',
+        value: props.metrics.support.open,
+        helper: `of ${formatNumber(props.metrics.support.total)} total`,
+        icon: LifeBuoy,
+    },
+    {
+        title: 'Forum threads started',
+        value: props.metrics.forum.threads,
+        helper: `${formatNumber(props.metrics.forum.active_this_month)} active this month`,
+        icon: MessageSquare,
+    },
+    {
+        title: 'Forum replies posted',
+        value: props.metrics.forum.replies,
+        helper: `${formatNumber(props.metrics.forum.replies_this_week)} this week`,
+        icon: Activity,
+    },
+    {
+        title: 'Published articles',
+        value: props.metrics.knowledge.published_articles,
+        helper: `${formatNumber(props.metrics.knowledge.drafts)} drafts in progress`,
+        icon: FileText,
+    },
+]);
+
+const chartSeries = ['Forum Replies', 'Support Tickets'] as const;
+
+const chartData = computed(() => props.activityChart ?? []);
+const hasChartData = computed(() =>
+    chartData.value.some(
+        (item) => (item['Forum Replies'] ?? 0) > 0 || (item['Support Tickets'] ?? 0) > 0,
+    ),
+);
+
+const recentActivity = computed(() => props.recentItems ?? []);
+const articles = computed(() => props.recommendedArticles ?? []);
+
+const alertState = computed(() => {
+    const openTickets = props.metrics.support.open ?? 0;
+    if (openTickets > 0) {
+        return {
+            variant: 'warning' as const,
+            icon: LifeBuoy,
+            title: 'Support tickets awaiting attention',
+            description: `You have ${formatNumber(openTickets)} ${pluralize(openTickets, 'open ticket', 'open tickets')} with our support team.`,
+        };
+    }
+
+    const unreadThreads = props.metrics.forum.unread_threads ?? 0;
+    if (unreadThreads > 0) {
+        return {
+            variant: 'default' as const,
+            icon: MessageSquare,
+            title: 'New discussions to catch up on',
+            description: `There ${unreadThreads === 1 ? 'is' : 'are'} ${formatNumber(unreadThreads)} unread ${pluralize(unreadThreads, 'discussion', 'discussions')} in the forum.`,
+        };
+    }
+
+    return {
+        variant: 'default' as const,
+        icon: CheckCircle2,
+        title: 'You are all caught up',
+        description: 'Nothing needs your attention right now. We will update this space as new activity arrives.',
+    };
+});
 </script>
 
 <template>
     <AppLayout :breadcrumbs="breadcrumbs">
         <Head title="Dashboard" />
 
-        <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
-            <Alert variant="destructive">
-                <AlertCircle class="w-4 h-4" />
-                <AlertTitle>Error</AlertTitle>
-                <AlertDescription>
-                    Your session has expired. Please log in again.
-                </AlertDescription>
+        <div class="flex h-full flex-1 flex-col gap-4 rounded-xl pb-4">
+            <Alert :variant="alertState.variant">
+                <component :is="alertState.icon" class="h-5 w-5" />
+                <AlertTitle>{{ alertState.title }}</AlertTitle>
+                <AlertDescription>{{ alertState.description }}</AlertDescription>
             </Alert>
-            <div class="grid auto-rows-min gap-4 md:grid-cols-3">
-                <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                    <PlaceholderPattern />
-                </div>
-                <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                    <PlaceholderPattern />
-                </div>
-                <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                    <PlaceholderPattern />
-                </div>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+                <Card
+                    v-for="(stat, index) in statCards"
+                    :key="index"
+                    class="overflow-hidden"
+                >
+                    <CardHeader class="flex flex-row items-start justify-between space-y-0 pb-2">
+                        <CardTitle class="text-sm font-medium">{{ stat.title }}</CardTitle>
+                        <component :is="stat.icon" class="h-5 w-5 text-muted-foreground" />
+                    </CardHeader>
+                    <CardContent>
+                        <div class="text-2xl font-semibold">{{ formatNumber(stat.value) }}</div>
+                        <p class="text-xs text-muted-foreground">{{ stat.helper }}</p>
+                    </CardContent>
+                </Card>
             </div>
-            <div class="relative h-full flex-1 rounded-xl border border-sidebar-border/70 dark:border-sidebar-border md:min-h-min">
-                <PlaceholderPattern />
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Community engagement</CardTitle>
+                    <CardDescription>Monthly view of your forum replies and support requests.</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <LineChart
+                        v-if="hasChartData"
+                        :data="chartData"
+                        index="period"
+                        :categories="chartSeries"
+                        :y-formatter="(tick) => (typeof tick === 'number' ? formatNumber(tick) : '')"
+                    />
+                    <p v-else class="text-sm text-muted-foreground">
+                        Not enough activity yet to visualise a trend.
+                    </p>
+                </CardContent>
+            </Card>
+
+            <div class="grid gap-4 lg:grid-cols-[2fr,1fr]">
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Recent activity</CardTitle>
+                        <CardDescription>The latest updates from your tickets and forum participation.</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <ul v-if="recentActivity.length" class="space-y-3">
+                            <li
+                                v-for="item in recentActivity"
+                                :key="item.id"
+                                class="rounded-lg border border-sidebar-border/60 p-3 text-sm dark:border-sidebar-border"
+                            >
+                                <div class="flex items-start justify-between gap-4">
+                                    <div>
+                                        <p class="font-medium">{{ item.summary }}</p>
+                                        <p class="text-xs text-muted-foreground">{{ item.context }}</p>
+                                    </div>
+                                    <span class="shrink-0 text-xs text-muted-foreground">{{ item.time ?? '—' }}</span>
+                                </div>
+                                <div v-if="item.url" class="mt-2">
+                                    <a :href="item.url" class="text-xs font-medium text-primary hover:underline">View</a>
+                                </div>
+                            </li>
+                        </ul>
+                        <p v-else class="text-sm text-muted-foreground">
+                            We will list your recent interactions here once you start engaging.
+                        </p>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Recommended reading</CardTitle>
+                        <CardDescription>Brush up on the latest knowledge base articles.</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <ul v-if="articles.length" class="space-y-4 text-sm">
+                            <li v-for="article in articles" :key="article.id">
+                                <a :href="article.url" class="font-medium text-primary hover:underline">
+                                    {{ article.title }}
+                                </a>
+                                <p v-if="article.excerpt" class="mt-1 text-xs text-muted-foreground">
+                                    {{ article.excerpt }}
+                                </p>
+                                <p class="mt-1 text-xs text-muted-foreground">
+                                    {{ formatDate(article.published_at) }}
+                                </p>
+                            </li>
+                        </ul>
+                        <p v-else class="text-sm text-muted-foreground">
+                            Freshly published articles will appear here as soon as they are available.
+                        </p>
+                    </CardContent>
+                </Card>
             </div>
         </div>
     </AppLayout>

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -168,7 +168,14 @@ const alertState = computed(() => {
     <AppLayout :breadcrumbs="breadcrumbs">
         <Head title="Dashboard" />
 
-        <div class="flex h-full flex-1 flex-col gap-4 rounded-xl pb-4">
+        <div class="flex h-full flex-1 flex-col gap-4 rounded-xl pt-4 pb-4">
+<!--            <Alert variant="destructive">-->
+<!--                <AlertCircle class="w-4 h-4" />-->
+<!--                <AlertTitle>Error</AlertTitle>-->
+<!--                <AlertDescription>-->
+<!--                    Your session has expired. Please log in again.-->
+<!--                </AlertDescription>-->
+<!--            </Alert>-->
             <Alert :variant="alertState.variant">
                 <component :is="alertState.icon" class="h-5 w-5" />
                 <AlertTitle>{{ alertState.title }}</AlertTitle>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\BlogController;
+use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\ForumController;
 use App\Http\Controllers\ForumPostController;
 use App\Http\Controllers\ForumThreadActionController;
@@ -65,9 +66,9 @@ Route::get('support', function () {
 })->name('support');
 
 //AUTH REQUIRED PAGES
-Route::get('dashboard', function () {
-    return Inertia::render('Dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+Route::get('dashboard', DashboardController::class)
+    ->middleware(['auth', 'verified'])
+    ->name('dashboard');
 
 require __DIR__.'/admin.php';
 require __DIR__.'/settings.php';


### PR DESCRIPTION
## Summary
- replace the dashboard placeholder view with metric cards, activity charts, and content feeds backed by real props
- add a dedicated DashboardController that assembles user-centric metrics, trend data, recent activity, and recommended articles
- update the dashboard route to resolve via the new controller for authenticated users

## Testing
- npm run lint *(fails: existing unused import errors in Support.vue and acp/Forums.vue)*

------
https://chatgpt.com/codex/tasks/task_e_68db245d54a4832cb232be0a3cde6972