### PR TITLE
Fix ACP forum board actions using slug binding

### DIFF
--- a/routes/admin.php
+++ b/routes/admin.php
@@ -55,10 +55,10 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
 
     Route::get('acp/forums/boards/create', [ForumBoardController::class, 'create'])->name('acp.forums.boards.create');
     Route::post('acp/forums/boards', [ForumBoardController::class, 'store'])->name('acp.forums.boards.store');
-    Route::get('acp/forums/boards/{board}/edit', [ForumBoardController::class, 'edit'])->name('acp.forums.boards.edit');
-    Route::put('acp/forums/boards/{board}', [ForumBoardController::class, 'update'])->name('acp.forums.boards.update');
-    Route::delete('acp/forums/boards/{board}', [ForumBoardController::class, 'destroy'])->name('acp.forums.boards.destroy');
-    Route::patch('acp/forums/boards/{board}/reorder', [ForumBoardController::class, 'reorder'])->name('acp.forums.boards.reorder');
+    Route::get('acp/forums/boards/{board:id}/edit', [ForumBoardController::class, 'edit'])->name('acp.forums.boards.edit');
+    Route::put('acp/forums/boards/{board:id}', [ForumBoardController::class, 'update'])->name('acp.forums.boards.update');
+    Route::delete('acp/forums/boards/{board:id}', [ForumBoardController::class, 'destroy'])->name('acp.forums.boards.destroy');
+    Route::patch('acp/forums/boards/{board:id}/reorder', [ForumBoardController::class, 'reorder'])->name('acp.forums.boards.reorder');
 
     // Support ACP
     Route::get('acp/support', [SupportController::class,'index'])->name('acp.support.index');


### PR DESCRIPTION
## Summary
- update ACP forum board routes to bind by id to match admin UI expectations
- ensure edit, reorder, and delete actions resolve correctly when using board IDs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db49d7c6d4832c8cea145834ae9e72