### PR TITLE
Add admin blog archive workflow

### DIFF
--- a/app/Http/Controllers/Admin/BlogController.php
+++ b/app/Http/Controllers/Admin/BlogController.php
@@ -167,4 +167,34 @@ class BlogController extends Controller
 
         return redirect()->back()->with('success', 'Blog post moved back to draft.');
     }
+
+    /**
+     * Archive the specified blog post.
+     */
+    public function archive(Blog $blog): RedirectResponse
+    {
+        if ($blog->status !== 'archived') {
+            $blog->forceFill([
+                'status' => 'archived',
+                'published_at' => null,
+            ])->save();
+        }
+
+        return redirect()->back()->with('success', 'Blog post archived successfully.');
+    }
+
+    /**
+     * Restore an archived blog post back to draft state.
+     */
+    public function unarchive(Blog $blog): RedirectResponse
+    {
+        if ($blog->status === 'archived') {
+            $blog->forceFill([
+                'status' => 'draft',
+                'published_at' => null,
+            ])->save();
+        }
+
+        return redirect()->back()->with('success', 'Blog post unarchived successfully.');
+    }
 }

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+    'ssr' => [
+        'enabled' => false,
+        'url' => null,
+    ],
+
+    'title' => null,
+
+    'root_view' => 'app',
+
+    'page_paths' => [
+        resource_path('js/pages'),
+        resource_path('js/Pages'),
+    ],
+
+    'testing' => [
+        'ensure_pages_exist' => true,
+    ],
+];

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -10,12 +10,12 @@ return [
 
     'root_view' => 'app',
 
-    'page_paths' => [
-        resource_path('js/pages'),
-        resource_path('js/Pages'),
-    ],
-
     'testing' => [
         'ensure_pages_exist' => true,
+        'page_paths' => [
+            resource_path('js/pages'),
+            resource_path('js/Pages'),
+        ],
+        'page_extensions' => ['js', 'jsx', 'ts', 'tsx', 'vue'],
     ],
 ];

--- a/database/factories/BlogFactory.php
+++ b/database/factories/BlogFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Blog;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Blog>
+ */
+class BlogFactory extends Factory
+{
+    protected $model = Blog::class;
+
+    public function definition(): array
+    {
+        $title = $this->faker->sentence(6);
+
+        return [
+            'title' => $title,
+            'slug' => Str::slug($title) . '-' . Str::random(5),
+            'excerpt' => $this->faker->paragraph(),
+            'body' => $this->faker->paragraphs(3, true),
+            'user_id' => User::factory(),
+            'status' => 'draft',
+            'published_at' => null,
+        ];
+    }
+
+    public function published(): self
+    {
+        return $this->state(function () {
+            return [
+                'status' => 'published',
+                'published_at' => now(),
+            ];
+        });
+    }
+
+    public function archived(): self
+    {
+        return $this->state(fn () => [
+            'status' => 'archived',
+            'published_at' => null,
+        ]);
+    }
+}

--- a/resources/js/pages/acp/Blogs.vue
+++ b/resources/js/pages/acp/Blogs.vue
@@ -144,6 +144,22 @@ const unpublishPost = (postId: number) => {
     });
 };
 
