### PR TITLE
Add assignable agent options to support overview

### DIFF
--- a/app/Http/Controllers/Admin/SupportController.php
+++ b/app/Http/Controllers/Admin/SupportController.php
@@ -84,6 +84,15 @@ class SupportController extends Controller
             'faqs' => $faqs->total(),
         ];
 
+        $assignableAgents = User::orderBy('nickname')
+            ->get(['id', 'nickname', 'email'])
+            ->map(fn (User $agent) => [
+                'id' => $agent->id,
+                'nickname' => $agent->nickname,
+                'email' => $agent->email,
+            ])
+            ->all();
+
         return Inertia::render('acp/Support', [
             'tickets' => array_merge([
                 'data' => $ticketItems,
@@ -92,6 +101,7 @@ class SupportController extends Controller
                 'data' => $faqItems,
             ], $this->inertiaPagination($faqs)),
             'supportStats' => $stats,
+            'assignableAgents' => $assignableAgents,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- include a lightweight list of assignable agents in the support index payload
- update the ticket assignment dialog to use the shared agent list via a dropdown selector
- simplify assignment submission by sending nullable agent IDs without manual parsing

## Testing
- npm run lint *(fails: existing unused import in resources/js/pages/acp/Forums.vue)*

------
https://chatgpt.com/codex/tasks/task_e_68db76473634832c93e069e15eaba572