### PR TITLE
Implement ACP forum management

### DIFF
--- a/app/Http/Controllers/Admin/Concerns/ManagesForumStructure.php
+++ b/app/Http/Controllers/Admin/Concerns/ManagesForumStructure.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Concerns;
+
+use App\Models\ForumBoard;
+use App\Models\ForumCategory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+trait ManagesForumStructure
+{
+    /**
+     * Resolve a slug for the given model, ensuring uniqueness.
+     *
+     * @param  class-string<Model>  $modelClass
+     */
+    protected function resolveSlug(?string $slug, string $title, string $modelClass, ?int $ignoreId = null): string
+    {
+        $candidate = Str::slug($slug ?: $title);
+
+        if ($candidate === '') {
+            $candidate = Str::random(8);
+        }
+
+        $original = $candidate;
+        $suffix = 1;
+
+        $query = $modelClass::query()->where('slug', $candidate);
+
+        if ($ignoreId) {
+            $query->where('id', '!=', $ignoreId);
+        }
+
+        while ($query->exists()) {
+            $candidate = $original.'-'.$suffix++;
+
+            $query = $modelClass::query()->where('slug', $candidate);
+
+            if ($ignoreId) {
+                $query->where('id', '!=', $ignoreId);
+            }
+        }
+
+        return $candidate;
+    }
+
+    protected function swapPositions(Model $first, Model $second): void
+    {
+        $firstPosition = $first->position;
+        $secondPosition = $second->position;
+
+        $first->forceFill(['position' => $secondPosition])->save();
+        $second->forceFill(['position' => $firstPosition])->save();
+    }
+
+    protected function resequenceCategories(): void
+    {
+        ForumCategory::query()
+            ->orderBy('position')
+            ->get()
+            ->values()
+            ->each(function (ForumCategory $category, int $index) {
+                $expected = $index + 1;
+
+                if ($category->position !== $expected) {
+                    $category->forceFill(['position' => $expected])->save();
+                }
+            });
+    }
+
+    protected function resequenceBoards(int $categoryId): void
+    {
+        ForumBoard::query()
+            ->where('forum_category_id', $categoryId)
+            ->orderBy('position')
+            ->get()
+            ->values()
+            ->each(function (ForumBoard $board, int $index) {
+                $expected = $index + 1;
+
+                if ($board->position !== $expected) {
+                    $board->forceFill(['position' => $expected])->save();
+                }
+            });
+    }
+}

--- a/app/Http/Controllers/Admin/ForumBoardController.php
+++ b/app/Http/Controllers/Admin/ForumBoardController.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Admin\Concerns\ManagesForumStructure;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\ReorderForumBoardRequest;
+use App\Http\Requests\Admin\StoreForumBoardRequest;
+use App\Http\Requests\Admin\UpdateForumBoardRequest;
+use App\Models\ForumBoard;
+use App\Models\ForumCategory;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Response;
+
+class ForumBoardController extends Controller
+{
+    use ManagesForumStructure;
+
+    public function create(Request $request): Response
+    {
+        abort_unless($request->user()?->can('forums.acp.create'), 403);
+
+        $categories = ForumCategory::query()
+            ->orderBy('position')
+            ->get(['id', 'title']);
+
+        $defaultCategoryId = $request->has('category') ? (int) $request->get('category') : null;
+
+        return inertia('acp/ForumBoardCreate', [
+            'categories' => $categories->map(fn (ForumCategory $category) => [
+                'id' => $category->id,
+                'title' => $category->title,
+            ])->values()->all(),
+            'defaultCategoryId' => $defaultCategoryId,
+        ]);
+    }
+
+    public function store(StoreForumBoardRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        $categoryId = (int) $validated['forum_category_id'];
+
+        ForumBoard::create([
+            'forum_category_id' => $categoryId,
+            'title' => $validated['title'],
+            'slug' => $this->resolveSlug($validated['slug'] ?? null, $validated['title'], ForumBoard::class),
+            'description' => $validated['description'] ?? null,
+            'position' => (ForumBoard::where('forum_category_id', $categoryId)->max('position') ?? 0) + 1,
+        ]);
+
+        return redirect()
+            ->route('acp.forums.index')
+            ->with('success', 'Forum board created successfully.');
+    }
+
+    public function edit(Request $request, ForumBoard $board): Response
+    {
+        abort_unless($request->user()?->can('forums.acp.edit'), 403);
+
+        $categories = ForumCategory::query()
+            ->orderBy('position')
+            ->get(['id', 'title']);
+
+        return inertia('acp/ForumBoardEdit', [
+            'board' => [
+                'id' => $board->id,
+                'title' => $board->title,
+                'slug' => $board->slug,
+                'description' => $board->description,
+                'forum_category_id' => $board->forum_category_id,
+            ],
+            'categories' => $categories->map(fn (ForumCategory $category) => [
+                'id' => $category->id,
+                'title' => $category->title,
+            ])->values()->all(),
+        ]);
+    }
+
+    public function update(UpdateForumBoardRequest $request, ForumBoard $board): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        $previousCategoryId = $board->forum_category_id;
+        $targetCategoryId = (int) $validated['forum_category_id'];
+        $newPosition = $board->position;
+
+        if ($targetCategoryId !== $previousCategoryId) {
+            $newPosition = (ForumBoard::where('forum_category_id', $targetCategoryId)->max('position') ?? 0) + 1;
+        }
+
+        $board->forceFill([
+            'forum_category_id' => $targetCategoryId,
+            'title' => $validated['title'],
+            'slug' => $this->resolveSlug($validated['slug'] ?? null, $validated['title'], ForumBoard::class, $board->id),
+            'description' => $validated['description'] ?? null,
+            'position' => $newPosition,
+        ])->save();
+
+        if ($targetCategoryId !== $previousCategoryId) {
+            $this->resequenceBoards($previousCategoryId);
+        }
+
+        return redirect()
+            ->route('acp.forums.index')
+            ->with('success', 'Forum board updated successfully.');
+    }
+
+    public function destroy(Request $request, ForumBoard $board): RedirectResponse
+    {
+        abort_unless($request->user()?->can('forums.acp.delete'), 403);
+
+        $categoryId = $board->forum_category_id;
+        $board->delete();
+        $this->resequenceBoards($categoryId);
+
+        return redirect()
+            ->route('acp.forums.index')
+            ->with('success', 'Forum board deleted successfully.');
+    }
+
+    public function reorder(ReorderForumBoardRequest $request, ForumBoard $board): RedirectResponse
+    {
+        $direction = $request->validated()['direction'];
+
+        $neighbor = ForumBoard::query()
+            ->where('forum_category_id', $board->forum_category_id)
+            ->when(
+                $direction === 'up',
+                fn ($query) => $query->where('position', '<', $board->position)->orderByDesc('position'),
+                fn ($query) => $query->where('position', '>', $board->position)->orderBy('position')
+            )
+            ->first();
+
+        if ($neighbor) {
+            $this->swapPositions($board, $neighbor);
+        }
+
+        return redirect()
+            ->back()
+            ->with('success', 'Forum boards reordered successfully.');
+    }
+}

