### PR TITLE
Implement admin token revoke and edit workflow

### DIFF
--- a/app/Http/Requests/Admin/UpdateTokenRequest.php
+++ b/app/Http/Requests/Admin/UpdateTokenRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateTokenRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('tokens.acp.edit');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'abilities' => ['nullable', 'array'],
+            'abilities.*' => ['string', 'max:255'],
+            'expires_at' => ['nullable', 'date'],
+            'clear_revocation' => ['sometimes', 'boolean'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'expires_at' => $this->input('expires_at') ?: null,
+            'clear_revocation' => $this->boolean('clear_revocation'),
+        ]);
+    }
+}

--- a/app/Models/PersonalAccessToken.php
+++ b/app/Models/PersonalAccessToken.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Laravel\Sanctum\PersonalAccessToken as SanctumPersonalAccessToken;
+
+class PersonalAccessToken extends SanctumPersonalAccessToken
+{
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'abilities' => 'array',
+        'last_used_at' => 'datetime',
+        'expires_at' => 'datetime',
+        'revoked_at' => 'datetime',
+    ];
+}

--- a/app/Models/TokenLog.php
+++ b/app/Models/TokenLog.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Laravel\Sanctum\PersonalAccessToken;
 
 class TokenLog extends Model
 {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace App\Providers;
 
+use App\Models\PersonalAccessToken;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Sanctum\Sanctum;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -27,5 +29,7 @@ class AppServiceProvider extends ServiceProvider
             //force DB timestamps to use 'UTC' timezone for more accurate dayjs conversion to local timezones
             DB::statement("SET time_zone = '+00:00'");
         }
+
+        Sanctum::usePersonalAccessTokenModel(PersonalAccessToken::class);
     }
 }

--- a/database/migrations/2025_05_02_120100_add_revoked_at_to_personal_access_tokens_table.php
+++ b/database/migrations/2025_05_02_120100_add_revoked_at_to_personal_access_tokens_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\\Database\\Migrations\\Migration;
-use Illuminate\\Database\\Schema\\Blueprint;
-use Illuminate\\Support\\Facades\\Schema;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {

--- a/database/migrations/2025_05_02_120100_add_revoked_at_to_personal_access_tokens_table.php
+++ b/database/migrations/2025_05_02_120100_add_revoked_at_to_personal_access_tokens_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table) {
+            $table->timestamp('revoked_at')->nullable()->after('expires_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table) {
+            $table->dropColumn('revoked_at');
+        });
+    }
+};

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -83,6 +83,8 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
     // Tokens
     Route::get('acp/tokens', [TokenController::class,'index'])->name('acp.tokens.index');
     Route::post('acp/tokens', [TokenController::class,'store'])->name('acp.tokens.store');
+    Route::put('acp/tokens/{token}', [TokenController::class,'update'])->name('acp.tokens.update');
+    Route::patch('acp/tokens/{token}/revoke', [TokenController::class,'revoke'])->name('acp.tokens.revoke');
     Route::delete('acp/tokens/{token}', [TokenController::class,'destroy'])->name('acp.tokens.destroy');
 
     Route::get('acp/tokens/logs/{tokenLog}', [TokenController::class, 'showLog'])


### PR DESCRIPTION
## Summary
- add a nullable `revoked_at` column to personal access tokens and register a custom Sanctum model that casts it
- implement token update and revoke endpoints plus validation and routing updates
- wire up the admin tokens UI with an edit dialog and revoke action that call the new endpoints and refresh the table

## Testing
- php artisan test *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68db5acb79e0832cbfe3f219c90aaa62