+const archivePost = (postId: number) => {
+    if (!confirm('Are you sure you want to archive this blog post? It will be hidden from the public.')) {
+        return;
+    }
+
+    router.put(route('acp.blogs.archive', { blog: postId }), {}, {
+        preserveScroll: true,
+    });
+};
+
+const unarchivePost = (postId: number) => {
+    router.put(route('acp.blogs.unarchive', { blog: postId }), {}, {
+        preserveScroll: true,
+    });
+};
+
 const deletePost = (postId: number) => {
     router.delete(route('acp.blogs.destroy', { blog: postId }), {
         preserveScroll: true,
@@ -238,11 +254,17 @@ const deletePost = (postId: number) => {
                                                         <EyeOff class="mr-2" />
                                                         <span>Unpublish</span>
                                                     </DropdownMenuItem>
-                                                    <DropdownMenuItem v-if="post.status === 'archived'">
+                                                    <DropdownMenuItem
+                                                        v-if="post.status === 'archived'"
+                                                        @click="unarchivePost(post.id)"
+                                                    >
                                                         <ArchiveRestore class="mr-2" />
-                                                        <span>Un Archive</span>
+                                                        <span>Unarchive</span>
                                                     </DropdownMenuItem>
-                                                    <DropdownMenuItem v-if="post.status !== 'archived'">
+                                                    <DropdownMenuItem
+                                                        v-if="post.status !== 'archived'"
+                                                        @click="archivePost(post.id)"
+                                                    >
                                                         <Archive class="mr-2" />
                                                         <span>Archive</span>
                                                     </DropdownMenuItem>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -44,6 +44,8 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
     Route::delete('acp/blogs/{blog}', [AdminBlogController::class, 'destroy'])->name('acp.blogs.destroy');
     Route::put('acp/blogs/{blog}/publish', [AdminBlogController::class, 'publish'])->name('acp.blogs.publish');
     Route::put('acp/blogs/{blog}/unpublish', [AdminBlogController::class, 'unpublish'])->name('acp.blogs.unpublish');
+    Route::put('acp/blogs/{blog}/archive', [AdminBlogController::class, 'archive'])->name('acp.blogs.archive');
+    Route::put('acp/blogs/{blog}/unarchive', [AdminBlogController::class, 'unarchive'])->name('acp.blogs.unarchive');
 
     Route::get('acp/forums', [ForumCategoryController::class, 'index'])->name('acp.forums.index');
     Route::get('acp/forums/categories/create', [ForumCategoryController::class, 'create'])->name('acp.forums.categories.create');

--- a/tests/Feature/Blog/BlogArchivingTest.php
+++ b/tests/Feature/Blog/BlogArchivingTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature\Blog;
+
+use App\Models\Blog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class BlogArchivingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingAsAdmin(): User
+    {
+        $user = User::factory()->create();
+        $role = Role::create(['name' => 'admin']);
+        $user->assignRole($role);
+
+        $this->actingAs($user);
+
+        return $user;
+    }
+
+    public function test_admin_can_archive_a_blog_post(): void
+    {
+        $user = $this->actingAsAdmin();
+        $blog = Blog::factory()->published()->for($user)->create();
+
+        $response = $this->from(route('acp.blogs.index'))
+            ->put(route('acp.blogs.archive', $blog));
+
+        $response->assertRedirect(route('acp.blogs.index'));
+
+        $blog->refresh();
+
+        $this->assertSame('archived', $blog->status);
+        $this->assertNull($blog->published_at);
+    }
+
+    public function test_admin_can_unarchive_a_blog_post(): void
+    {
+        $user = $this->actingAsAdmin();
+        $blog = Blog::factory()->archived()->for($user)->create();
+
+        $response = $this->from(route('acp.blogs.index'))
+            ->put(route('acp.blogs.unarchive', $blog));
+
+        $response->assertRedirect(route('acp.blogs.index'));
+
+        $blog->refresh();
+
+        $this->assertSame('draft', $blog->status);
+        $this->assertNull($blog->published_at);
+    }
+
+    public function test_archived_posts_do_not_appear_in_public_listing(): void
+    {
+        $publishedBlog = Blog::factory()->published()->create(['title' => 'Visible Post']);
+        Blog::factory()->archived()->create(['title' => 'Hidden Post']);
+
+        $response = $this->get(route('blogs.index'));
+
+        $response->assertStatus(200);
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('Blog')
+            ->where('blogs.data', fn ($data) => collect($data)->pluck('id')->contains($publishedBlog->id))
+            ->where('blogs.data', fn ($data) => !collect($data)->pluck('title')->contains('Hidden Post'))
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add archive and unarchive routes and controller actions for admin blogs
- connect the admin archive menu items to the new endpoints
- introduce a blog factory and feature coverage to keep archived posts out of public listings

## Testing
- php artisan test --filter=BlogArchivingTest *(fails: composer install requires GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db5a9bcdfc832cba1c55862a594cc6