### PR TITLE
Add ability for users to close their support tickets

### DIFF
--- a/app/Http/Controllers/SupportCenterController.php
+++ b/app/Http/Controllers/SupportCenterController.php
@@ -10,6 +10,7 @@ use App\Models\SupportTicket;
 use App\Models\SupportTicketMessage;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response as HttpResponse;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -194,5 +195,24 @@ class SupportCenterController extends Controller
         return redirect()
             ->route('support.tickets.show', $ticket)
             ->with('success', 'Your message has been sent.');
+    }
+
+    public function updateStatus(Request $request, SupportTicket $ticket): HttpResponse
+    {
+        $user = $request->user();
+
+        abort_unless($user && $ticket->user_id === $user->id, 403);
+
+        $validated = $request->validate([
+            'status' => ['required', 'in:closed'],
+        ]);
+
+        if ($ticket->status !== $validated['status']) {
+            $ticket->update([
+                'status' => $validated['status'],
+            ]);
+        }
+
+        return response()->noContent();
     }
 }

--- a/resources/js/pages/Support.vue
+++ b/resources/js/pages/Support.vue
@@ -193,6 +193,19 @@ const form = useForm({
 });
 
 const closingTicketId = ref<number | null>(null);
+const openTicketMenuId = ref<number | null>(null);
+
+const handleTicketMenuOpenChange = (ticketId: number, open: boolean) => {
+    if (open) {
+        openTicketMenuId.value = ticketId;
+
+        return;
+    }
+
+    if (openTicketMenuId.value === ticketId) {
+        openTicketMenuId.value = null;
+    }
+};
 
 const submitTicket = () => {
     form.post(route('support.tickets.store'), {
@@ -212,6 +225,7 @@ const closeTicket = (ticket: Ticket) => {
         return;
     }
 
+    openTicketMenuId.value = null;
     closingTicketId.value = ticket.id;
 
     router.patch(
@@ -232,6 +246,7 @@ const closeTicket = (ticket: Ticket) => {
             },
             onFinish: () => {
                 closingTicketId.value = null;
+                openTicketMenuId.value = null;
             },
         },
     );
@@ -433,7 +448,10 @@ watch(faqSearchQuery, () => {
                                         <TableCell class="text-center">{{ ticket.assignee?.nickname || '—' }}</TableCell>
                                         <TableCell class="text-center">{{ formatDate(ticket.created_at) }}</TableCell>
                                         <TableCell class="text-center">
-                                            <DropdownMenu>
+                                            <DropdownMenu
+                                                :open="openTicketMenuId === ticket.id"
+                                                @update:open="(open) => handleTicketMenuOpenChange(ticket.id, open)"
+                                            >
                                                 <DropdownMenuTrigger as-child @click.stop>
                                                     <Button variant="outline" size="icon">
                                                         <Ellipsis class="h-8 w-8" />

--- a/routes/web.php
+++ b/routes/web.php
@@ -84,6 +84,9 @@ Route::middleware('auth')->group(function () {
 
     Route::post('support/tickets/{ticket}/messages', [SupportCenterController::class, 'storeMessage'])
         ->name('support.tickets.messages.store');
+
+    Route::patch('support/tickets/{ticket}/status', [SupportCenterController::class, 'updateStatus'])
+        ->name('support.tickets.status');
 });
 
 //AUTH REQUIRED PAGES

--- a/tests/Feature/Support/SupportTicketStatusTest.php
+++ b/tests/Feature/Support/SupportTicketStatusTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature\Support;
+
+use App\Models\SupportTicket;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SupportTicketStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_close_own_ticket(): void
+    {
+        $user = User::factory()->create();
+
+        $ticket = SupportTicket::create([
+            'user_id' => $user->id,
+            'subject' => 'Issue resolved',
+            'body' => 'No longer need assistance.',
+            'status' => 'open',
+            'priority' => 'low',
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->patch(route('support.tickets.status', $ticket), [
+                'status' => 'closed',
+            ]);
+
+        $response->assertNoContent();
+        $this->assertSame('closed', $ticket->fresh()->status);
+    }
+
+    public function test_user_cannot_close_ticket_they_do_not_own(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $ticket = SupportTicket::create([
+            'user_id' => $otherUser->id,
+            'subject' => 'Need help',
+            'body' => 'Please assist.',
+            'status' => 'pending',
+            'priority' => 'medium',
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->patch(route('support.tickets.status', $ticket), [
+                'status' => 'closed',
+            ]);
+
+        $response->assertForbidden();
+        $this->assertSame('pending', $ticket->fresh()->status);
+    }
+}


### PR DESCRIPTION
## Summary
- add an authenticated PATCH route for updating a support ticket's status
- authorize ticket owners in the SupportCenterController and return a no-content response when closing tickets
- connect the Support page close action to the new endpoint with toast feedback and add feature tests covering the behaviour

## Testing
- php artisan test --filter=SupportTicketStatusTest *(fails: composer install requires GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db6fbbf714832ca47d5687ff11db68