--- a/app/Http/Controllers/Admin/ForumCategoryController.php
+++ b/app/Http/Controllers/Admin/ForumCategoryController.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Admin\Concerns\ManagesForumStructure;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\ReorderForumCategoryRequest;
+use App\Http\Requests\Admin\StoreForumCategoryRequest;
+use App\Http\Requests\Admin\UpdateForumCategoryRequest;
+use App\Models\ForumBoard;
+use App\Models\ForumCategory;
+use App\Models\ForumPost;
+use App\Models\ForumThread;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Response;
+
+class ForumCategoryController extends Controller
+{
+    use ManagesForumStructure;
+
+    public function index(Request $request): Response
+    {
+        abort_unless($request->user()?->can('forums.acp.view'), 403);
+
+        $categories = ForumCategory::query()
+            ->with(['boards' => function ($query) {
+                $query->withCount(['threads', 'posts'])
+                    ->orderBy('position')
+                    ->with([
+                        'latestThread' => function ($threadQuery) {
+                            $threadQuery->with(['author:id,nickname', 'lastPostAuthor:id,nickname']);
+                        },
+                    ]);
+            }])
+            ->orderBy('position')
+            ->get();
+
+        $categoryItems = $categories->map(function (ForumCategory $category) {
+            return [
+                'id' => $category->id,
+                'title' => $category->title,
+                'slug' => $category->slug,
+                'description' => $category->description,
+                'position' => $category->position,
+                'boards' => $category->boards->map(function (ForumBoard $board) {
+                    $latestThread = $board->latestThread;
+                    $latestAuthor = $latestThread?->lastPostAuthor ?? $latestThread?->author;
+                    $latestTimestamp = $latestThread?->last_posted_at ?? $latestThread?->created_at;
+
+                    return [
+                        'id' => $board->id,
+                        'title' => $board->title,
+                        'slug' => $board->slug,
+                        'description' => $board->description,
+                        'position' => $board->position,
+                        'thread_count' => $board->threads_count ?? 0,
+                        'post_count' => $board->posts_count ?? 0,
+                        'latest_post' => $latestThread ? [
+                            'title' => $latestThread->title,
+                            'author' => $latestAuthor ? [
+                                'id' => $latestAuthor->id,
+                                'nickname' => $latestAuthor->nickname,
+                            ] : null,
+                            'posted_at' => optional($latestTimestamp)->toIso8601String(),
+                        ] : null,
+                    ];
+                })->values()->all(),
+            ];
+        })->values()->all();
+
+        $stats = [
+            ['title' => 'Total Categories', 'value' => ForumCategory::count()],
+            ['title' => 'Total Boards', 'value' => ForumBoard::count()],
+            ['title' => 'Total Threads', 'value' => ForumThread::count()],
+            ['title' => 'Total Posts', 'value' => ForumPost::count()],
+        ];
+
+        return inertia('acp/Forums', [
+            'stats' => $stats,
+            'categories' => $categoryItems,
+        ]);
+    }
+
+    public function create(Request $request): Response
+    {
+        abort_unless($request->user()?->can('forums.acp.create'), 403);
+
+        return inertia('acp/ForumCategoryCreate');
+    }
+
+    public function store(StoreForumCategoryRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        ForumCategory::create([
+            'title' => $validated['title'],
+            'slug' => $this->resolveSlug($validated['slug'] ?? null, $validated['title'], ForumCategory::class),
+            'description' => $validated['description'] ?? null,
+            'position' => (ForumCategory::max('position') ?? 0) + 1,
+        ]);
+
+        return redirect()
+            ->route('acp.forums.index')
+            ->with('success', 'Forum category created successfully.');
+    }
+
+    public function edit(Request $request, ForumCategory $category): Response
+    {
+        abort_unless($request->user()?->can('forums.acp.edit'), 403);
+
+        return inertia('acp/ForumCategoryEdit', [
+            'category' => [
+                'id' => $category->id,
+                'title' => $category->title,
+                'slug' => $category->slug,
+                'description' => $category->description,
+            ],
+        ]);
+    }
+
+    public function update(UpdateForumCategoryRequest $request, ForumCategory $category): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        $category->forceFill([
+            'title' => $validated['title'],
+            'slug' => $this->resolveSlug($validated['slug'] ?? null, $validated['title'], ForumCategory::class, $category->id),
+            'description' => $validated['description'] ?? null,
+        ])->save();
+
+        return redirect()
+            ->route('acp.forums.index')
+            ->with('success', 'Forum category updated successfully.');
+    }
+
+    public function destroy(Request $request, ForumCategory $category): RedirectResponse
+    {
+        abort_unless($request->user()?->can('forums.acp.delete'), 403);
+
+        $category->delete();
+        $this->resequenceCategories();
+
+        return redirect()
+            ->route('acp.forums.index')
+            ->with('success', 'Forum category deleted successfully.');
+    }
+
+    public function reorder(ReorderForumCategoryRequest $request, ForumCategory $category): RedirectResponse
+    {
+        $direction = $request->validated()['direction'];
+
+        $neighbor = ForumCategory::query()
+            ->when(
+                $direction === 'up',
+                fn ($query) => $query->where('position', '<', $category->position)->orderByDesc('position'),
+                fn ($query) => $query->where('position', '>', $category->position)->orderBy('position')
+            )
+            ->first();
+
+        if ($neighbor) {
+            $this->swapPositions($category, $neighbor);
+        }
+
+        return redirect()
+            ->back()
+            ->with('success', 'Forum categories reordered successfully.');
+    }
+}

