### PR TITLE
Add persistent ACP system settings storage and diagnostics

### DIFF
--- a/app/Http/Controllers/Admin/SystemSettingsController.php
+++ b/app/Http/Controllers/Admin/SystemSettingsController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\SystemSetting;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class SystemSettingsController extends Controller
+{
+    /**
+     * Display the system settings management screen.
+     */
+    public function index(): Response
+    {
+        return Inertia::render('acp/System', [
+            'settings' => [
+                'maintenance_mode' => (bool) SystemSetting::get('maintenance_mode', false),
+                'email_verification_required' => (bool) SystemSetting::get(
+                    'email_verification_required',
+                    (bool) config('auth.must_verify_email', false)
+                ),
+            ],
+            'diagnostics' => $this->diagnosticsPayload(),
+        ]);
+    }
+
+    /**
+     * Persist the incoming system setting updates.
+     */
+    public function update(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'maintenance_mode' => ['required', 'boolean'],
+            'email_verification_required' => ['required', 'boolean'],
+        ]);
+
+        foreach ($validated as $key => $value) {
+            SystemSetting::set($key, (bool) $value);
+        }
+
+        return back()->with('success', 'System settings were updated successfully.');
+    }
+
+    /**
+     * Build a diagnostics payload with real server information.
+     */
+    protected function diagnosticsPayload(): array
+    {
+        return [
+            'php_version' => PHP_VERSION,
+            'laravel_version' => app()->version(),
+            'server_environment' => config('app.env'),
+            'server_time' => now()->toDateTimeString(),
+            'server_timezone' => config('app.timezone'),
+            'app_url' => config('app.url'),
+            'queue_connection' => config('queue.default'),
+            'cache_driver' => config('cache.default'),
+            'session_driver' => config('session.driver'),
+            'memory_usage' => $this->formatBytes(memory_get_usage(true)),
+            'memory_peak' => $this->formatBytes(memory_get_peak_usage(true)),
+        ];
+    }
+
+    /**
+     * Present a human readable representation of a memory size.
+     */
+    protected function formatBytes(int $bytes): string
+    {
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $precision = 2;
+
+        $bytes = max($bytes, 0);
+        $pow = $bytes > 0 ? floor(log($bytes, 1024)) : 0;
+        $pow = min($pow, count($units) - 1);
+
+        $bytes /= (1 << (10 * $pow));
+
+        return round($bytes, $precision) . ' ' . $units[$pow];
+    }
+}

--- a/app/Models/SystemSetting.php
+++ b/app/Models/SystemSetting.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SystemSetting extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     */
+    protected $fillable = [
+        'key',
+        'value',
+    ];
+
+    /**
+     * Cast the raw JSON value to native PHP types when accessing.
+     */
+    protected function getValueAttribute($value): mixed
+    {
+        return json_decode($value, true);
+    }
+
+    /**
+     * Ensure the value is stored as JSON.
+     */
+    protected function setValueAttribute($value): void
+    {
+        $this->attributes['value'] = json_encode($value);
+    }
+
+    /**
+     * Retrieve a setting value with a fallback default.
+     */
+    public static function get(string $key, mixed $default = null): mixed
+    {
+        return static::query()->where('key', $key)->first()?->value ?? $default;
+    }
+
+    /**
+     * Persist a setting value.
+     */
+    public static function set(string $key, mixed $value): void
+    {
+        static::query()->updateOrCreate(
+            ['key' => $key],
+            ['value' => $value]
+        );
+    }
+}

--- a/database/migrations/2024_07_26_000000_create_system_settings_table.php
+++ b/database/migrations/2024_07_26_000000_create_system_settings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('system_settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->longText('value');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('system_settings');
+    }
+};

--- a/resources/js/pages/acp/System.vue
+++ b/resources/js/pages/acp/System.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed } from 'vue';
 import AppLayout from '@/layouts/AppLayout.vue';
 import AdminLayout from '@/layouts/acp/AdminLayout.vue';
 import { type BreadcrumbItem } from '@/types';
