### PR TITLE
Fix missing Layers icon import in forums ACP

### DIFF
--- a/resources/js/pages/acp/Forums.vue
+++ b/resources/js/pages/acp/Forums.vue
@@ -7,7 +7,7 @@ import { Head, Link, router } from '@inertiajs/vue3';
 import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
 import {
     Folder, MessageSquare, CheckCircle, Ellipsis, EyeOff, Shield,
-    Trash2, MoveUp, MoveDown, Pencil, MessageSquareShare, Lock
+    Trash2, MoveUp, MoveDown, Pencil, MessageSquareShare, Lock, Layers
 } from 'lucide-vue-next';
 import Button from '@/components/ui/button/Button.vue';
 import {


### PR DESCRIPTION
## Summary
- import the missing Layers icon used by the forums ACP stats mapping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db46fc9a00832c906859f91f090dc2