### PR TITLE
Add persistent token activity logging

### DIFF
--- a/app/Http/Middleware/LogTokenActivity.php
+++ b/app/Http/Middleware/LogTokenActivity.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\TokenLog;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class LogTokenActivity
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $startedAt = microtime(true);
+
+        try {
+            $response = $next($request);
+        } catch (Throwable $exception) {
+            $this->logRequest($request, $startedAt, null, $exception);
+
+            throw $exception;
+        }
+
+        $this->logRequest($request, $startedAt, $response);
+
+        return $response;
+    }
+
+    /**
+     * Persist the API request details when a personal access token was used.
+     */
+    protected function logRequest(Request $request, float $startedAt, ?Response $response = null, ?Throwable $exception = null): void
+    {
+        $user = $request->user();
+        $token = method_exists($user, 'currentAccessToken') ? $user?->currentAccessToken() : null;
+
+        if (! $token) {
+            return;
+        }
+
+        $responseStatus = $response?->getStatusCode();
+        $status = 'success';
+
+        if ($exception) {
+            $status = 'failed';
+            $responseStatus = $this->resolveExceptionStatus($exception) ?? $responseStatus ?? 500;
+        } elseif ($responseStatus && $responseStatus >= 400) {
+            $status = 'failed';
+        }
+
+        $requestPayload = $this->sanitizePayload($request->all());
+
+        TokenLog::create([
+            'personal_access_token_id' => $token->id,
+            'token_name' => $token->name,
+            'route' => '/' . ltrim($request->path(), '/'),
+            'method' => $request->method(),
+            'status' => $status,
+            'http_status' => $responseStatus,
+            'ip_address' => $request->ip(),
+            'user_agent' => $request->userAgent(),
+            'request_payload' => $requestPayload ?: null,
+            'response_summary' => $this->extractResponseSummary($response),
+            'response_time_ms' => (int) round((microtime(true) - $startedAt) * 1000),
+            'error_message' => $exception?->getMessage(),
+        ]);
+    }
+
+    protected function sanitizePayload(array $payload): array
+    {
+        $hiddenKeys = ['password', 'password_confirmation', 'token'];
+
+        return collect($payload)
+            ->except($hiddenKeys)
+            ->map(function ($value) {
+                if (is_array($value)) {
+                    return $this->sanitizePayload($value);
+                }
+
+                if (is_object($value)) {
+                    return (string) $value;
+                }
+
+                if (is_string($value)) {
+                    return Str::limit($value, 500);
+                }
+
+                return $value;
+            })
+            ->all();
+    }
+
+    protected function extractResponseSummary(?Response $response): ?array
+    {
+        if (! $response) {
+            return null;
+        }
+
+        $contentType = $response->headers->get('Content-Type');
+
+        if ($contentType && str_contains($contentType, 'application/json')) {
+            $content = $response->getContent();
+
+            $decoded = json_decode($content, true);
+
+            if (json_last_error() === JSON_ERROR_NONE) {
+                return $decoded;
+            }
+        }
+
+        return null;
+    }
+
+    protected function resolveExceptionStatus(Throwable $exception): ?int
+    {
+        if (method_exists($exception, 'getStatusCode')) {
+            return $exception->getStatusCode();
+        }
+
+        $code = $exception->getCode();
+
+        return is_int($code) && $code >= 100 && $code < 600
+            ? $code
+            : null;
+    }
+}

