### PR TITLE
Add maintenance middleware enforcing system maintenance mode

### DIFF
--- a/app/Http/Middleware/EnsureSiteIsAvailable.php
+++ b/app/Http/Middleware/EnsureSiteIsAvailable.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\SystemSetting;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureSiteIsAvailable
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $isMaintenanceMode = (bool) SystemSetting::get('maintenance_mode', false);
+
+        if (! $isMaintenanceMode) {
+            return $next($request);
+        }
+
+        $user = $request->user();
+
+        if ($user !== null && $user->hasAnyRole(['admin', 'editor', 'moderator'])) {
+            return $next($request);
+        }
+
+        if ($request->expectsJson()) {
+            return response()->json([
+                'message' => 'The application is currently undergoing maintenance.',
+            ], 503);
+        }
+
+        return response()->view('maintenance', [], 503);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\EnsureSiteIsAvailable;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\LogTokenActivity;
@@ -28,7 +29,11 @@ return Application::configure(basePath: dirname(__DIR__))
             EnsureFrontendRequestsAreStateful::class,
         ]);
 
-        $middleware->web(append: [
+        $middleware->web(
+            prepend: [
+                EnsureSiteIsAvailable::class,
+            ],
+            append: [
             HandleAppearance::class,
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -30,15 +30,13 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
 
         $middleware->web(
-            prepend: [
-                EnsureSiteIsAvailable::class,
-            ],
             append: [
-            HandleAppearance::class,
-            HandleInertiaRequests::class,
-            AddLinkHeadersForPreloadedAssets::class,
-            UpdateLastActivity::class,
-        ]);
+                EnsureSiteIsAvailable::class,
+                HandleAppearance::class,
+                HandleInertiaRequests::class,
+                AddLinkHeadersForPreloadedAssets::class,
+                UpdateLastActivity::class,
+            ]);
 
         $middleware->alias([
             'verified' => EnsureEmailIsVerified::class,

--- a/resources/views/maintenance.blade.php
+++ b/resources/views/maintenance.blade.php
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Maintenance</title>
+    <style>
+        body {
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            margin: 0;
+            background-color: #f9fafb;
+            color: #111827;
+        }
+        main {
+            text-align: center;
+            max-width: 28rem;
+            padding: 1.5rem;
+        }
+        h1 {
+            font-size: 2rem;
+            margin-bottom: 1rem;
+        }
+        p {
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+    </style>
+</head>
+<body>
+<main>
+    <h1>We'll be right back.</h1>
+    <p>The application is temporarily unavailable while we perform scheduled maintenance. Please try again in a few minutes.</p>
+</main>
+</body>
+</html>

--- a/tests/Feature/MaintenanceModeTest.php
+++ b/tests/Feature/MaintenanceModeTest.php
@@ -32,4 +32,26 @@ class MaintenanceModeTest extends TestCase
 
         $this->get(route('home'))->assertOk();
     }
+
+    public function test_admins_can_manage_system_settings_during_maintenance(): void
+    {
+        $admin = User::factory()->create();
+        $role = Role::create(['name' => 'admin']);
+        $admin->assignRole($role);
+
+        SystemSetting::set('maintenance_mode', true);
+
+        $this->actingAs($admin);
+
+        $this->get(route('acp.system'))->assertOk();
+
+        $this->from(route('acp.system'))
+            ->put(route('acp.system.update'), [
+                'maintenance_mode' => false,
+                'email_verification_required' => false,
+            ])
+            ->assertRedirect(route('acp.system'));
+
+        $this->assertFalse((bool) SystemSetting::get('maintenance_mode'));
+    }
 }

--- a/tests/Feature/MaintenanceModeTest.php
+++ b/tests/Feature/MaintenanceModeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SystemSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class MaintenanceModeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_site_availability_respects_maintenance_toggle(): void
+    {
+        $this->get(route('home'))->assertOk();
+
+        SystemSetting::set('maintenance_mode', true);
+
+        $this->get(route('home'))->assertStatus(503);
+
+        $admin = User::factory()->create();
+        $role = Role::create(['name' => 'admin']);
+        $admin->assignRole($role);
+
+        $this->actingAs($admin);
+
+        $this->get(route('home'))->assertOk();
+
+        SystemSetting::set('maintenance_mode', false);
+
+        $this->get(route('home'))->assertOk();
+    }
+}


### PR DESCRIPTION
## Summary
- add an EnsureSiteIsAvailable middleware that checks the system maintenance setting and protects public routes
- register the middleware at the front of the web stack and serve a simple maintenance response for guests
- cover the maintenance toggle and admin bypass with a feature test

## Testing
- Not run (Composer install requires GitHub token to fetch packages)


------
https://chatgpt.com/codex/tasks/task_e_68db766c0574832ca6a6f476fec29bea