--- a/app/Http/Requests/Admin/ReorderForumBoardRequest.php
+++ b/app/Http/Requests/Admin/ReorderForumBoardRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReorderForumBoardRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('forums.acp.move') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'direction' => ['required', 'in:up,down'],
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/ReorderForumCategoryRequest.php
+++ b/app/Http/Requests/Admin/ReorderForumCategoryRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReorderForumCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('forums.acp.move') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'direction' => ['required', 'in:up,down'],
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/StoreForumBoardRequest.php
+++ b/app/Http/Requests/Admin/StoreForumBoardRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreForumBoardRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('forums.acp.create') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'forum_category_id' => ['required', 'exists:forum_categories,id'],
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255', 'unique:forum_boards,slug'],
+            'description' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/StoreForumCategoryRequest.php
+++ b/app/Http/Requests/Admin/StoreForumCategoryRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreForumCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('forums.acp.create') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255', 'unique:forum_categories,slug'],
+            'description' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/UpdateForumBoardRequest.php
+++ b/app/Http/Requests/Admin/UpdateForumBoardRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateForumBoardRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('forums.acp.edit') ?? false;
+    }
+
+    public function rules(): array
+    {
+        $boardId = $this->route('board')?->id;
+
+        return [
+            'forum_category_id' => ['required', 'exists:forum_categories,id'],
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'nullable',
+                'string',
+                'max:255',
+                Rule::unique('forum_boards', 'slug')->ignore($boardId),
+            ],
+            'description' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/UpdateForumCategoryRequest.php
+++ b/app/Http/Requests/Admin/UpdateForumCategoryRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateForumCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('forums.acp.edit') ?? false;
+    }
+
+    public function rules(): array
+    {
+        $categoryId = $this->route('category')?->id;
+
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'nullable',
+                'string',
+                'max:255',
+                Rule::unique('forum_categories', 'slug')->ignore($categoryId),
+            ],
+            'description' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/resources/js/pages/acp/ForumBoardCreate.vue
+++ b/resources/js/pages/acp/ForumBoardCreate.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Head, Link, useForm } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import InputError from '@/components/InputError.vue';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+
+const props = defineProps<{
+    categories: Array<{ id: number; title: string }>;
+    defaultCategoryId?: number | null;
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Forums ACP', href: route('acp.forums.index') },
+    { title: 'Create board', href: route('acp.forums.boards.create') },
+];
+
+const initialCategoryId = props.defaultCategoryId ?? props.categories[0]?.id ?? '';
+
+const form = useForm({
+    forum_category_id: initialCategoryId ? String(initialCategoryId) : '',
+    title: '',
+    slug: '',
+    description: '',
+});
+
+const hasCategories = computed(() => props.categories.length > 0);
+
+const handleSubmit = () => {
+    form.post(route('acp.forums.boards.store'), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Create forum board" />
+
+        <AdminLayout>
+            <form class="flex flex-1 flex-col gap-6" @submit.prevent="handleSubmit">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">Create forum board</h1>
+                        <p class="text-sm text-muted-foreground">
+                            Boards live inside categories and hold the threads and discussions for a specific topic.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2">
+                        <Button variant="outline" as-child>
+                            <Link :href="route('acp.forums.index')">Cancel</Link>
+                        </Button>
+                        <Button type="submit" :disabled="form.processing || !hasCategories">
+                            Save board
+                        </Button>
+                    </div>
+                </div>
+
+                <Card>
+                    <CardHeader class="relative overflow-hidden">
+                        <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                        <div class="relative space-y-1">
+                            <CardTitle>Board details</CardTitle>
+                            <CardDescription>
+                                Choose which category this board belongs to and describe its purpose for members.
+                            </CardDescription>
+                        </div>
+                    </CardHeader>
+                    <CardContent class="space-y-6">
+                        <div class="grid gap-2">
+                            <Label for="forum_category_id">Category</Label>
+                            <select
+                                id="forum_category_id"
+                                v-model="form.forum_category_id"
+                                class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                                :disabled="!hasCategories"
+                                required
+                            >
+                                <option value="" disabled>Select a category</option>
+                                <option v-for="category in props.categories" :key="category.id" :value="String(category.id)">
+                                    {{ category.title }}
+                                </option>
+                            </select>
+                            <InputError :message="form.errors.forum_category_id" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="title">Title</Label>
+                            <Input id="title" v-model="form.title" type="text" autocomplete="off" required />
+                            <InputError :message="form.errors.title" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="slug">Slug</Label>
+                            <Input
+                                id="slug"
+                                v-model="form.slug"
+                                type="text"
+                                autocomplete="off"
+                                placeholder="Optional custom slug (leave blank to auto-generate)"
+                            />
+                            <InputError :message="form.errors.slug" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="description">Description</Label>
+                            <Textarea
+                                id="description"
+                                v-model="form.description"
+                                placeholder="Explain the focus of this board to help members know what belongs here."
+                                class="min-h-24"
+                            />
+                            <InputError :message="form.errors.description" />
+                        </div>
+                    </CardContent>
+                    <CardFooter class="justify-end gap-2">
+                        <Button type="submit" :disabled="form.processing || !hasCategories">Save board</Button>
+                    </CardFooter>
+                </Card>
+
+                <p v-if="!hasCategories" class="rounded-lg border border-dashed border-sidebar-border/70 p-4 text-sm text-muted-foreground">
+                    You need to create a forum category before you can add boards.
+                </p>
+            </form>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/ForumBoardEdit.vue
+++ b/resources/js/pages/acp/ForumBoardEdit.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Head, Link, router, useForm } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import InputError from '@/components/InputError.vue';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+
+const props = defineProps<{
+    board: {
+        id: number;
+        title: string;
+        slug: string;
+        description: string | null;
+        forum_category_id: number;
+    };
+    categories: Array<{ id: number; title: string }>;
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Forums ACP', href: route('acp.forums.index') },
+    { title: 'Edit board', href: route('acp.forums.boards.edit', { board: props.board.id }) },
+];
+
+const form = useForm({
+    forum_category_id: String(props.board.forum_category_id),
+    title: props.board.title ?? '',
+    slug: props.board.slug ?? '',
+    description: props.board.description ?? '',
+});
+
+const hasCategories = computed(() => props.categories.length > 0);
+
+const handleSubmit = () => {
+    form.put(route('acp.forums.boards.update', { board: props.board.id }), {
+        preserveScroll: true,
+    });
+};
+
+const handleDelete = () => {
+    if (confirm('Deleting this board will remove all threads and posts it contains. Do you want to proceed?')) {
+        router.delete(route('acp.forums.boards.destroy', { board: props.board.id }), {
+            preserveScroll: true,
+        });
+    }
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Edit forum board" />
+
+        <AdminLayout>
+            <form class="flex flex-1 flex-col gap-6" @submit.prevent="handleSubmit">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">Edit forum board</h1>
+                        <p class="text-sm text-muted-foreground">
+                            Change the board details or move it to a different category. Updates apply immediately.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2">
+                        <Button variant="outline" as-child>
+                            <Link :href="route('acp.forums.index')">Back to forums</Link>
+                        </Button>
+                        <Button type="submit" :disabled="form.processing || !hasCategories">Save changes</Button>
+                    </div>
+                </div>
+
+                <Card>
+                    <CardHeader class="relative overflow-hidden">
+                        <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                        <div class="relative space-y-1">
+                            <CardTitle>Board details</CardTitle>
+                            <CardDescription>Modify where this board lives and how it is presented to members.</CardDescription>
+                        </div>
+                    </CardHeader>
+                    <CardContent class="space-y-6">
+                        <div class="grid gap-2">
+                            <Label for="forum_category_id">Category</Label>
+                            <select
+                                id="forum_category_id"
+                                v-model="form.forum_category_id"
+                                class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                                :disabled="!hasCategories"
+                                required
+                            >
+                                <option value="" disabled>Select a category</option>
+                                <option v-for="category in props.categories" :key="category.id" :value="String(category.id)">
+                                    {{ category.title }}
+                                </option>
+                            </select>
+                            <InputError :message="form.errors.forum_category_id" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="title">Title</Label>
+                            <Input id="title" v-model="form.title" type="text" autocomplete="off" required />
+                            <InputError :message="form.errors.title" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="slug">Slug</Label>
+                            <Input
+                                id="slug"
+                                v-model="form.slug"
+                                type="text"
+                                autocomplete="off"
+                                placeholder="Optional custom slug (leave blank to auto-generate)"
+                            />
+                            <InputError :message="form.errors.slug" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="description">Description</Label>
+                            <Textarea
+                                id="description"
+                                v-model="form.description"
+                                placeholder="Explain the focus of this board to help members know what belongs here."
+                                class="min-h-24"
+                            />
+                            <InputError :message="form.errors.description" />
+                        </div>
+                    </CardContent>
+                    <CardFooter class="flex flex-col gap-4 border-t border-border/50 pt-6 md:flex-row md:items-center md:justify-between">
+                        <div class="text-sm text-muted-foreground">
+                            Removing this board permanently deletes all threads and replies posted inside it.
+                        </div>
+                        <div class="flex flex-wrap gap-2">
+                            <Button type="submit" :disabled="form.processing || !hasCategories">Save changes</Button>
+                            <Button type="button" variant="destructive" @click="handleDelete">Delete board</Button>
+                        </div>
+                    </CardFooter>
+                </Card>
+            </form>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/ForumCategoryCreate.vue
+++ b/resources/js/pages/acp/ForumCategoryCreate.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { Head, Link, useForm } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import InputError from '@/components/InputError.vue';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Forums ACP', href: route('acp.forums.index') },
+    { title: 'Create category', href: route('acp.forums.categories.create') },
+];
+
+const form = useForm({
+    title: '',
+    slug: '',
+    description: '',
+});
+
+const handleSubmit = () => {
+    form.post(route('acp.forums.categories.store'), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Create forum category" />
+
+        <AdminLayout>
+            <form class="flex flex-1 flex-col gap-6" @submit.prevent="handleSubmit">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">Create forum category</h1>
+                        <p class="text-sm text-muted-foreground">
+                            Define a new top-level category to organize related boards within the community forum.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2">
+                        <Button variant="outline" as-child>
+                            <Link :href="route('acp.forums.index')">Cancel</Link>
+                        </Button>
+                        <Button type="submit" :disabled="form.processing">Save category</Button>
+                    </div>
+                </div>
+
+                <Card>
+                    <CardHeader class="relative overflow-hidden">
+                        <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                        <div class="relative space-y-1">
+                            <CardTitle>Category details</CardTitle>
+                            <CardDescription>
+                                Set the name, optional slug, and description that will be shown to community members.
+                            </CardDescription>
+                        </div>
+                    </CardHeader>
+                    <CardContent class="space-y-6">
+                        <div class="grid gap-2">
+                            <Label for="title">Title</Label>
+                            <Input id="title" v-model="form.title" type="text" autocomplete="off" required />
+                            <InputError :message="form.errors.title" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="slug">Slug</Label>
+                            <Input
+                                id="slug"
+                                v-model="form.slug"
+                                type="text"
+                                autocomplete="off"
+                                placeholder="Optional custom slug (leave blank to auto-generate)"
+                            />
+                            <InputError :message="form.errors.slug" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="description">Description</Label>
+                            <Textarea
+                                id="description"
+                                v-model="form.description"
+                                placeholder="Describe the kinds of boards or discussions that belong in this category."
+                                class="min-h-24"
+                            />
+                            <InputError :message="form.errors.description" />
+                        </div>
+                    </CardContent>
+                    <CardFooter class="justify-end gap-2">
+                        <Button type="submit" :disabled="form.processing">Save category</Button>
+                    </CardFooter>
+                </Card>
+            </form>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/ForumCategoryEdit.vue
+++ b/resources/js/pages/acp/ForumCategoryEdit.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import { Head, Link, router, useForm } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import InputError from '@/components/InputError.vue';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+
+const props = defineProps<{
+    category: {
+        id: number;
+        title: string;
+        slug: string;
+        description: string | null;
+    };
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Forums ACP', href: route('acp.forums.index') },
+    { title: 'Edit category', href: route('acp.forums.categories.edit', { category: props.category.id }) },
+];
+
+const form = useForm({
+    title: props.category.title ?? '',
+    slug: props.category.slug ?? '',
+    description: props.category.description ?? '',
+});
+
+const handleSubmit = () => {
+    form.put(route('acp.forums.categories.update', { category: props.category.id }), {
+        preserveScroll: true,
+    });
+};
+
+const handleDelete = () => {
+    if (
+        confirm(
+            'Deleting this category will also remove all boards, threads, and posts within it. Are you sure you want to continue?',
+        )
+    ) {
+        router.delete(route('acp.forums.categories.destroy', { category: props.category.id }), {
+            preserveScroll: true,
+        });
+    }
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Edit forum category" />
+
+        <AdminLayout>
+            <form class="flex flex-1 flex-col gap-6" @submit.prevent="handleSubmit">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">Edit forum category</h1>
+                        <p class="text-sm text-muted-foreground">
+                            Update the category name, slug, or description. Changes apply immediately across the forums.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2">
+                        <Button variant="outline" as-child>
+                            <Link :href="route('acp.forums.index')">Back to forums</Link>
+                        </Button>
+                        <Button type="submit" :disabled="form.processing">Save changes</Button>
+                    </div>
+                </div>
+
+                <Card>
+                    <CardHeader class="relative overflow-hidden">
+                        <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                        <div class="relative space-y-1">
+                            <CardTitle>Category details</CardTitle>
+                            <CardDescription>Adjust how this category appears to community members.</CardDescription>
+                        </div>
+                    </CardHeader>
+                    <CardContent class="space-y-6">
+                        <div class="grid gap-2">
+                            <Label for="title">Title</Label>
+                            <Input id="title" v-model="form.title" type="text" autocomplete="off" required />
+                            <InputError :message="form.errors.title" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="slug">Slug</Label>
+                            <Input
+                                id="slug"
+                                v-model="form.slug"
+                                type="text"
+                                autocomplete="off"
+                                placeholder="Optional custom slug (leave blank to auto-generate)"
+                            />
+                            <InputError :message="form.errors.slug" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="description">Description</Label>
+                            <Textarea
+                                id="description"
+                                v-model="form.description"
+                                placeholder="Describe the kinds of boards or discussions that belong in this category."
+                                class="min-h-24"
+                            />
+                            <InputError :message="form.errors.description" />
+                        </div>
+                    </CardContent>
+                    <CardFooter class="flex flex-col gap-4 border-t border-border/50 pt-6 md:flex-row md:items-center md:justify-between">
+                        <div class="text-sm text-muted-foreground">
+                            Removing this category also deletes every board and discussion nested inside it.
+                        </div>
+                        <div class="flex flex-wrap gap-2">
+                            <Button type="submit" :disabled="form.processing">Save changes</Button>
+                            <Button type="button" variant="destructive" @click="handleDelete">Delete category</Button>
+                        </div>
+                    </CardFooter>
+                </Card>
+            </form>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/Forums.vue
+++ b/resources/js/pages/acp/Forums.vue
@@ -3,11 +3,20 @@ import { computed } from 'vue';
 import AppLayout from '@/layouts/AppLayout.vue';
 import AdminLayout from '@/layouts/acp/AdminLayout.vue';
 import { type BreadcrumbItem } from '@/types';
-import { Head, Link } from '@inertiajs/vue3';
+import { Head, Link, router } from '@inertiajs/vue3';
 import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
 import {
-    Folder, MessageSquare, CheckCircle, Ellipsis, Eye, EyeOff, Shield,
-    Trash2, MoveUp, MoveDown, Pencil, MessageSquareShare, Lock
+    Folder,
+    Layers,
+    MessageSquare,
+    CheckCircle,
+    Ellipsis,
+    MoveUp,
+    MoveDown,
+    Pencil,
+    Trash2,
+    ExternalLink,
+    PlusCircle,
 } from 'lucide-vue-next';
 import Button from '@/components/ui/button/Button.vue';
 import {
@@ -16,95 +25,137 @@ import {
     DropdownMenuGroup,
     DropdownMenuItem,
     DropdownMenuLabel,
-    DropdownMenuPortal,
     DropdownMenuSeparator,
-    DropdownMenuShortcut,
-    DropdownMenuSub,
-    DropdownMenuSubContent,
-    DropdownMenuSubTrigger,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { usePermissions } from '@/composables/usePermissions';
+import { useUserTimezone } from '@/composables/useUserTimezone';
 
-// Permission checks
+type ForumStat = {
+    title: string;
+    value: number;
+};
+
+type ForumBoardSummary = {
+    id: number;
+    title: string;
+    slug: string;
+    description: string | null;
+    position: number;
+    thread_count: number;
+    post_count: number;
+    latest_post: {
+        title: string;
+        author: { id: number; nickname: string } | null;
+        posted_at: string | null;
+    } | null;
+};
+
+type ForumCategorySummary = {
+    id: number;
+    title: string;
+    slug: string;
+    description: string | null;
+    position: number;
+    boards: ForumBoardSummary[];
+};
+
+const props = defineProps<{
+    stats: ForumStat[];
+    categories: ForumCategorySummary[];
+}>();
+
 const { hasPermission } = usePermissions();
+const { fromNow } = useUserTimezone();
+
 const createForums = computed(() => hasPermission('forums.acp.create'));
 const editForums = computed(() => hasPermission('forums.acp.edit'));
-const lockForums = computed(() => hasPermission('forums.acp.lock'));
-const migrateForums = computed(() => hasPermission('forums.acp.migrate'));
 const moveForums = computed(() => hasPermission('forums.acp.move'));
-const publishForums = computed(() => hasPermission('forums.acp.publish'));
 const deleteForums = computed(() => hasPermission('forums.acp.delete'));
-const permissionsForums = computed(() => hasPermission('forums.acp.permissions'));
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
         title: 'Forums ACP',
-        href: '/acp/forums',
+        href: route('acp.forums.index'),
     },
 ];
 
-// Dummy forum statistics
-const forumStats = [
-    { title: 'Total Categories', value: '2', icon: Folder },
-    { title: 'Total Subcategories', value: '4', icon: MessageSquare },
-    { title: 'Total Threads', value: '388', icon: CheckCircle },
-    { title: 'Total Posts', value: '7712', icon: MessageSquare },
-];
+const statIconMap = {
+    'Total Categories': Folder,
+    'Total Boards': Layers,
+    'Total Threads': MessageSquare,
+    'Total Posts': CheckCircle,
+} as const;
 
-// Dummy data for forum categories with subcategories
-const forumCategories = [
-    {
-        title: 'Gaming',
-        subCategories: [
-            {
-                title: 'PC Games',
-                threadCount: 123,
-                postCount: 4567,
-                latestPost: {
-                    title: 'Latest PC game discussion',
-                    author: 'GamerOne',
-                    date: '2 hours ago',
-                },
-            },
-            {
-                title: 'Console Games',
-                threadCount: 89,
-                postCount: 2345,
-                latestPost: {
-                    title: 'Upcoming console releases',
-                    author: 'ConsoleFan',
-                    date: '3 hours ago',
-                },
-            },
-        ],
-    },
-    {
-        title: 'Hardware',
-        subCategories: [
-            {
-                title: 'PC Hardware',
-                threadCount: 101,
-                postCount: 500,
-                latestPost: {
-                    title: 'Best GPU deals',
-                    author: 'TechGuru',
-                    date: '1 day ago',
-                },
-            },
-            {
-                title: 'Peripherals',
-                threadCount: 75,
-                postCount: 300,
-                latestPost: {
-                    title: 'Mechanical keyboard reviews',
-                    author: 'KeyMaster',
-                    date: '5 hours ago',
-                },
-            },
-        ],
-    },
-];
+const defaultStatIcons = [Folder, Layers, MessageSquare, CheckCircle];
+
+const forumStats = computed(() =>
+    props.stats.map((stat, index) => ({
+        ...stat,
+        icon: statIconMap[stat.title as keyof typeof statIconMap] ?? defaultStatIcons[index] ?? Folder,
+    })),
+);
+
+const categories = computed(() => props.categories);
+const hasCategories = computed(() => categories.value.length > 0);
+
+const formatRelative = (value: string | null | undefined) => {
+    if (!value) {
+        return null;
+    }
+
+    return fromNow(value);
+};
+
+const reorderCategory = (categoryId: number, direction: 'up' | 'down') => {
+    router.patch(
+        route('acp.forums.categories.reorder', { category: categoryId }),
+        { direction },
+        { preserveScroll: true },
+    );
+};
+
+const goToCategoryEdit = (categoryId: number) => {
+    router.get(route('acp.forums.categories.edit', { category: categoryId }));
+};
+
+const deleteCategory = (categoryId: number) => {
+    if (
+        confirm(
+            'Deleting this category will also remove all boards, threads, and posts within it. Are you sure you want to continue?',
+        )
+    ) {
+        router.delete(route('acp.forums.categories.destroy', { category: categoryId }), {
+            preserveScroll: true,
+        });
+    }
+};
+
+const openBoardCreate = (categoryId: number) => {
+    router.get(route('acp.forums.boards.create'), { category: categoryId });
+};
+
+const reorderBoard = (boardId: number, direction: 'up' | 'down') => {
+    router.patch(
+        route('acp.forums.boards.reorder', { board: boardId }),
+        { direction },
+        { preserveScroll: true },
+    );
+};
+
+const goToBoardEdit = (boardId: number) => {
+    router.get(route('acp.forums.boards.edit', { board: boardId }));
+};
+
+const deleteBoard = (boardId: number) => {
+    if (
+        confirm('Deleting this board will remove all threads and posts it contains. Do you want to proceed?')
+    ) {
+        router.delete(route('acp.forums.boards.destroy', { board: boardId }), {
+            preserveScroll: true,
+        });
+    }
+};
 </script>
 
 <template>
@@ -113,12 +164,11 @@ const forumCategories = [
 
         <AdminLayout>
             <div class="flex h-full flex-1 flex-col gap-4 rounded-xl pb-4">
-                <!-- Forum Stats Section -->
                 <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
                     <div
                         v-for="(stat, index) in forumStats"
                         :key="index"
-                        class="relative overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border p-4 flex items-center"
+                        class="relative flex items-center overflow-hidden rounded-xl border border-sidebar-border/70 p-4"
                     >
                         <div class="mr-4">
                             <component :is="stat.icon" class="h-8 w-8 text-gray-600" />
@@ -131,22 +181,47 @@ const forumCategories = [
                     </div>
                 </div>
 
-                <!-- Forum Categories Management Section -->
                 <div>
                     <div class="flex items-center justify-between pb-4">
-                        <h2 class="mb-4 text-xl font-bold">Manage Forum Categories</h2>
-                        <Button v-if="createForums" variant="success" class="text-sm text-white bg-green-500 hover:bg-green-600">
-                            Create Category
+                        <div>
+                            <h2 class="mb-2 text-xl font-bold">Manage Forum Categories</h2>
+                            <p class="text-sm text-muted-foreground">
+                                Create, arrange, and update the categories and boards that power the community forums.
+                            </p>
+                        </div>
+                        <Button
+                            v-if="createForums"
+                            variant="success"
+                            class="text-sm text-white bg-green-500 hover:bg-green-600"
+                            as-child
+                        >
+                            <Link :href="route('acp.forums.categories.create')" preserve-scroll>
+                                <PlusCircle class="mr-2 h-4 w-4" />
+                                Create Category
+                            </Link>
                         </Button>
                     </div>
-                    <div
-                        v-for="(category, catIndex) in forumCategories"
-                        :key="catIndex"
-                        class="mb-6 rounded-lg border border-sidebar-border/70 shadow hover:shadow-lg transition"
+
+                    <p
+                        v-if="!hasCategories"
+                        class="rounded-lg border border-dashed border-sidebar-border/70 p-6 text-center text-sm text-muted-foreground"
                     >
-                        <!-- Category Card Header -->
-                        <div class="flex items-center justify-between p-4 bg-gray-100 dark:bg-neutral-900 rounded-t-lg">
-                            <h3 class="text-xl font-bold">{{ category.title }}</h3>
+                        No forum categories have been created yet. Use the button above to add your first category.
+                    </p>
+
+                    <div
+                        v-for="(category, catIndex) in categories"
+                        v-else
+                        :key="category.id"
+                        class="mb-6 rounded-lg border border-sidebar-border/70 shadow transition hover:shadow-lg"
+                    >
+                        <div class="flex items-start justify-between rounded-t-lg bg-gray-100 p-4 dark:bg-neutral-900">
+                            <div>
+                                <h3 class="text-xl font-bold">{{ category.title }}</h3>
+                                <p v-if="category.description" class="mt-1 text-sm text-muted-foreground">
+                                    {{ category.description }}
+                                </p>
+                            </div>
                             <DropdownMenu>
                                 <DropdownMenuTrigger as-child>
                                     <Button variant="outline" size="icon">
@@ -154,89 +229,93 @@ const forumCategories = [
                                     </Button>
                                 </DropdownMenuTrigger>
                                 <DropdownMenuContent>
-                                    <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                                    <DropdownMenuSeparator v-if="moveForums||publishForums" />
+                                    <DropdownMenuLabel>Category Actions</DropdownMenuLabel>
                                     <DropdownMenuGroup v-if="moveForums">
-                                        <DropdownMenuItem>
-                                            <MoveUp class="h-8 w-8" />
+                                        <DropdownMenuItem
+                                            :disabled="catIndex === 0"
+                                            @select="reorderCategory(category.id, 'up')"
+                                        >
+                                            <MoveUp class="h-4 w-4" />
                                             <span>Move Up</span>
                                         </DropdownMenuItem>
-                                        <DropdownMenuItem>
-                                            <MoveDown class="h-8 w-8" />
+                                        <DropdownMenuItem
+                                            :disabled="catIndex === categories.length - 1"
+                                            @select="reorderCategory(category.id, 'down')"
+                                        >
+                                            <MoveDown class="h-4 w-4" />
                                             <span>Move Down</span>
                                         </DropdownMenuItem>
                                     </DropdownMenuGroup>
-                                    <DropdownMenuGroup v-if="publishForums">
-                                        <DropdownMenuItem>
-                                            <EyeOff class="h-8 w-8" />
-                                            <span>Unpublish</span>
+                                    <DropdownMenuGroup v-if="createForums">
+                                        <DropdownMenuItem @select="openBoardCreate(category.id)">
+                                            <PlusCircle class="h-4 w-4" />
+                                            <span>Add Board</span>
                                         </DropdownMenuItem>
                                     </DropdownMenuGroup>
-                                    <DropdownMenuSeparator v-if="editForums||permissionsForums" />
                                     <DropdownMenuGroup v-if="editForums">
-                                        <DropdownMenuItem class="text-blue-500">
-                                            <Pencil class="h-8 w-8" />
-                                            <span>Edit</span>
-                                        </DropdownMenuItem>
-                                    </DropdownMenuGroup>
-                                    <DropdownMenuGroup v-if="permissionsForums">
-                                        <DropdownMenuItem>
-                                            <Shield class="h-8 w-8" />
-                                            <span>Permissions</span>
-                                        </DropdownMenuItem>
-                                    </DropdownMenuGroup>
-                                    <DropdownMenuSeparator v-if="migrateForums" />
-                                    <DropdownMenuGroup v-if="migrateForums">
-                                        <DropdownMenuItem>
-                                            <MessageSquareShare class="h-8 w-8" />
-                                            <span>Migrate Children</span>
+                                        <DropdownMenuItem class="text-blue-500" @select="goToCategoryEdit(category.id)">
+                                            <Pencil class="h-4 w-4" />
+                                            <span>Edit Category</span>
                                         </DropdownMenuItem>
                                     </DropdownMenuGroup>
                                     <DropdownMenuSeparator v-if="deleteForums" />
-                                    <DropdownMenuItem v-if="deleteForums" class="text-red-500" disabled>
-                                        <Trash2 class="h-8 w-8" />
-                                        <span>Delete</span>
+                                    <DropdownMenuItem
+                                        v-if="deleteForums"
+                                        class="text-red-500"
+                                        @select="deleteCategory(category.id)"
+                                    >
+                                        <Trash2 class="h-4 w-4" />
+                                        <span>Delete Category</span>
                                     </DropdownMenuItem>
                                 </DropdownMenuContent>
                             </DropdownMenu>
                         </div>
-                        <!-- Subcategories Table -->
-                        <div class="divide-y">
+
+                        <div v-if="category.boards.length" class="divide-y">
                             <div
-                                v-for="(sub, subIndex) in category.subCategories"
-                                :key="subIndex"
-                                class="flex items-center p-4 hover:bg-gray-50 dark:hover:bg-neutral-800 transition even:bg-gray-50 dark:even:bg-neutral-900"
+                                v-for="(board, boardIndex) in category.boards"
+                                :key="board.id"
+                                class="flex flex-col gap-3 p-4 transition hover:bg-gray-50 dark:hover:bg-neutral-800 md:flex-row md:items-center"
                             >
-                                <!-- Subcategory Icon -->
-                                <div class="mr-4">
+                                <div class="mr-4 flex items-center md:items-start">
                                     <Folder class="h-8 w-8 text-gray-600" />
                                 </div>
-                                <!-- Subcategory Details -->
                                 <div class="flex-1">
-                                    <h4 class="font-semibold text-lg">
-                                        <Link
-                                            :href="sub.slug ? route('forum.boards.show', { board: sub.slug }) : '#'"
-                                            class="font-semibold hover:underline"
-                                        >
-                                            {{ sub.title }}
-                                        </Link>
-                                    </h4>
-                                    <div class="text-xs text-gray-500">
-                                        Latest: <span class="font-medium">{{ sub.latestPost.title }}</span> by
-                                        {{ sub.latestPost.author }} <span>({{ sub.latestPost.date }})</span>
+                                    <div class="flex flex-col md:flex-row md:items-center md:justify-between">
+                                        <div>
+                                            <h4 class="text-lg font-semibold">
+                                                <Link
+                                                    :href="route('forum.boards.show', { board: board.slug })"
+                                                    class="hover:underline"
+                                                >
+                                                    {{ board.title }}
+                                                </Link>
+                                            </h4>
+                                            <p v-if="board.description" class="text-sm text-muted-foreground">
+                                                {{ board.description }}
+                                            </p>
+                                        </div>
+                                        <div class="mt-3 flex gap-6 text-sm text-muted-foreground md:mt-0">
+                                            <span><strong class="font-semibold">{{ board.thread_count }}</strong> Threads</span>
+                                            <span><strong class="font-semibold">{{ board.post_count }}</strong> Posts</span>
+                                        </div>
+                                    </div>
+                                    <div class="mt-2 text-xs text-muted-foreground">
+                                        <template v-if="board.latest_post">
+                                            Latest: <span class="font-medium">{{ board.latest_post.title }}</span>
+                                            <template v-if="board.latest_post.author">
+                                                by {{ board.latest_post.author.nickname }}
+                                            </template>
+                                            <span v-if="formatRelative(board.latest_post.posted_at)" class="ml-1">
+                                                ({{ formatRelative(board.latest_post.posted_at) }})
+                                            </span>
+                                        </template>
+                                        <template v-else>
+                                            No posts yet.
+                                        </template>
                                     </div>
                                 </div>
-                                <!-- Thread & Post Counts -->
-                                <div class="w-24 text-center">
-                                    <div class="font-bold">{{ sub.threadCount }}</div>
-                                    <div class="text-xs text-gray-500">Threads</div>
-                                </div>
-                                <div class="w-24 text-center">
-                                    <div class="font-bold">{{ sub.postCount }}</div>
-                                    <div class="text-xs text-gray-500">Posts</div>
-                                </div>
-                                <!-- Actions -->
-                                <div class="w-32 text-right">
+                                <div class="flex w-full items-center justify-between md:w-48 md:justify-end">
                                     <DropdownMenu>
                                         <DropdownMenuTrigger as-child>
                                             <Button variant="outline" size="icon">
@@ -244,59 +323,64 @@ const forumCategories = [
                                             </Button>
                                         </DropdownMenuTrigger>
                                         <DropdownMenuContent>
-                                            <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                                            <DropdownMenuSeparator v-if="moveForums||publishForums" />
+                                            <DropdownMenuLabel>Board Actions</DropdownMenuLabel>
+                                            <DropdownMenuGroup>
+                                                <DropdownMenuItem as-child>
+                                                    <Link
+                                                        :href="route('forum.boards.show', { board: board.slug })"
+                                                        class="flex items-center gap-2"
+                                                    >
+                                                        <ExternalLink class="h-4 w-4" />
+                                                        <span>View Board</span>
+                                                    </Link>
+                                                </DropdownMenuItem>
+                                            </DropdownMenuGroup>
                                             <DropdownMenuGroup v-if="moveForums">
-                                                <DropdownMenuItem>
-                                                    <MoveUp class="h-8 w-8" />
+                                                <DropdownMenuItem
+                                                    :disabled="boardIndex === 0"
+                                                    @select="reorderBoard(board.id, 'up')"
+                                                >
+                                                    <MoveUp class="h-4 w-4" />
                                                     <span>Move Up</span>
                                                 </DropdownMenuItem>
-                                                <DropdownMenuItem>
-                                                    <MoveDown class="h-8 w-8" />
+                                                <DropdownMenuItem
+                                                    :disabled="boardIndex === category.boards.length - 1"
+                                                    @select="reorderBoard(board.id, 'down')"
+                                                >
+                                                    <MoveDown class="h-4 w-4" />
                                                     <span>Move Down</span>
                                                 </DropdownMenuItem>
                                             </DropdownMenuGroup>
-                                            <DropdownMenuGroup v-if="publishForums">
-                                                <DropdownMenuItem>
-                                                    <EyeOff class="h-8 w-8" />
-                                                    <span>Unpublish</span>
-                                                </DropdownMenuItem>
-                                            </DropdownMenuGroup>
-                                            <DropdownMenuSeparator v-if="editForums" />
                                             <DropdownMenuGroup v-if="editForums">
-                                                <DropdownMenuItem class="text-blue-500">
-                                                    <Pencil class="h-8 w-8" />
-                                                    <span>Edit Category</span>
-                                                </DropdownMenuItem>
-                                            </DropdownMenuGroup>
-                                            <DropdownMenuGroup v-if="permissionsForums">
-                                                <DropdownMenuItem>
-                                                    <Shield class="h-8 w-8" />
-                                                    <span>Permissions</span>
-                                                </DropdownMenuItem>
-                                            </DropdownMenuGroup>
-                                            <DropdownMenuSeparator v-if="lockForums||migrateForums" />
-                                            <DropdownMenuGroup v-if="lockForums">
-                                                <DropdownMenuItem>
-                                                    <Lock class="h-8 w-8" />
-                                                    <span>Lock Threads</span>
-                                                </DropdownMenuItem>
-                                            </DropdownMenuGroup>
-                                            <DropdownMenuGroup v-if="migrateForums">
-                                                <DropdownMenuItem>
-                                                    <MessageSquareShare class="h-8 w-8" />
-                                                    <span>Migrate Threads</span>
+                                                <DropdownMenuItem class="text-blue-500" @select="goToBoardEdit(board.id)">
+                                                    <Pencil class="h-4 w-4" />
+                                                    <span>Edit Board</span>
                                                 </DropdownMenuItem>
                                             </DropdownMenuGroup>
                                             <DropdownMenuSeparator v-if="deleteForums" />
-                                            <DropdownMenuItem v-if="deleteForums" class="text-red-500" disabled>
-                                                <Trash2 class="h-8 w-8" />
-                                                <span>Delete</span>
+                                            <DropdownMenuItem
+                                                v-if="deleteForums"
+                                                class="text-red-500"
+                                                @select="deleteBoard(board.id)"
+                                            >
+                                                <Trash2 class="h-4 w-4" />
+                                                <span>Delete Board</span>
                                             </DropdownMenuItem>
                                         </DropdownMenuContent>
                                     </DropdownMenu>
                                 </div>
                             </div>
+                        </div>
+                        <div v-else class="px-4 py-6 text-sm text-muted-foreground">
+                            This category does not contain any boards yet.
+                            <button
+                                v-if="createForums"
+                                type="button"
+                                class="ml-1 font-medium text-primary hover:underline"
+                                @click="openBoardCreate(category.id)"
+                            >
+                                Add a board now.
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\Admin\ACLController as AdminACLController;
 use App\Http\Controllers\Admin\SupportController;
 use App\Http\Controllers\Admin\TokenController;
 use App\Http\Controllers\Admin\UsersController as AdminUserController;
+use App\Http\Controllers\Admin\ForumBoardController;
+use App\Http\Controllers\Admin\ForumCategoryController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -42,9 +44,20 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
     Route::put('acp/blogs/{blog}/publish', [AdminBlogController::class, 'publish'])->name('acp.blogs.publish');
     Route::put('acp/blogs/{blog}/unpublish', [AdminBlogController::class, 'unpublish'])->name('acp.blogs.unpublish');
 
-    Route::get('acp/forums', function () {
-        return Inertia::render('acp/Forums');
-    })->name('acp.forums');
+    Route::get('acp/forums', [ForumCategoryController::class, 'index'])->name('acp.forums.index');
+    Route::get('acp/forums/categories/create', [ForumCategoryController::class, 'create'])->name('acp.forums.categories.create');
+    Route::post('acp/forums/categories', [ForumCategoryController::class, 'store'])->name('acp.forums.categories.store');
+    Route::get('acp/forums/categories/{category}/edit', [ForumCategoryController::class, 'edit'])->name('acp.forums.categories.edit');
+    Route::put('acp/forums/categories/{category}', [ForumCategoryController::class, 'update'])->name('acp.forums.categories.update');
+    Route::delete('acp/forums/categories/{category}', [ForumCategoryController::class, 'destroy'])->name('acp.forums.categories.destroy');
+    Route::patch('acp/forums/categories/{category}/reorder', [ForumCategoryController::class, 'reorder'])->name('acp.forums.categories.reorder');
+
+    Route::get('acp/forums/boards/create', [ForumBoardController::class, 'create'])->name('acp.forums.boards.create');
+    Route::post('acp/forums/boards', [ForumBoardController::class, 'store'])->name('acp.forums.boards.store');
+    Route::get('acp/forums/boards/{board}/edit', [ForumBoardController::class, 'edit'])->name('acp.forums.boards.edit');
+    Route::put('acp/forums/boards/{board}', [ForumBoardController::class, 'update'])->name('acp.forums.boards.update');
+    Route::delete('acp/forums/boards/{board}', [ForumBoardController::class, 'destroy'])->name('acp.forums.boards.destroy');
+    Route::patch('acp/forums/boards/{board}/reorder', [ForumBoardController::class, 'reorder'])->name('acp.forums.boards.reorder');
 
     // Support ACP
     Route::get('acp/support', [SupportController::class,'index'])->name('acp.support.index');


### PR DESCRIPTION
## Summary
- add dedicated admin controllers, routes, and request validation to manage forum categories and boards with proper permissions
- feed real forum data and ordering actions into the ACP listing while reworking the Vue page from placeholders to functional controls
- introduce Inertia forms for creating and editing forum categories and boards that reuse the new backend endpoints

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db3b28cf4c832ca2ccc26185573148