### PR TITLE
Add dynamic email verification requirement

### DIFF
--- a/app/Http/Controllers/Admin/SystemSettingsController.php
+++ b/app/Http/Controllers/Admin/SystemSettingsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\SystemSetting;
+use App\Support\EmailVerification;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -19,10 +20,7 @@ class SystemSettingsController extends Controller
         return Inertia::render('acp/System', [
             'settings' => [
                 'maintenance_mode' => (bool) SystemSetting::get('maintenance_mode', false),
-                'email_verification_required' => (bool) SystemSetting::get(
-                    'email_verification_required',
-                    (bool) config('auth.must_verify_email', false)
-                ),
+                'email_verification_required' => EmailVerification::isRequired(),
             ],
             'diagnostics' => $this->diagnosticsPayload(),
         ]);

--- a/app/Http/Controllers/Settings/PasswordController.php
+++ b/app/Http/Controllers/Settings/PasswordController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Settings;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Support\EmailVerification;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
@@ -19,7 +19,7 @@ class PasswordController extends Controller
     public function edit(Request $request): Response
     {
         return Inertia::render('settings/Password', [
-            'mustVerifyEmail' => $request->user() instanceof MustVerifyEmail,
+            'mustVerifyEmail' => EmailVerification::isRequired(),
             'status' => $request->session()->get('status'),
         ]);
     }

--- a/app/Http/Controllers/Settings/ProfileController.php
+++ b/app/Http/Controllers/Settings/ProfileController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Settings;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\ProfileUpdateRequest;
-use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Support\EmailVerification;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -19,7 +19,7 @@ class ProfileController extends Controller
     public function edit(Request $request): Response
     {
         return Inertia::render('settings/Profile', [
-            'mustVerifyEmail' => $request->user() instanceof MustVerifyEmail,
+            'mustVerifyEmail' => EmailVerification::isRequired(),
             'status' => $request->session()->get('status'),
         ]);
     }