--- a/app/Models/TokenLog.php
+++ b/app/Models/TokenLog.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class TokenLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'personal_access_token_id',
+        'token_name',
+        'route',
+        'method',
+        'status',
+        'http_status',
+        'ip_address',
+        'user_agent',
+        'request_payload',
+        'response_summary',
+        'response_time_ms',
+        'error_message',
+    ];
+
+    protected $casts = [
+        'request_payload' => 'array',
+        'response_summary' => 'array',
+    ];
+
+    public function token(): BelongsTo
+    {
+        return $this->belongsTo(PersonalAccessToken::class, 'personal_access_token_id');
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\LogTokenActivity;
 use App\Http\Middleware\UpdateLastActivity;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -36,6 +37,7 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->alias([
             'verified' => EnsureEmailIsVerified::class,
+            'token.activity' => LogTokenActivity::class,
         ]);
 
         $middleware->alias([

--- a/database/migrations/2025_05_01_120000_create_token_logs_table.php
+++ b/database/migrations/2025_05_01_120000_create_token_logs_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('token_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('personal_access_token_id')
+                ->constrained('personal_access_tokens')
+                ->cascadeOnDelete();
+            $table->string('token_name')->nullable();
+            $table->string('route');
+            $table->string('method', 16);
+            $table->string('status', 32);
+            $table->unsignedSmallInteger('http_status')->nullable();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->json('request_payload')->nullable();
+            $table->json('response_summary')->nullable();
+            $table->unsignedInteger('response_time_ms')->nullable();
+            $table->text('error_message')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('token_logs');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,5 +19,9 @@ class DatabaseSeeder extends Seeder
             'nickname' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        $this->call([
+            TokenLogDemoSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/TokenLogDemoSeeder.php
+++ b/database/seeders/TokenLogDemoSeeder.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\TokenLog;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class TokenLogDemoSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::transaction(function () {
+            $now = Carbon::now();
+            $password = Hash::make('password');
+
+            $admin = User::updateOrCreate(
+                ['email' => 'token-log-admin@example.com'],
+                [
+                    'nickname' => 'Token Log Admin',
+                    'password' => $password,
+                    'email_verified_at' => $now->copy()->subDays(14),
+                    'last_activity_at' => $now->copy()->subDay(),
+                ]
+            );
+
+            $admin->forceFill([
+                'created_at' => $now->copy()->subMonths(2),
+                'updated_at' => $now,
+            ])->saveQuietly();
+
+            $serviceUser = User::updateOrCreate(
+                ['email' => 'token-log-service@example.com'],
+                [
+                    'nickname' => 'Token Log Service',
+                    'password' => $password,
+                    'email_verified_at' => $now->copy()->subDays(30),
+                    'last_activity_at' => $now->copy()->subHours(6),
+                ]
+            );
+
+            $serviceUser->forceFill([
+                'created_at' => $now->copy()->subMonths(6),
+                'updated_at' => $now->copy()->subHours(2),
+            ])->saveQuietly();
+
+            $tokenDefinitions = [
+                [
+                    'key' => 'admin-web',
+                    'user' => $admin,
+                    'name' => 'Admin Dashboard Token',
+                    'abilities' => ['tokens:read', 'tokens:manage'],
+                    'created_at' => $now->copy()->subDays(40),
+                    'last_used_at' => $now->copy()->subMinutes(50),
+                ],
+                [
+                    'key' => 'service-webhook',
+                    'user' => $serviceUser,
+                    'name' => 'Automation Webhook Token',
+                    'abilities' => ['webhooks:send', 'tokens:read'],
+                    'created_at' => $now->copy()->subDays(9),
+                    'last_used_at' => $now->copy()->subMinutes(5),
+                ],
+            ];
+
+            $tokens = collect($tokenDefinitions)->mapWithKeys(function (array $definition) {
+                $tokenValue = hash('sha256', 'demo-token-'.$definition['key']);
+
+                $token = PersonalAccessToken::updateOrCreate(
+                    ['token' => $tokenValue],
+                    [
+                        'tokenable_type' => User::class,
+                        'tokenable_id' => $definition['user']->id,
+                        'name' => $definition['name'],
+                        'abilities' => json_encode($definition['abilities']),
+                        'last_used_at' => $definition['last_used_at'],
+                    ]
+                );
+
+                $token->forceFill([
+                    'created_at' => $definition['created_at'],
+                    'updated_at' => $definition['last_used_at'] ?? $definition['created_at'],
+                ])->saveQuietly();
+
+                return [$definition['key'] => $token];
+            });
+
+            $logDefinitions = [
+                [
+                    'id' => 900001,
+                    'token_key' => 'admin-web',
+                    'route' => 'api/admin/tokens',
+                    'method' => 'GET',
+                    'status' => 'success',
+                    'http_status' => 200,
+                    'ip_address' => '203.0.113.7',
+                    'user_agent' => 'Laravel HTTP Client/10.x',
+                    'request_payload' => [],
+                    'response_summary' => ['count' => 23],
+                    'response_time_ms' => 118,
+                    'created_at' => $now->copy()->subMinutes(45),
+                ],
+                [
+                    'id' => 900002,
+                    'token_key' => 'admin-web',
+                    'route' => 'api/admin/tokens/42/revoke',
+                    'method' => 'DELETE',
+                    'status' => 'success',
+                    'http_status' => 204,
+                    'ip_address' => '203.0.113.7',
+                    'user_agent' => 'Laravel HTTP Client/10.x',
+                    'request_payload' => ['token_id' => 42],
+                    'response_summary' => ['message' => 'Revoked'],
+                    'response_time_ms' => 86,
+                    'created_at' => $now->copy()->subMinutes(32),
+                ],
+                [
+                    'id' => 900003,
+                    'token_key' => 'service-webhook',
+                    'route' => 'api/webhooks/token-rotations',
+                    'method' => 'POST',
+                    'status' => 'success',
+                    'http_status' => 201,
+                    'ip_address' => '198.51.100.24',
+                    'user_agent' => 'Acme Webhook Client/2.4',
+                    'request_payload' => ['rotation_id' => Str::uuid()->toString()],
+                    'response_summary' => ['accepted' => true],
+                    'response_time_ms' => 153,
+                    'created_at' => $now->copy()->subMinutes(14),
+                ],
+                [
+                    'id' => 900004,
+                    'token_key' => 'service-webhook',
+                    'route' => 'api/webhooks/token-rotations',
+                    'method' => 'POST',
+                    'status' => 'error',
+                    'http_status' => 422,
+                    'ip_address' => '198.51.100.24',
+                    'user_agent' => 'Acme Webhook Client/2.4',
+                    'request_payload' => ['rotation_id' => Str::uuid()->toString()],
+                    'response_summary' => ['accepted' => false],
+                    'response_time_ms' => 210,
+                    'error_message' => 'Token rotation payload failed validation.',
+                    'created_at' => $now->copy()->subMinutes(4),
+                ],
+            ];
+
+            foreach ($logDefinitions as $definition) {
+                $token = $tokens->get($definition['token_key']);
+
+                if (! $token) {
+                    continue;
+                }
+
+                $log = TokenLog::find($definition['id']) ?? new TokenLog();
+
+                $log->forceFill([
+                    'id' => $definition['id'],
+                    'personal_access_token_id' => $token->id,
+                    'token_name' => $token->name,
+                    'route' => $definition['route'],
+                    'method' => $definition['method'],
+                    'status' => $definition['status'],
+                    'http_status' => $definition['http_status'],
+                    'ip_address' => $definition['ip_address'],
+                    'user_agent' => $definition['user_agent'],
+                    'request_payload' => $definition['request_payload'],
+                    'response_summary' => $definition['response_summary'],
+                    'response_time_ms' => $definition['response_time_ms'],
+                    'error_message' => $definition['error_message'] ?? null,
+                    'created_at' => $definition['created_at'],
+                    'updated_at' => $definition['created_at'],
+                ])->save();
+            }
+        });
+
+        $this->command?->info('Token log demo data seeded. Check the ACP token activity views to verify.');
+    }
+}

--- a/resources/js/pages/acp/Forums.vue
+++ b/resources/js/pages/acp/Forums.vue
@@ -6,7 +6,7 @@ import { type BreadcrumbItem } from '@/types';
 import { Head, Link } from '@inertiajs/vue3';
 import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
 import {
-    Folder, MessageSquare, CheckCircle, Ellipsis, Eye, EyeOff, Shield,
+    Folder, MessageSquare, CheckCircle, Ellipsis, EyeOff, Shield,
     Trash2, MoveUp, MoveDown, Pencil, MessageSquareShare, Lock
 } from 'lucide-vue-next';
 import Button from '@/components/ui/button/Button.vue';
@@ -16,12 +16,7 @@ import {
     DropdownMenuGroup,
     DropdownMenuItem,
     DropdownMenuLabel,
-    DropdownMenuPortal,
     DropdownMenuSeparator,
-    DropdownMenuShortcut,
-    DropdownMenuSub,
-    DropdownMenuSubContent,
-    DropdownMenuSubTrigger,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { usePermissions } from '@/composables/usePermissions';

--- a/resources/js/pages/acp/TokenLogView.vue
+++ b/resources/js/pages/acp/TokenLogView.vue
@@ -55,7 +55,7 @@ function formatStructuredData(data: Record<string, unknown> | unknown[] | null):
 
     try {
         return JSON.stringify(data, null, 2);
-    } catch (error) {
+    } catch {
         return '—';
     }
 }

--- a/resources/js/pages/acp/TokenLogView.vue
+++ b/resources/js/pages/acp/TokenLogView.vue
@@ -1,56 +1,64 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed } from 'vue';
 import AppLayout from '@/layouts/AppLayout.vue';
 import AdminLayout from '@/layouts/acp/AdminLayout.vue';
 import { Head, Link } from '@inertiajs/vue3';
 import { type BreadcrumbItem } from '@/types';
 import Button from '@/components/ui/button/Button.vue';
 import { ArrowLeft } from 'lucide-vue-next';
+import { useUserTimezone } from '@/composables/useUserTimezone';
 
-// Define an interface for our token log details with additional fields
 interface TokenLogDetail {
     id: number;
-    token_name: string;
+    token_name: string | null;
     api_route: string;
     method: string;
     status: string;
-    http_status: number;
-    timestamp: string;
-    ip: string;
-    response_time: number;
-    request_params: string;      // Sanitized request parameters
-    response_summary: string;    // Summary of the response data
-    user_agent: string;          // Information about the client making the request
-    server_memory_usage: string; // e.g., "512 MB / 2048 MB"
-    auth_method: string;         // e.g., "session" or "token"
-    error_message?: string;      // Additional error details (if any)
+    http_status: number | null;
+    timestamp: string | null;
+    ip: string | null;
+    response_time_ms: number | null;
+    request_payload: Record<string, unknown> | unknown[] | null;
+    response_summary: Record<string, unknown> | unknown[] | null;
+    user_agent: string | null;
+    error_message?: string | null;
 }
 
-// Dummy breadcrumbs for navigation
+const props = defineProps<{ log: TokenLogDetail }>();
+
 const breadcrumbs: BreadcrumbItem[] = [
     { title: 'Tokens', href: '/acp/tokens' },
-    { title: 'Activity Logs', href: '/acp/tokens/logs' },
+    { title: 'Activity Logs', href: '/acp/tokens#logs' },
     { title: 'Log Detail', href: '#' },
 ];
 
-// Dummy token log data with extra details
-const tokenLog = ref<TokenLogDetail>({
-    id: 1,
-    token_name: 'Admin Token',
-    api_route: '/api/dashboard',
-    method: 'GET',
-    status: 'success',
-    http_status: 200,
-    timestamp: '2023-07-28 07:45:00',
-    ip: '192.168.1.10',
-    response_time: 125,
-    request_params: '{"id":1}', // Example: a sanitized JSON string
-    response_summary: '{"data":"Dashboard data retrieved successfully"}', // Example: a sanitized JSON string
-    user_agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)...',
-    server_memory_usage: '512 MB / 2048 MB',
-    auth_method: 'token',
-    error_message: '{"error":"lorem ipsum"}', // Example: a sanitized JSON string
-});
+const { fromNow } = useUserTimezone();
+
+const log = computed(() => props.log);
+
+const formattedRequestPayload = computed(() => formatStructuredData(log.value.request_payload));
+const formattedResponseSummary = computed(() => formatStructuredData(log.value.response_summary));
+const relativeTimestamp = computed(() => log.value.timestamp ? fromNow(log.value.timestamp) : 'Unknown');
+
+function formatStructuredData(data: Record<string, unknown> | unknown[] | null): string {
+    if (!data) {
+        return '—';
+    }
+
+    if (Array.isArray(data)) {
+        if (data.length === 0) {
+            return '—';
+        }
+    } else if (Object.keys(data).length === 0) {
+        return '—';
+    }
+
+    try {
+        return JSON.stringify(data, null, 2);
+    } catch (error) {
+        return '—';
+    }
+}
 </script>
 
 <template>
@@ -74,63 +82,56 @@ const tokenLog = ref<TokenLogDetail>({
                     <dl class="grid grid-cols-1 gap-4 sm:grid-cols-2">
                         <div>
                             <dt class="text-sm font-medium text-gray-500">ID</dt>
-                            <dd class="text-lg font-bold text-gray-700">{{ tokenLog.id }}</dd>
+                            <dd class="text-lg font-bold text-gray-700">{{ log.id }}</dd>
                         </div>
                         <div>
                             <dt class="text-sm font-medium text-gray-500">Token Name</dt>
-                            <dd class="text-lg font-bold text-gray-700">{{ tokenLog.token_name }}</dd>
+                            <dd class="text-lg font-bold text-gray-700">{{ log.token_name ?? 'Unknown token' }}</dd>
                         </div>
                         <div>
                             <dt class="text-sm font-medium text-gray-500">API Route</dt>
-                            <dd class="text-lg font-bold text-gray-700">{{ tokenLog.api_route }}</dd>
+                            <dd class="text-lg font-bold text-gray-700">{{ log.api_route }}</dd>
                         </div>
                         <div>
                             <dt class="text-sm font-medium text-gray-500">HTTP Method</dt>
-                            <dd class="text-lg font-bold text-gray-700">{{ tokenLog.method }}</dd>
+                            <dd class="text-lg font-bold text-gray-700">{{ log.method }}</dd>
                         </div>
                         <div>
                             <dt class="text-sm font-medium text-gray-500">Status</dt>
-                            <dd class="text-lg font-bold text-gray-700">{{ tokenLog.status }}</dd>
+                            <dd class="text-lg font-bold text-gray-700">{{ log.status }}</dd>
                         </div>
                         <div>
                             <dt class="text-sm font-medium text-gray-500">HTTP Status Code</dt>
-                            <dd class="text-lg font-bold text-gray-700">{{ tokenLog.http_status }}</dd>
+                            <dd class="text-lg font-bold text-gray-700">{{ log.http_status ?? '—' }}</dd>
                         </div>
                         <div>
                             <dt class="text-sm font-medium text-gray-500">Timestamp</dt>
-                            <dd class="text-lg font-bold text-gray-700">{{ tokenLog.timestamp }}</dd>
+                            <dd class="text-lg font-bold text-gray-700">{{ log.timestamp ?? 'Unknown' }}</dd>
+                            <dd v-if="log.timestamp" class="text-sm text-muted-foreground">{{ relativeTimestamp }}</dd>
                         </div>
                         <div>
                             <dt class="text-sm font-medium text-gray-500">IP Address</dt>
-                            <dd class="text-lg font-bold text-gray-700">{{ tokenLog.ip }}</dd>
+                            <dd class="text-lg font-bold text-gray-700">{{ log.ip ?? '—' }}</dd>
                         </div>
                         <div>
                             <dt class="text-sm font-medium text-gray-500">Response Time</dt>
-                            <dd class="text-lg font-bold text-gray-700">{{ tokenLog.response_time }} ms</dd>
+                            <dd class="text-lg font-bold text-gray-700">{{ log.response_time_ms ? `${log.response_time_ms} ms` : '—' }}</dd>
                         </div>
                         <div>
-                            <dt class="text-sm font-medium text-gray-500">Request Parameters</dt>
-                            <dd class="text-lg font-bold text-gray-700">{{ tokenLog.request_params }}</dd>
+                            <dt class="text-sm font-medium text-gray-500">Request Payload</dt>
+                            <dd class="text-sm font-mono whitespace-pre-wrap break-words bg-muted/40 p-3 rounded">{{ formattedRequestPayload }}</dd>
                         </div>
                         <div>
                             <dt class="text-sm font-medium text-gray-500">Response Summary</dt>
-                            <dd class="text-lg font-bold text-gray-700">{{ tokenLog.response_summary }}</dd>
+                            <dd class="text-sm font-mono whitespace-pre-wrap break-words bg-muted/40 p-3 rounded">{{ formattedResponseSummary }}</dd>
                         </div>
                         <div>
                             <dt class="text-sm font-medium text-gray-500">User Agent</dt>
-                            <dd class="text-lg font-bold text-gray-700">{{ tokenLog.user_agent }}</dd>
+                            <dd class="text-lg font-bold text-gray-700">{{ log.user_agent ?? '—' }}</dd>
                         </div>
-                        <div>
-                            <dt class="text-sm font-medium text-gray-500">Server Memory Usage</dt>
-                            <dd class="text-lg font-bold text-gray-700">{{ tokenLog.server_memory_usage }}</dd>
-                        </div>
-                        <div>
-                            <dt class="text-sm font-medium text-gray-500">Authentication Method</dt>
-                            <dd class="text-lg font-bold text-gray-700">{{ tokenLog.auth_method }}</dd>
-                        </div>
-                        <div v-if="tokenLog.error_message">
+                        <div v-if="log.error_message">
                             <dt class="text-sm font-medium text-red-500">Error Message</dt>
-                            <dd class="text-lg font-bold text-red-500">{{ tokenLog.error_message }}</dd>
+                            <dd class="text-lg font-bold text-red-500">{{ log.error_message }}</dd>
                         </div>
                     </dl>
                 </div>

--- a/resources/js/pages/acp/Tokens.vue
+++ b/resources/js/pages/acp/Tokens.vue
@@ -67,6 +67,16 @@ interface Token {
     revoked_at?: string | null;
 }
 
+interface TokenLog {
+    id: number;
+    token_name: string | null;
+    api_route: string;
+    method: string;
+    status: string;
+    http_status: number | null;
+    timestamp: string | null;
+}
+
 const props = defineProps<{
     tokens: {
         data: Token[];
@@ -89,6 +99,7 @@ const props = defineProps<{
         nickname: string;
         email: string;
     }>;
+    tokenLogs: TokenLog[];
 }>();
 
 const {
@@ -209,50 +220,23 @@ const lastUsedDisplay = (value?: string | null) => {
     return fromNow(value);
 };
 
-// --------------------
-// Dummy Token Logs Data
-// --------------------
-interface TokenLog {
-    id: number;
-    token_name: string;
-    api_route: string;
-    timestamp: string;
-    status: string;
-}
-
-const tokenLogs = ref<TokenLog[]>([
-    {
-        id: 1,
-        token_name: 'Admin Token',
-        api_route: '/api/dashboard',
-        timestamp: '2023-07-28 07:45:00',
-        status: 'success',
-    },
-    {
-        id: 2,
-        token_name: 'Editor Token',
-        api_route: '/api/posts',
-        timestamp: '2023-07-28 08:15:00',
-        status: 'failed',
-    },
-    {
-        id: 3,
-        token_name: 'Discord Bot Token',
-        api_route: '/api/discord',
-        timestamp: '2025-04-15 08:10:00',
-        status: 'success',
-    },
-]);
-
 const logSearchQuery = ref('');
 const filteredLogs = computed(() => {
-    if (!logSearchQuery.value) return tokenLogs.value;
+    const logs = props.tokenLogs ?? [];
+
+    if (!logSearchQuery.value) {
+        return logs;
+    }
     const q = logSearchQuery.value.toLowerCase();
-    return tokenLogs.value.filter(log =>
-        log.token_name.toLowerCase().includes(q) ||
-        log.api_route.toLowerCase().includes(q) ||
-        log.status.toLowerCase().includes(q)
-    );
+    return logs.filter((log) => {
+        const tokenName = log.token_name?.toLowerCase() ?? '';
+        return (
+            tokenName.includes(q) ||
+            log.api_route.toLowerCase().includes(q) ||
+            log.status.toLowerCase().includes(q) ||
+            log.method.toLowerCase().includes(q)
+        );
+    });
 });
 </script>
 
@@ -569,9 +553,9 @@ const filteredLogs = computed(() => {
                                             class="hover:bg-gray-50 dark:hover:bg-gray-900"
                                         >
                                             <TableCell>{{ log.id }}</TableCell>
-                                            <TableCell>{{ log.token_name }}</TableCell>
+                                            <TableCell>{{ log.token_name ?? 'Unknown token' }}</TableCell>
                                             <TableCell>{{ log.api_route }}</TableCell>
-                                            <TableCell>{{ fromNow(log.timestamp) }}</TableCell>
+                                            <TableCell>{{ log.timestamp ? fromNow(log.timestamp) : 'Unknown' }}</TableCell>
                                             <TableCell class="text-center">
                                                 <span :class="{
                                                   'text-green-500': log.status === 'success',
@@ -581,7 +565,7 @@ const filteredLogs = computed(() => {
                                                 </span>
                                             </TableCell>
                                             <TableCell class="text-center">
-                                                <Link :href="route('acp.tokens.logs.view')">
+                                                <Link :href="route('acp.tokens.logs.show', { tokenLog: log.id })">
                                                     <Button variant="ghost" class="text-blue-500 text-sm">View</Button>
                                                 </Link>
                                             </TableCell>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -72,7 +72,6 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
     Route::post('acp/tokens', [TokenController::class,'store'])->name('acp.tokens.store');
     Route::delete('acp/tokens/{token}', [TokenController::class,'destroy'])->name('acp.tokens.destroy');
 
-    Route::get('acp/tokens/logs/view', function () {
-        return Inertia::render('acp/TokenLogView');
-    })->name('acp.tokens.logs.view');
+    Route::get('acp/tokens/logs/{tokenLog}', [TokenController::class, 'showLog'])
+        ->name('acp.tokens.logs.show');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,7 +22,7 @@ Route::get('/public-data', function() {
 });
 
 // Sanctum-protected routes
-Route::middleware('auth:sanctum')->group(function () {
+Route::middleware(['auth:sanctum', 'token.activity'])->group(function () {
     // Return the authenticated user details
     Route::get('/user', function (Request $request) {
         return $request->user();


### PR DESCRIPTION
## Summary
- add a dedicated `token_logs` table and model for storing personal access token request activity
- record Sanctum-authenticated API traffic via a new middleware and expose recent entries to the admin token index
- replace the hard-coded activity views with real log data, including a detailed log view page

## Testing
- npm run build *(fails: could not load vendor/tightenco/ziggy because Composer dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68db3b7d4298832cb1db0b383442981b