-import { Head } from '@inertiajs/vue3';
+import { Head, useForm } from '@inertiajs/vue3';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
-import { Toaster, toast } from 'vue-sonner'
+import { Toaster, toast } from 'vue-sonner';
 
 
 const breadcrumbs: BreadcrumbItem[] = [
@@ -16,36 +16,44 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
-// Reactive state for system settings
-const maintenanceMode = ref(false);
-const emailVerificationRequired = ref(true);
-// const enabledSections = ref({
-//     blog: true,
-//     forum: true,
-//     support: true,
-// });
+const props = defineProps<{
+    settings: {
+        maintenance_mode: boolean;
+        email_verification_required: boolean;
+    };
+    diagnostics: {
+        php_version: string;
+        laravel_version: string;
+        server_environment: string;
+        server_time: string;
+        server_timezone: string;
+        app_url: string | null;
+        queue_connection: string | null;
+        cache_driver: string | null;
+        session_driver: string | null;
+        memory_usage: string;
+        memory_peak: string;
+    };
+}>();
 
-// Dummy system info (replace with dynamic data as needed)
-const phpVersion = '8.4';
-const laravelVersion = '12.x';
-const serverEnvironment = 'Development';
+const form = useForm({
+    maintenance_mode: props.settings.maintenance_mode,
+    email_verification_required: props.settings.email_verification_required,
+});
 
-// Additional server info
-const serverTime = ref('2023-07-27 15:34:00'); // Example server time
-const serverTimezone = ref('UTC');
-const memoryUsage = ref('512 MB used / 2048 MB total');
-const averagePageLoadSpeed = ref('0.69 s');
+const diagnostics = computed(() => props.diagnostics);
 
-// Function to "save" settings (stubbed)
-function saveSettings() {
-    toast.success('System Settings Saved Successfully', {
-        description: 'Tuesday, March 25, 2025 at 4:34 PM',
-        action: {
-            label: 'Close',
-            onClick: () => console.log('Closed'),
+const saveSettings = () => {
+    form.put(route('acp.system.update'), {
+        preserveScroll: true,
+        onSuccess: () => {
+            toast.success('System settings saved successfully');
         },
-    })
-}
+        onError: () => {
+            toast.error('Unable to save settings. Please review the form and try again.');
+        },
+    });
+};
 </script>
 
 <template>
@@ -62,9 +70,9 @@ function saveSettings() {
                             Toggle maintenance mode to temporarily disable access for users.
                         </p>
                         <div class="flex items-center">
-                            <Switch v-model="maintenanceMode" />
+                            <Switch v-model="form.maintenance_mode" />
                             <span class="ml-2 text-sm">
-                                {{ maintenanceMode ? 'Enabled' : 'Disabled' }}
+                                {{ form.maintenance_mode ? 'Enabled' : 'Disabled' }}
                             </span>
                         </div>
                     </div>
@@ -76,9 +84,9 @@ function saveSettings() {
                             Require users to verify their email address upon registration.
                         </p>
                         <div class="flex items-center">
-                            <Switch v-model="emailVerificationRequired" />
+                            <Switch v-model="form.email_verification_required" />
                             <span class="ml-2 text-sm">
-                                {{ emailVerificationRequired ? 'Required' : 'Not Required' }}
+                                {{ form.email_verification_required ? 'Required' : 'Not Required' }}
                             </span>
                         </div>
                     </div>
@@ -114,31 +122,47 @@ function saveSettings() {
                     <ul class="space-y-2 text-sm">
                         <li>
                             <span class="font-medium text-gray-500">PHP Version: </span>
-                            <span class="font-medium text-gray-600">{{ phpVersion }}</span>
+                            <span class="font-medium text-gray-600">{{ diagnostics.php_version }}</span>
                         </li>
                         <li>
                             <span class="font-medium text-gray-500">Laravel Version: </span>
-                            <span class="font-medium text-gray-600">{{ laravelVersion }}</span>
+                            <span class="font-medium text-gray-600">{{ diagnostics.laravel_version }}</span>
                         </li>
                         <li>
                             <span class="font-medium text-gray-500">Server Environment: </span>
-                            <span class="font-medium text-gray-600">{{ serverEnvironment }}</span>
+                            <span class="font-medium text-gray-600">{{ diagnostics.server_environment }}</span>
                         </li>
                         <li>
                             <span class="font-medium text-gray-500">Server Time: </span>
-                            <span class="font-medium text-gray-600">{{ serverTime }}</span>
+                            <span class="font-medium text-gray-600">{{ diagnostics.server_time }}</span>
                         </li>
                         <li>
                             <span class="font-medium text-gray-500">Server Timezone: </span>
-                            <span class="font-medium text-gray-600">{{ serverTimezone }}</span>
+                            <span class="font-medium text-gray-600">{{ diagnostics.server_timezone }}</span>
+                        </li>
+                        <li>
+                            <span class="font-medium text-gray-500">Application URL: </span>
+                            <span class="font-medium text-gray-600">{{ diagnostics.app_url ?? 'Not configured' }}</span>
+                        </li>
+                        <li>
+                            <span class="font-medium text-gray-500">Queue Connection: </span>
+                            <span class="font-medium text-gray-600">{{ diagnostics.queue_connection }}</span>
+                        </li>
+                        <li>
+                            <span class="font-medium text-gray-500">Cache Driver: </span>
+                            <span class="font-medium text-gray-600">{{ diagnostics.cache_driver }}</span>
+                        </li>
+                        <li>
+                            <span class="font-medium text-gray-500">Session Driver: </span>
+                            <span class="font-medium text-gray-600">{{ diagnostics.session_driver }}</span>
                         </li>
                         <li>
                             <span class="font-medium text-gray-500">Memory Usage: </span>
-                            <span class="font-medium text-gray-600">{{ memoryUsage }}</span>
+                            <span class="font-medium text-gray-600">{{ diagnostics.memory_usage }}</span>
                         </li>
                         <li>
-                            <span class="font-medium text-gray-500">Average Page Load Speed: </span>
-                            <span class="font-medium text-gray-600">{{ averagePageLoadSpeed }}</span>
+                            <span class="font-medium text-gray-500">Peak Memory Usage: </span>
+                            <span class="font-medium text-gray-600">{{ diagnostics.memory_peak }}</span>
                         </li>
                     </ul>
                 </div>
@@ -146,7 +170,11 @@ function saveSettings() {
                 <!-- Save Settings Button -->
                 <div class="flex justify-end">
                     <Toaster theme="dark" richColors />
-                    <Button @click="saveSettings" class="rounded bg-blue-500 px-6 py-2 text-white hover:bg-blue-600">
+                    <Button
+                        @click="saveSettings"
+                        :disabled="form.processing"
+                        class="rounded bg-blue-500 px-6 py-2 text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-70"
+                    >
                         Save Changes
                     </Button>
                 </div>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Admin\AdminController;
 use App\Http\Controllers\Admin\BlogController as AdminBlogController;
 use App\Http\Controllers\Admin\ACLController as AdminACLController;
 use App\Http\Controllers\Admin\SupportController;
+use App\Http\Controllers\Admin\SystemSettingsController;
 use App\Http\Controllers\Admin\TokenController;
 use App\Http\Controllers\Admin\UsersController as AdminUserController;
 use Illuminate\Support\Facades\Route;
@@ -63,9 +64,8 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
     Route::put('acp/support/faqs/{faq}', [SupportController::class,'updateFaq'])->name('acp.support.faqs.update');
     Route::delete('acp/support/faqs/{faq}', [SupportController::class,'destroyFaq'])->name('acp.support.faqs.destroy');
 
-    Route::get('acp/system', function () {
-        return Inertia::render('acp/System');
-    })->name('acp.system');
+    Route::get('acp/system', [SystemSettingsController::class, 'index'])->name('acp.system');
+    Route::put('acp/system', [SystemSettingsController::class, 'update'])->name('acp.system.update');
 
     // Tokens
     Route::get('acp/tokens', [TokenController::class,'index'])->name('acp.tokens.index');


### PR DESCRIPTION
## Summary
- add a system settings controller backed by a database table to expose ACP data and persistence
- wire ACP routes to the controller and add a SystemSetting model with helpers
- hydrate the Vue admin settings page from Inertia props and submit updates to the backend while rendering live diagnostics

## Testing
- `php artisan test` *(fails: vendor dependencies are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db3ba6f2cc832c941058cf79b7e65b