--- a/app/Http/Middleware/EnsureEmailIsVerifiedIfRequired.php
+++ b/app/Http/Middleware/EnsureEmailIsVerifiedIfRequired.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Support\EmailVerification;
+use Closure;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Redirect;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureEmailIsVerifiedIfRequired
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next, ?string $redirectToRoute = null): Response
+    {
+        if (! EmailVerification::isRequired()) {
+            return $next($request);
+        }
+
+        $user = $request->user();
+
+        if (! $user || ($this->requiresVerification($user) && ! $this->hasVerifiedEmail($user))) {
+            return $request->expectsJson()
+                ? abort(Response::HTTP_FORBIDDEN, 'Your email address is not verified.')
+                : Redirect::guest($this->redirectTo($request, $redirectToRoute));
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Determine if the given user should be considered for verification.
+     */
+    protected function requiresVerification(object $user): bool
+    {
+        if ($user instanceof MustVerifyEmail) {
+            return true;
+        }
+
+        return property_exists($user, 'email_verified_at') || method_exists($user, 'getAttribute');
+    }
+
+    /**
+     * Determine if the given user has a verified email address.
+     */
+    protected function hasVerifiedEmail(object $user): bool
+    {
+        if (method_exists($user, 'hasVerifiedEmail')) {
+            return (bool) $user->hasVerifiedEmail();
+        }
+
+        $emailVerifiedAt = null;
+
+        if (method_exists($user, 'getAttribute')) {
+            $emailVerifiedAt = $user->getAttribute('email_verified_at');
+        } elseif (property_exists($user, 'email_verified_at')) {
+            $emailVerifiedAt = $user->email_verified_at;
+        }
+
+        return ! is_null($emailVerifiedAt);
+    }
+
+    /**
+     * Get the path the user should be redirected to when verification is required.
+     */
+    protected function redirectTo(Request $request, ?string $route): string
+    {
+        return $route ? route($route) : route('verification.notice');
+    }
+}

--- a/app/Http/Middleware/EnsureEmailIsVerifiedIfRequired.php
+++ b/app/Http/Middleware/EnsureEmailIsVerifiedIfRequired.php
@@ -4,12 +4,11 @@ namespace App\Http\Middleware;
 
 use App\Support\EmailVerification;
 use Closure;
-use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Auth\Middleware\EnsureEmailIsVerified as BaseMiddleware;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Redirect;
 use Symfony\Component\HttpFoundation\Response;
 
-class EnsureEmailIsVerifiedIfRequired
+class EnsureEmailIsVerifiedIfRequired extends BaseMiddleware
 {
     /**
      * Handle an incoming request.
@@ -20,54 +19,6 @@ class EnsureEmailIsVerifiedIfRequired
             return $next($request);
         }
 
-        $user = $request->user();
-
-        if (! $user || ($this->requiresVerification($user) && ! $this->hasVerifiedEmail($user))) {
-            return $request->expectsJson()
-                ? abort(Response::HTTP_FORBIDDEN, 'Your email address is not verified.')
-                : Redirect::guest($this->redirectTo($request, $redirectToRoute));
-        }
-
-        return $next($request);
-    }
-
-    /**
-     * Determine if the given user should be considered for verification.
-     */
-    protected function requiresVerification(object $user): bool
-    {
-        if ($user instanceof MustVerifyEmail) {
-            return true;
-        }
-
-        return property_exists($user, 'email_verified_at') || method_exists($user, 'getAttribute');
-    }
-
-    /**
-     * Determine if the given user has a verified email address.
-     */
-    protected function hasVerifiedEmail(object $user): bool
-    {
-        if (method_exists($user, 'hasVerifiedEmail')) {
-            return (bool) $user->hasVerifiedEmail();
-        }
-
-        $emailVerifiedAt = null;
-
-        if (method_exists($user, 'getAttribute')) {
-            $emailVerifiedAt = $user->getAttribute('email_verified_at');
-        } elseif (property_exists($user, 'email_verified_at')) {
-            $emailVerifiedAt = $user->email_verified_at;
-        }
-
-        return ! is_null($emailVerifiedAt);
-    }
-
-    /**
-     * Get the path the user should be redirected to when verification is required.
-     */
-    protected function redirectTo(Request $request, ?string $route): string
-    {
-        return $route ? route($route) : route('verification.notice');
+        return parent::handle($request, $next, $redirectToRoute);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use Illuminate\Auth\MustVerifyEmail as MustVerifyEmailTrait;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -9,9 +11,9 @@ use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
 
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
-    use HasFactory, Notifiable, HasRoles, HasApiTokens;
+    use HasFactory, Notifiable, HasRoles, HasApiTokens, MustVerifyEmailTrait;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Support/EmailVerification.php
+++ b/app/Support/EmailVerification.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\SystemSetting;
+
+class EmailVerification
+{
+    /**
+     * Determine if email verification is required for user access.
+     */
+    public static function isRequired(): bool
+    {
+        return (bool) SystemSetting::get(
+            'email_verification_required',
+            (bool) config('auth.must_verify_email', false)
+        );
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\EnsureEmailIsVerifiedIfRequired;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\LogTokenActivity;
@@ -12,7 +13,6 @@ use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
 use Spatie\Permission\Middleware\PermissionMiddleware;
 use Spatie\Permission\Middleware\RoleMiddleware;
 use Spatie\Permission\Middleware\RoleOrPermissionMiddleware;
-use Illuminate\Auth\Middleware\EnsureEmailIsVerified;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -36,7 +36,7 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
 
         $middleware->alias([
-            'verified' => EnsureEmailIsVerified::class,
+            'verified' => EnsureEmailIsVerifiedIfRequired::class,
             'token.activity' => LogTokenActivity::class,
         ]);
 

--- a/config/auth.php
+++ b/config/auth.php
@@ -20,6 +20,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Email Verification Requirement
+    |--------------------------------------------------------------------------
+    |
+    | This option defines the default expectation for email verification when
+    | a setting has not been stored in the database. Administrators may toggle
+    | the requirement at runtime via the system settings panel.
+    |
+    */
+
+    'must_verify_email' => env('AUTH_MUST_VERIFY_EMAIL', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Authentication Guards
     |--------------------------------------------------------------------------
     |

--- a/tests/Feature/Auth/EmailVerificationRequirementTest.php
+++ b/tests/Feature/Auth/EmailVerificationRequirementTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\SystemSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EmailVerificationRequirementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_unverified_users_are_blocked_when_verification_is_required(): void
+    {
+        SystemSetting::set('email_verification_required', true);
+
+        $user = User::factory()->unverified()->create();
+
+        $response = $this->actingAs($user)->get('/dashboard');
+
+        $response->assertRedirect(route('verification.notice'));
+    }
+
+    public function test_unverified_users_can_access_when_verification_is_not_required(): void
+    {
+        SystemSetting::set('email_verification_required', false);
+
+        $user = User::factory()->unverified()->create();
+
+        $response = $this->actingAs($user)->get('/dashboard');
+
+        $response->assertOk();
+    }
+}


### PR DESCRIPTION
## Summary
- add an EmailVerification helper and middleware that honours the system setting for requiring verified emails
- update auth configuration and controllers to source the requirement dynamically with a config fallback
- add a feature test that covers toggling the setting and the resulting access control

## Testing
- composer install *(fails: GitHub API request returned 403 without token)*

------
https://chatgpt.com/codex/tasks/task_e_68db767a67b4832c9d278bd3279a316c