### PR TITLE
Add forum report moderation tools to ACP

### DIFF
--- a/app/Http/Controllers/Admin/ForumReportController.php
+++ b/app/Http/Controllers/Admin/ForumReportController.php
@@ -1,0 +1,322 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Concerns\InteractsWithInertiaPagination;
+use App\Http\Controllers\Controller;
+use App\Models\ForumBoard;
+use App\Models\ForumPostReport;
+use App\Models\ForumThreadReport;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ForumReportController extends Controller
+{
+    use InteractsWithInertiaPagination;
+
+    public function index(Request $request): Response
+    {
+        $reasons = config('forum.report_reasons', []);
+
+        $validated = $request->validate([
+            'type' => ['nullable', 'string', Rule::in(['all', 'thread', 'post'])],
+            'status' => ['nullable', 'string', Rule::in(array_merge(['all'], ForumThreadReport::STATUSES))],
+            'reason_category' => ['nullable', 'string', Rule::in(array_keys($reasons))],
+            'board_id' => ['nullable', 'integer', 'exists:forum_boards,id'],
+            'search' => ['nullable', 'string', 'max:100'],
+            'per_page' => ['nullable', 'integer', 'min:5', 'max:100'],
+        ]);
+
+        $type = $validated['type'] ?? 'all';
+        $status = $validated['status'] ?? ForumThreadReport::STATUS_PENDING;
+        $reasonCategory = $validated['reason_category'] ?? null;
+        $boardId = $validated['board_id'] ?? null;
+        $search = isset($validated['search']) ? trim((string) $validated['search']) : null;
+        $search = $search === '' ? null : $search;
+        $perPage = isset($validated['per_page']) ? (int) $validated['per_page'] : 25;
+        $perPage = max(5, min(100, $perPage));
+        $page = max(1, (int) $request->query('page', 1));
+
+        $threadQuery = ForumThreadReport::query()
+            ->with([
+                'thread:id,forum_board_id,title,slug,is_locked,is_published',
+                'thread.board:id,title,slug,forum_category_id',
+                'reporter:id,nickname,email',
+                'reviewer:id,nickname,email',
+            ])
+            ->whereHas('thread')
+            ->orderByDesc('created_at');
+
+        $postQuery = ForumPostReport::query()
+            ->with([
+                'post:id,forum_thread_id,user_id,body',
+                'post.thread:id,forum_board_id,title,slug,is_locked,is_published',
+                'post.thread.board:id,title,slug,forum_category_id',
+                'post.author:id,nickname,email',
+                'reporter:id,nickname,email',
+                'reviewer:id,nickname,email',
+            ])
+            ->whereHas('post')
+            ->orderByDesc('created_at');
+
+        if ($status !== 'all') {
+            $threadQuery->where('status', $status);
+            $postQuery->where('status', $status);
+        }
+
+        if ($reasonCategory !== null) {
+            $threadQuery->where('reason_category', $reasonCategory);
+            $postQuery->where('reason_category', $reasonCategory);
+        }
+
+        if ($boardId !== null) {
+            $threadQuery->whereHas('thread', function ($query) use ($boardId) {
+                $query->where('forum_board_id', $boardId);
+            });
+
+            $postQuery->whereHas('post.thread', function ($query) use ($boardId) {
+                $query->where('forum_board_id', $boardId);
+            });
+        }
+
+        if ($search !== null) {
+            $threadQuery->whereHas('thread', function ($query) use ($search) {
+                $query->where('title', 'like', "%{$search}%");
+            });
+
+            $postQuery->whereHas('post.thread', function ($query) use ($search) {
+                $query->where('title', 'like', "%{$search}%");
+            });
+        }
+
+        $reports = collect();
+
+        if ($type === 'all' || $type === 'thread') {
+            $reports = $reports->merge(
+                $threadQuery->get()->map(function (ForumThreadReport $report) {
+                    $thread = $report->thread;
+
+                    return [
+                        'id' => $report->id,
+                        'type' => 'thread',
+                        'status' => $report->status,
+                        'reason_category' => $report->reason_category,
+                        'reason' => $report->reason,
+                        'evidence_url' => $report->evidence_url,
+                        'created_at' => optional($report->created_at)->toIso8601String(),
+                        'reviewed_at' => optional($report->reviewed_at)->toIso8601String(),
+                        'reporter' => $report->reporter ? [
+                            'id' => $report->reporter->id,
+                            'nickname' => $report->reporter->nickname,
+                            'email' => $report->reporter->email,
+                        ] : null,
+                        'reviewer' => $report->reviewer ? [
+                            'id' => $report->reviewer->id,
+                            'nickname' => $report->reviewer->nickname,
+                            'email' => $report->reviewer->email,
+                        ] : null,
+                        'thread' => $thread ? [
+                            'id' => $thread->id,
+                            'title' => $thread->title,
+                            'slug' => $thread->slug,
+                            'is_locked' => (bool) $thread->is_locked,
+                            'is_published' => (bool) $thread->is_published,
+                            'board' => $thread->board ? [
+                                'id' => $thread->board->id,
+                                'title' => $thread->board->title,
+                                'slug' => $thread->board->slug,
+                            ] : null,
+                        ] : null,
+                    ];
+                })
+            );
+        }
+
+        if ($type === 'all' || $type === 'post') {
+            $reports = $reports->merge(
+                $postQuery->get()->map(function (ForumPostReport $report) {
+                    $post = $report->post;
+                    $thread = $post?->thread;
+
+                    return [
+                        'id' => $report->id,
+                        'type' => 'post',
+                        'status' => $report->status,
+                        'reason_category' => $report->reason_category,
+                        'reason' => $report->reason,
+                        'evidence_url' => $report->evidence_url,
+                        'created_at' => optional($report->created_at)->toIso8601String(),
+                        'reviewed_at' => optional($report->reviewed_at)->toIso8601String(),
+                        'reporter' => $report->reporter ? [
+                            'id' => $report->reporter->id,
+                            'nickname' => $report->reporter->nickname,
+                            'email' => $report->reporter->email,
+                        ] : null,
+                        'reviewer' => $report->reviewer ? [
+                            'id' => $report->reviewer->id,
+                            'nickname' => $report->reviewer->nickname,
+                            'email' => $report->reviewer->email,
+                        ] : null,
+                        'post' => $post ? [
+                            'id' => $post->id,
+                            'body_preview' => Str::limit(strip_tags($post->body), 160),
+                            'author' => $post->author ? [
+                                'id' => $post->author->id,
+                                'nickname' => $post->author->nickname,
+                                'email' => $post->author->email,
+                            ] : null,
+                        ] : null,
+                        'thread' => $thread ? [
+                            'id' => $thread->id,
+                            'title' => $thread->title,
+                            'slug' => $thread->slug,
+                            'is_locked' => (bool) $thread->is_locked,
+                            'is_published' => (bool) $thread->is_published,
+                            'board' => $thread->board ? [
+                                'id' => $thread->board->id,
+                                'title' => $thread->board->title,
+                                'slug' => $thread->board->slug,
+                            ] : null,
+                        ] : null,
+                    ];
+                })
+            );
+        }
+
+        $sortedReports = $reports
+            ->sortByDesc(function (array $report) {
+                return $report['created_at'] ?? '';
+            })
+            ->values();
+
+        $total = $sortedReports->count();
+        $sliced = $sortedReports->slice(($page - 1) * $perPage, $perPage)->values();
+
+        $paginator = new LengthAwarePaginator(
+            $sliced,
+            $total,
+            $perPage,
+            $page,
+            [
+                'path' => $request->url(),
+                'query' => $request->query(),
+            ]
+        );
+
+        $threadCounts = ForumThreadReport::query()
+            ->select('status', DB::raw('count(*) as aggregate'))
+            ->groupBy('status')
+            ->pluck('aggregate', 'status');
+
+        $postCounts = ForumPostReport::query()
+            ->select('status', DB::raw('count(*) as aggregate'))
+            ->groupBy('status')
+            ->pluck('aggregate', 'status');
+
+        $statusSummary = [];
+
+        foreach (ForumThreadReport::STATUSES as $statusKey) {
+            $threadCount = (int) ($threadCounts[$statusKey] ?? 0);
+            $postCount = (int) ($postCounts[$statusKey] ?? 0);
+
+            $statusSummary[$statusKey] = [
+                'threads' => $threadCount,
+                'posts' => $postCount,
+                'total' => $threadCount + $postCount,
+            ];
+        }
+
+        $boards = ForumBoard::query()
+            ->orderBy('title')
+            ->get(['id', 'title', 'slug']);
+
+        return Inertia::render('acp/ForumReports', [
+            'reports' => array_merge([
+                'data' => $sliced->all(),
+            ], $this->inertiaPagination($paginator)),
+            'filters' => [
+                'type' => $type,
+                'status' => $status,
+                'reason_category' => $reasonCategory,
+                'board_id' => $boardId,
+                'search' => $search,
+                'per_page' => $perPage,
+            ],
+            'reportReasons' => collect($reasons)
+                ->map(fn (array $reason, string $key) => [
+                    'value' => $key,
+                    'label' => $reason['label'] ?? Str::title(str_replace('_', ' ', $key)),
+                ])
+                ->values()
+                ->all(),
+            'boards' => $boards->map(fn (ForumBoard $board) => [
+                'id' => $board->id,
+                'title' => $board->title,
+                'slug' => $board->slug,
+            ])->all(),
+            'statusSummary' => $statusSummary,
+        ]);
+    }
+
+    public function updateThread(Request $request, ForumThreadReport $report): RedirectResponse
+    {
+        $validated = $request->validate([
+            'status' => ['required', 'string', Rule::in(ForumThreadReport::STATUSES)],
+            'moderation_action' => ['nullable', 'string', Rule::in(['none', 'lock_thread', 'unlock_thread', 'unpublish_thread', 'republish_thread'])],
+        ]);
+
+        $status = $validated['status'];
+        $moderationAction = $validated['moderation_action'] ?? 'none';
+        $moderationAction = $moderationAction === 'none' ? null : $moderationAction;
+
+        $report->forceFill([
+            'status' => $status,
+            'reviewed_at' => $status === ForumThreadReport::STATUS_PENDING ? null : now(),
+            'reviewed_by' => $status === ForumThreadReport::STATUS_PENDING ? null : optional($request->user())->id,
+        ])->save();
+
+        $thread = $report->thread;
+
+        if ($thread) {
+            match ($moderationAction) {
+                'lock_thread' => $thread->forceFill(['is_locked' => true])->save(),
+                'unlock_thread' => $thread->forceFill(['is_locked' => false])->save(),
+                'unpublish_thread' => $thread->forceFill(['is_published' => false])->save(),
+                'republish_thread' => $thread->forceFill(['is_published' => true])->save(),
+                default => null,
+            };
+        }
+
+        return back()->with('success', 'Thread report updated.');
+    }
+
+    public function updatePost(Request $request, ForumPostReport $report): RedirectResponse
+    {
+        $validated = $request->validate([
+            'status' => ['required', 'string', Rule::in(ForumPostReport::STATUSES)],
+            'moderation_action' => ['nullable', 'string', Rule::in(['none', 'delete_post'])],
+        ]);
+
+        $status = $validated['status'];
+        $moderationAction = $validated['moderation_action'] ?? 'none';
+        $moderationAction = $moderationAction === 'none' ? null : $moderationAction;
+
+        $report->forceFill([
+            'status' => $status,
+            'reviewed_at' => $status === ForumPostReport::STATUS_PENDING ? null : now(),
+            'reviewed_by' => $status === ForumPostReport::STATUS_PENDING ? null : optional($request->user())->id,
+        ])->save();
+
+        if ($moderationAction === 'delete_post') {
+            $report->post?->delete();
+        }
+
+        return back()->with('success', 'Post report updated.');
+    }
+}

--- a/app/Http/Controllers/ForumPostController.php
+++ b/app/Http/Controllers/ForumPostController.php
@@ -165,6 +165,9 @@ class ForumPostController extends Controller
                 'reason_category' => $validated['reason_category'],
                 'reason' => $reason,
                 'evidence_url' => $evidenceUrl,
+                'status' => ForumPostReport::STATUS_PENDING,
+                'reviewed_at' => null,
+                'reviewed_by' => null,
             ],
         );
 

--- a/app/Http/Controllers/ForumThreadActionController.php
+++ b/app/Http/Controllers/ForumThreadActionController.php
@@ -44,6 +44,9 @@ class ForumThreadActionController extends Controller
                 'reason_category' => $validated['reason_category'],
                 'reason' => $reason,
                 'evidence_url' => $evidenceUrl,
+                'status' => ForumThreadReport::STATUS_PENDING,
+                'reviewed_at' => null,
+                'reviewed_by' => null,
             ],
         );
 

--- a/app/Models/ForumPost.php
+++ b/app/Models/ForumPost.php
@@ -5,10 +5,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class ForumPost extends Model
 {
     use HasFactory;
+    use SoftDeletes;
 
     protected $fillable = [
         'forum_thread_id',

--- a/app/Models/ForumPostReport.php
+++ b/app/Models/ForumPostReport.php
@@ -37,7 +37,7 @@ class ForumPostReport extends Model
 
     public function post(): BelongsTo
     {
-        return $this->belongsTo(ForumPost::class, 'forum_post_id');
+        return $this->belongsTo(ForumPost::class, 'forum_post_id')->withTrashed();
     }
 
     public function reporter(): BelongsTo

--- a/app/Models/ForumPostReport.php
+++ b/app/Models/ForumPostReport.php
@@ -10,12 +10,29 @@ class ForumPostReport extends Model
 {
     use HasFactory;
 
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_REVIEWED = 'reviewed';
+    public const STATUS_DISMISSED = 'dismissed';
+
+    public const STATUSES = [
+        self::STATUS_PENDING,
+        self::STATUS_REVIEWED,
+        self::STATUS_DISMISSED,
+    ];
+
     protected $fillable = [
         'forum_post_id',
         'reporter_id',
         'reason_category',
         'reason',
         'evidence_url',
+        'status',
+        'reviewed_at',
+        'reviewed_by',
+    ];
+
+    protected $casts = [
+        'reviewed_at' => 'datetime',
     ];
 
     public function post(): BelongsTo
@@ -26,5 +43,10 @@ class ForumPostReport extends Model
     public function reporter(): BelongsTo
     {
         return $this->belongsTo(User::class, 'reporter_id');
+    }
+
+    public function reviewer(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'reviewed_by');
     }
 }

--- a/app/Models/ForumThreadReport.php
+++ b/app/Models/ForumThreadReport.php
@@ -10,12 +10,29 @@ class ForumThreadReport extends Model
 {
     use HasFactory;
 
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_REVIEWED = 'reviewed';
+    public const STATUS_DISMISSED = 'dismissed';
+
+    public const STATUSES = [
+        self::STATUS_PENDING,
+        self::STATUS_REVIEWED,
+        self::STATUS_DISMISSED,
+    ];
+
     protected $fillable = [
         'forum_thread_id',
         'reporter_id',
         'reason_category',
         'reason',
         'evidence_url',
+        'status',
+        'reviewed_at',
+        'reviewed_by',
+    ];
+
+    protected $casts = [
+        'reviewed_at' => 'datetime',
     ];
 
     public function thread(): BelongsTo
@@ -26,5 +43,10 @@ class ForumThreadReport extends Model
     public function reporter(): BelongsTo
     {
         return $this->belongsTo(User::class, 'reporter_id');
+    }
+
+    public function reviewer(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'reviewed_by');
     }
 }

--- a/database/migrations/2025_05_01_000900_add_status_columns_to_forum_reports_table.php
+++ b/database/migrations/2025_05_01_000900_add_status_columns_to_forum_reports_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\\Database\\Migrations\\Migration;
-use Illuminate\\Database\\Schema\\Blueprint;
-use Illuminate\\Support\\Facades\\Schema;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {

--- a/database/migrations/2025_05_01_000900_add_status_columns_to_forum_reports_table.php
+++ b/database/migrations/2025_05_01_000900_add_status_columns_to_forum_reports_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('forum_thread_reports', function (Blueprint $table) {
+            $table->string('status', 20)->default('pending')->after('evidence_url');
+            $table->timestamp('reviewed_at')->nullable()->after('status');
+            $table->foreignId('reviewed_by')->nullable()->after('reviewed_at')->constrained('users')->nullOnDelete();
+
+            $table->index(['status']);
+            $table->index(['reviewed_at']);
+        });
+
+        Schema::table('forum_post_reports', function (Blueprint $table) {
+            $table->string('status', 20)->default('pending')->after('evidence_url');
+            $table->timestamp('reviewed_at')->nullable()->after('status');
+            $table->foreignId('reviewed_by')->nullable()->after('reviewed_at')->constrained('users')->nullOnDelete();
+
+            $table->index(['status']);
+            $table->index(['reviewed_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('forum_thread_reports', function (Blueprint $table) {
+            $table->dropForeign(['reviewed_by']);
+            $table->dropColumn(['status', 'reviewed_at', 'reviewed_by']);
+        });
+
+        Schema::table('forum_post_reports', function (Blueprint $table) {
+            $table->dropForeign(['reviewed_by']);
+            $table->dropColumn(['status', 'reviewed_at', 'reviewed_by']);
+        });
+    }
+};

--- a/database/migrations/2025_05_01_001100_add_soft_deletes_to_forum_posts_table.php
+++ b/database/migrations/2025_05_01_001100_add_soft_deletes_to_forum_posts_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('forum_posts', function (Blueprint $table) {
+            if (!Schema::hasColumn('forum_posts', 'deleted_at')) {
+                $table->softDeletes()->after('edited_at');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('forum_posts', function (Blueprint $table) {
+            if (Schema::hasColumn('forum_posts', 'deleted_at')) {
+                $table->dropSoftDeletes();
+            }
+        });
+    }
+};

--- a/resources/js/layouts/acp/AdminLayout.vue
+++ b/resources/js/layouts/acp/AdminLayout.vue
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { type NavItem } from '@/types';
 import { Link, usePage } from '@inertiajs/vue3';
-import { LayoutGrid, User, Shield, BookOpen, MessageSquare, LifeBuoy, Settings, Key } from 'lucide-vue-next';
+import { LayoutGrid, User, Shield, BookOpen, MessageSquare, LifeBuoy, Settings, Key, ShieldAlert } from 'lucide-vue-next';
 
 import { useRoles } from '@/composables/useRoles';
 import { usePermissions } from '@/composables/usePermissions';
@@ -49,6 +49,11 @@ const sidebarNavItems: NavItem[] = [
         icon: MessageSquare,
     },
     {
+        title: 'Forum Reports',
+        href: '/acp/forums/reports',
+        icon: ShieldAlert,
+    },
+    {
         title: 'Support',
         href: '/acp/support',
         icon: LifeBuoy,
@@ -81,6 +86,8 @@ const filteredNavItems = computed(() => {
             case 'Blogs':
                 return manageBlogs.value;
             case 'Forums':
+                return manageForums.value;
+            case 'Forum Reports':
                 return manageForums.value;
             case 'Support':
                 return manageSupport.value;

--- a/resources/js/pages/acp/ForumReports.vue
+++ b/resources/js/pages/acp/ForumReports.vue
@@ -29,7 +29,14 @@ import {
     PaginationNext,
     PaginationPrev,
 } from '@/components/ui/pagination';
-import { ShieldAlert, ShieldCheck, ShieldX } from 'lucide-vue-next';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Ellipsis, ShieldAlert, ShieldCheck, ShieldX } from 'lucide-vue-next';
 
 const props = defineProps<{
     reports: {
@@ -459,7 +466,7 @@ const hasReports = computed(() => (props.reports.data?.length ?? 0) > 0);
                                             <TableHead class="w-40">Reason</TableHead>
                                             <TableHead class="w-40">Reporter</TableHead>
                                             <TableHead class="w-48">Submitted</TableHead>
-                                            <TableHead class="w-32 text-right">Actions</TableHead>
+                                            <TableHead class="w-16 text-right">Actions</TableHead>
                                         </TableRow>
                                     </TableHeader>
                                     <TableBody>
@@ -551,14 +558,24 @@ const hasReports = computed(() => (props.reports.data?.length ?? 0) > 0);
                                                 </div>
                                             </TableCell>
                                             <TableCell class="text-right">
-                                                <div class="flex justify-end gap-2">
-                                                    <Button size="sm" variant="outline" @click="openModerationDialog(report, 'reviewed')">
-                                                        Mark reviewed
-                                                    </Button>
-                                                    <Button size="sm" variant="ghost" @click="openModerationDialog(report, 'dismissed')">
-                                                        Dismiss
-                                                    </Button>
-                                                </div>
+                                                <DropdownMenu>
+                                                    <DropdownMenuTrigger as-child>
+                                                        <Button size="icon" variant="outline">
+                                                            <Ellipsis class="h-4 w-4" />
+                                                        </Button>
+                                                    </DropdownMenuTrigger>
+                                                    <DropdownMenuContent align="end">
+                                                        <DropdownMenuLabel>Report actions</DropdownMenuLabel>
+                                                        <DropdownMenuItem @select="openModerationDialog(report, 'reviewed')">
+                                                            <ShieldCheck class="h-4 w-4" />
+                                                            <span>Mark reviewed</span>
+                                                        </DropdownMenuItem>
+                                                        <DropdownMenuItem @select="openModerationDialog(report, 'dismissed')">
+                                                            <ShieldX class="h-4 w-4" />
+                                                            <span>Dismiss</span>
+                                                        </DropdownMenuItem>
+                                                    </DropdownMenuContent>
+                                                </DropdownMenu>
                                             </TableCell>
                                         </TableRow>
                                     </TableBody>

--- a/resources/js/pages/acp/ForumReports.vue
+++ b/resources/js/pages/acp/ForumReports.vue
@@ -464,8 +464,7 @@ const hasReports = computed(() => (props.reports.data?.length ?? 0) > 0);
                                             <TableHead class="w-32">Type</TableHead>
                                             <TableHead>Content</TableHead>
                                             <TableHead class="w-40">Reason</TableHead>
-                                            <TableHead class="w-40">Reporter</TableHead>
-                                            <TableHead class="w-48">Submitted</TableHead>
+                                            <TableHead class="w-48">Reporter</TableHead>
                                             <TableHead class="w-16 text-right">Actions</TableHead>
                                         </TableRow>
                                     </TableHeader>
@@ -541,19 +540,15 @@ const hasReports = computed(() => (props.reports.data?.length ?? 0) > 0);
                                                     <div v-if="report.reporter?.email" class="text-xs text-muted-foreground">
                                                         {{ report.reporter.email }}
                                                     </div>
-                                                    <div v-if="report.reviewer" class="text-xs text-muted-foreground">
-                                                        Reviewed by {{ report.reviewer.nickname }}
+                                                    <div v-if="report.created_at" class="text-xs text-muted-foreground">
+                                                        Submitted {{ fromNow(report.created_at) }}
                                                     </div>
-                                                </div>
-                                            </TableCell>
-                                            <TableCell>
-                                                <div class="space-y-1 text-sm">
-                                                    <div v-if="report.created_at">
-                                                        {{ fromNow(report.created_at) }}
-                                                    </div>
-                                                    <div v-else class="text-muted-foreground">Unknown</div>
+                                                    <div v-else class="text-xs text-muted-foreground">Submitted date unknown</div>
                                                     <div v-if="report.reviewed_at" class="text-xs text-muted-foreground">
                                                         Updated {{ fromNow(report.reviewed_at) }}
+                                                    </div>
+                                                    <div v-if="report.reviewer" class="text-xs text-muted-foreground">
+                                                        Reviewed by {{ report.reviewer.nickname }}
                                                     </div>
                                                 </div>
                                             </TableCell>

--- a/resources/js/pages/acp/ForumReports.vue
+++ b/resources/js/pages/acp/ForumReports.vue
@@ -224,7 +224,6 @@ const clearFilters = () => {
 
 const {
     meta: reportsMeta,
-    page: reportsPage,
     rangeLabel: reportsRangeLabel,
     setPage: setReportsPage,
 } = useInertiaPagination({

--- a/resources/js/pages/acp/ForumReports.vue
+++ b/resources/js/pages/acp/ForumReports.vue
@@ -1,0 +1,669 @@
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue';
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+import { type BreadcrumbItem } from '@/types';
+import { useUserTimezone } from '@/composables/useUserTimezone';
+import { useInertiaPagination, type PaginationMeta } from '@/composables/useInertiaPagination';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import Button from '@/components/ui/button/Button.vue';
+import Input from '@/components/ui/input/Input.vue';
+import { Label } from '@/components/ui/label';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
+    Pagination,
+    PaginationEllipsis,
+    PaginationFirst,
+    PaginationLast,
+    PaginationList,
+    PaginationListItem,
+    PaginationNext,
+    PaginationPrev,
+} from '@/components/ui/pagination';
+import { ShieldAlert, ShieldCheck, ShieldX } from 'lucide-vue-next';
+
+const props = defineProps<{
+    reports: {
+        data: Array<{
+            id: number;
+            type: 'thread' | 'post';
+            status: 'pending' | 'reviewed' | 'dismissed';
+            reason_category: string | null;
+            reason: string | null;
+            evidence_url: string | null;
+            created_at: string | null;
+            reviewed_at: string | null;
+            reporter: {
+                id: number;
+                nickname: string;
+                email: string;
+            } | null;
+            reviewer: {
+                id: number;
+                nickname: string;
+                email: string;
+            } | null;
+            thread: {
+                id: number;
+                title: string;
+                slug: string;
+                is_locked: boolean;
+                is_published: boolean;
+                board: {
+                    id: number;
+                    title: string;
+                    slug: string;
+                } | null;
+            } | null;
+            post?: {
+                id: number;
+                body_preview: string | null;
+                author: {
+                    id: number;
+                    nickname: string;
+                    email: string;
+                } | null;
+            } | null;
+        }>;
+        meta?: PaginationMeta | null;
+        links?: {
+            first: string | null;
+            last: string | null;
+            prev: string | null;
+            next: string | null;
+        } | null;
+    };
+    filters: {
+        type: string | null;
+        status: string | null;
+        reason_category: string | null;
+        board_id: number | null;
+        search: string | null;
+        per_page: number | null;
+    };
+    reportReasons: Array<{ value: string; label: string }>;
+    boards: Array<{ id: number; title: string; slug: string }>;
+    statusSummary: Record<string, { threads: number; posts: number; total: number }>;
+}>();
+
+type Report = (typeof props.reports.data)[number];
+
+type ModerationStatus = 'reviewed' | 'dismissed';
+
+type ModerationAction =
+    | 'none'
+    | 'lock_thread'
+    | 'unlock_thread'
+    | 'unpublish_thread'
+    | 'republish_thread'
+    | 'delete_post';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Admin Control Panel', href: '/acp/dashboard' },
+    { title: 'Forum Reports', href: '/acp/forums/reports' },
+];
+
+const quickVisitOptions = {
+    preserveScroll: true,
+    preserveState: true,
+    replace: true,
+} as const;
+
+const filterState = reactive({
+    type: 'all',
+    status: 'pending',
+    reason_category: '',
+    board_id: '',
+    search: '',
+    per_page: String(props.filters.per_page ?? 25),
+});
+
+watch(
+    () => props.filters,
+    (filters) => {
+        filterState.type = filters.type ?? 'all';
+        filterState.status = filters.status ?? 'pending';
+        filterState.reason_category = filters.reason_category ?? '';
+        filterState.board_id = filters.board_id ? String(filters.board_id) : '';
+        filterState.search = filters.search ?? '';
+        filterState.per_page = String(filters.per_page ?? 25);
+    },
+    { immediate: true },
+);
+
+const { fromNow } = useUserTimezone();
+
+const reasonLookup = computed<Record<string, string>>(() => {
+    const lookup: Record<string, string> = {};
+
+    for (const reason of props.reportReasons) {
+        lookup[reason.value] = reason.label;
+    }
+
+    return lookup;
+});
+
+const statusLabels: Record<Report['status'], string> = {
+    pending: 'Pending review',
+    reviewed: 'Reviewed',
+    dismissed: 'Dismissed',
+};
+
+const typeLabels: Record<Report['type'], string> = {
+    thread: 'Thread',
+    post: 'Post',
+};
+
+const statusIcons: Record<Report['status'], typeof ShieldAlert> = {
+    pending: ShieldAlert,
+    reviewed: ShieldCheck,
+    dismissed: ShieldX,
+};
+
+const statusSummary = computed(() => props.statusSummary ?? {});
+
+const pendingTotals = computed(() => statusSummary.value['pending'] ?? { threads: 0, posts: 0, total: 0 });
+const reviewedTotals = computed(() => statusSummary.value['reviewed'] ?? { threads: 0, posts: 0, total: 0 });
+const dismissedTotals = computed(() => statusSummary.value['dismissed'] ?? { threads: 0, posts: 0, total: 0 });
+
+const buildQuery = (overrides: Record<string, unknown> = {}) => {
+    const query: Record<string, unknown> = {
+        type: filterState.type,
+        status: filterState.status,
+        per_page: Number.parseInt(filterState.per_page, 10) || undefined,
+        ...overrides,
+    };
+
+    const reasonCategory = filterState.reason_category.trim();
+    if (reasonCategory !== '') {
+        query.reason_category = reasonCategory;
+    }
+
+    const boardId = filterState.board_id.trim();
+    if (boardId !== '') {
+        const parsed = Number.parseInt(boardId, 10);
+        if (!Number.isNaN(parsed)) {
+            query.board_id = parsed;
+        }
+    }
+
+    const search = filterState.search.trim();
+    if (search !== '') {
+        query.search = search;
+    }
+
+    return query;
+};
+
+const applyFilters = (overrides: Record<string, unknown> = {}) => {
+    router.get(
+        route('acp.forums.reports.index'),
+        buildQuery({ page: 1, ...overrides }),
+        quickVisitOptions,
+    );
+};
+
+const clearFilters = () => {
+    filterState.type = 'all';
+    filterState.status = 'pending';
+    filterState.reason_category = '';
+    filterState.board_id = '';
+    filterState.search = '';
+    filterState.per_page = '25';
+    applyFilters();
+};
+
+const {
+    meta: reportsMeta,
+    page: reportsPage,
+    rangeLabel: reportsRangeLabel,
+    setPage: setReportsPage,
+} = useInertiaPagination({
+    meta: computed(() => props.reports.meta ?? null),
+    itemsLength: computed(() => props.reports.data?.length ?? 0),
+    defaultPerPage: props.filters.per_page ?? 25,
+    itemLabel: 'report',
+    itemLabelPlural: 'reports',
+    onNavigate: (page) => {
+        router.get(
+            route('acp.forums.reports.index'),
+            buildQuery({ page }),
+            quickVisitOptions,
+        );
+    },
+});
+
+const moderationDialogOpen = ref(false);
+const moderationTarget = ref<Report | null>(null);
+const moderationStatus = ref<ModerationStatus>('reviewed');
+const moderationAction = ref<ModerationAction>('none');
+
+const closeModerationDialog = () => {
+    moderationDialogOpen.value = false;
+    moderationTarget.value = null;
+    moderationAction.value = 'none';
+};
+
+const openModerationDialog = (report: Report, status: ModerationStatus) => {
+    moderationTarget.value = report;
+    moderationStatus.value = status;
+    moderationAction.value = 'none';
+    moderationDialogOpen.value = true;
+};
+
+const moderationOptions = computed(() => {
+    if (!moderationTarget.value) {
+        return [] as Array<{ value: ModerationAction; label: string }>;
+    }
+
+    if (moderationTarget.value.type === 'thread') {
+        return [
+            { value: 'none', label: 'No additional action' },
+            { value: 'lock_thread', label: 'Lock thread' },
+            { value: 'unlock_thread', label: 'Unlock thread' },
+            { value: 'unpublish_thread', label: 'Unpublish thread' },
+            { value: 'republish_thread', label: 'Republish thread' },
+        ];
+    }
+
+    return [
+        { value: 'none', label: 'No additional action' },
+        { value: 'delete_post', label: 'Delete post' },
+    ];
+});
+
+const submitModeration = () => {
+    if (!moderationTarget.value) {
+        return;
+    }
+
+    const report = moderationTarget.value;
+    const routeName = report.type === 'thread'
+        ? 'acp.forums.reports.threads.update'
+        : 'acp.forums.reports.posts.update';
+
+    const payload: Record<string, unknown> = {
+        status: moderationStatus.value,
+    };
+
+    if (moderationAction.value !== 'none') {
+        payload.moderation_action = moderationAction.value;
+    }
+
+    router.patch(route(routeName, { report: report.id }), payload, {
+        preserveScroll: true,
+        preserveState: true,
+        onSuccess: () => closeModerationDialog(),
+        onFinish: () => {
+            moderationAction.value = 'none';
+        },
+    });
+};
+
+const statusOptions = computed(() => [
+    { value: 'pending', label: `Pending (${pendingTotals.value.total})` },
+    { value: 'reviewed', label: `Reviewed (${reviewedTotals.value.total})` },
+    { value: 'dismissed', label: `Dismissed (${dismissedTotals.value.total})` },
+    { value: 'all', label: 'All statuses' },
+]);
+
+const typeOptions = computed(() => [
+    { value: 'all', label: 'All content' },
+    { value: 'thread', label: `Threads (${pendingTotals.value.threads})` },
+    { value: 'post', label: `Posts (${pendingTotals.value.posts})` },
+]);
+
+const hasReports = computed(() => (props.reports.data?.length ?? 0) > 0);
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Forum Reports" />
+
+        <AdminLayout>
+            <div class="flex w-full flex-1 flex-col gap-6 pb-6">
+                <section class="rounded-xl border bg-background p-6 shadow-sm">
+                    <h1 class="text-2xl font-semibold">Forum moderation queue</h1>
+                    <p class="mt-2 max-w-3xl text-sm text-muted-foreground">
+                        Review reported threads and posts. Apply moderation actions as needed and mark reports once addressed.
+                    </p>
+
+                    <div class="mt-6 grid gap-4 md:grid-cols-3">
+                        <div class="rounded-lg border bg-muted/20 p-4">
+                            <div class="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+                                <ShieldAlert class="h-4 w-4" /> Pending
+                            </div>
+                            <div class="mt-2 text-2xl font-semibold">{{ pendingTotals.total }}</div>
+                            <p class="mt-1 text-xs text-muted-foreground">{{ pendingTotals.threads }} threads · {{ pendingTotals.posts }} posts</p>
+                        </div>
+                        <div class="rounded-lg border bg-muted/20 p-4">
+                            <div class="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+                                <ShieldCheck class="h-4 w-4" /> Reviewed
+                            </div>
+                            <div class="mt-2 text-2xl font-semibold">{{ reviewedTotals.total }}</div>
+                            <p class="mt-1 text-xs text-muted-foreground">{{ reviewedTotals.threads }} threads · {{ reviewedTotals.posts }} posts</p>
+                        </div>
+                        <div class="rounded-lg border bg-muted/20 p-4">
+                            <div class="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+                                <ShieldX class="h-4 w-4" /> Dismissed
+                            </div>
+                            <div class="mt-2 text-2xl font-semibold">{{ dismissedTotals.total }}</div>
+                            <p class="mt-1 text-xs text-muted-foreground">{{ dismissedTotals.threads }} threads · {{ dismissedTotals.posts }} posts</p>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="rounded-xl border bg-background p-6 shadow-sm">
+                    <div class="flex flex-col gap-6">
+                        <form class="grid gap-4 md:grid-cols-5" @submit.prevent="applyFilters">
+                            <div class="grid gap-2">
+                                <Label for="filter-type">Content</Label>
+                                <select
+                                    id="filter-type"
+                                    v-model="filterState.type"
+                                    class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                                >
+                                    <option v-for="option in typeOptions" :key="option.value" :value="option.value">
+                                        {{ option.label }}
+                                    </option>
+                                </select>
+                            </div>
+
+                            <div class="grid gap-2">
+                                <Label for="filter-status">Status</Label>
+                                <select
+                                    id="filter-status"
+                                    v-model="filterState.status"
+                                    class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                                >
+                                    <option v-for="option in statusOptions" :key="option.value" :value="option.value">
+                                        {{ option.label }}
+                                    </option>
+                                </select>
+                            </div>
+
+                            <div class="grid gap-2">
+                                <Label for="filter-reason">Reason</Label>
+                                <select
+                                    id="filter-reason"
+                                    v-model="filterState.reason_category"
+                                    class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                                >
+                                    <option value="">All reasons</option>
+                                    <option v-for="reason in props.reportReasons" :key="reason.value" :value="reason.value">
+                                        {{ reason.label }}
+                                    </option>
+                                </select>
+                            </div>
+
+                            <div class="grid gap-2">
+                                <Label for="filter-board">Board</Label>
+                                <select
+                                    id="filter-board"
+                                    v-model="filterState.board_id"
+                                    class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                                >
+                                    <option value="">All boards</option>
+                                    <option v-for="board in props.boards" :key="board.id" :value="String(board.id)">
+                                        {{ board.title }}
+                                    </option>
+                                </select>
+                            </div>
+
+                            <div class="grid gap-2">
+                                <Label for="filter-search">Search</Label>
+                                <Input
+                                    id="filter-search"
+                                    v-model="filterState.search"
+                                    type="search"
+                                    placeholder="Thread title keywords"
+                                    class="h-10"
+                                />
+                            </div>
+
+                            <div class="flex items-end gap-2 md:col-span-5">
+                                <Button type="submit" class="md:w-auto">Apply filters</Button>
+                                <Button type="button" variant="ghost" class="md:w-auto" @click="clearFilters">Reset</Button>
+                                <div class="ml-auto grid gap-1 text-sm text-muted-foreground">
+                                    <Label for="filter-per-page" class="text-xs">Per page</Label>
+                                    <select
+                                        id="filter-per-page"
+                                        v-model="filterState.per_page"
+                                        @change="applyFilters({ per_page: Number.parseInt(filterState.per_page, 10) || 25 })"
+                                        class="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                                    >
+                                        <option value="15">15</option>
+                                        <option value="25">25</option>
+                                        <option value="50">50</option>
+                                        <option value="100">100</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </form>
+
+                        <div v-if="hasReports" class="space-y-4">
+                            <div class="overflow-x-auto">
+                                <Table>
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead class="w-32">Type</TableHead>
+                                            <TableHead>Content</TableHead>
+                                            <TableHead class="w-40">Reason</TableHead>
+                                            <TableHead class="w-40">Reporter</TableHead>
+                                            <TableHead class="w-48">Submitted</TableHead>
+                                            <TableHead class="w-32 text-right">Actions</TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        <TableRow v-for="report in props.reports.data" :key="`${report.type}-${report.id}`" class="align-top">
+                                            <TableCell class="font-medium">
+                                                <div class="flex items-center gap-2">
+                                                    <component :is="statusIcons[report.status]" class="h-4 w-4" />
+                                                    <div class="space-y-1">
+                                                        <div>{{ typeLabels[report.type] }}</div>
+                                                        <div class="text-xs text-muted-foreground">{{ statusLabels[report.status] }}</div>
+                                                    </div>
+                                                </div>
+                                            </TableCell>
+                                            <TableCell>
+                                                <div class="space-y-2">
+                                                    <div v-if="report.thread" class="space-y-1">
+                                                        <div class="font-semibold">
+                                                            <Link
+                                                                v-if="report.thread.board?.slug"
+                                                                :href="route('forum.threads.show', {
+                                                                    board: report.thread.board.slug,
+                                                                    thread: report.thread.slug,
+                                                                })"
+                                                                class="hover:underline"
+                                                            >
+                                                                {{ report.thread.title }}
+                                                            </Link>
+                                                            <span v-else>{{ report.thread.title }}</span>
+                                                        </div>
+                                                        <div class="text-xs text-muted-foreground">
+                                                            <span v-if="report.thread.board">{{ report.thread.board.title }}</span>
+                                                            <span v-else>Board unavailable</span>
+                                                            ·
+                                                            <span v-if="!report.thread.is_published" class="text-amber-600">Unpublished</span>
+                                                            <span v-else-if="report.thread.is_locked" class="text-amber-600">Locked</span>
+                                                        </div>
+                                                    </div>
+                                                    <div v-else class="text-sm text-muted-foreground">Thread no longer available</div>
+
+                                                    <div v-if="report.type === 'post'" class="rounded-md border bg-muted/40 p-3 text-sm">
+                                                        <p class="font-medium text-muted-foreground">Post excerpt</p>
+                                                        <p class="mt-1 whitespace-pre-wrap text-muted-foreground">
+                                                            {{ report.post?.body_preview ?? 'Post deleted' }}
+                                                        </p>
+                                                    </div>
+
+                                                    <div v-if="report.reason" class="rounded-md border border-dashed border-muted bg-muted/20 p-2 text-xs text-muted-foreground">
+                                                        "{{ report.reason }}"
+                                                    </div>
+
+                                                    <div v-if="report.evidence_url" class="text-xs">
+                                                        <a :href="report.evidence_url" class="text-primary hover:underline" target="_blank" rel="noopener">Evidence link</a>
+                                                    </div>
+                                                </div>
+                                            </TableCell>
+                                            <TableCell>
+                                                <div class="space-y-1 text-sm">
+                                                    <div class="font-medium">
+                                                        {{ reasonLookup[report.reason_category ?? ''] ?? 'Not specified' }}
+                                                    </div>
+                                                    <div v-if="report.reason_category" class="text-xs text-muted-foreground">
+                                                        {{ report.reason_category }}
+                                                    </div>
+                                                </div>
+                                            </TableCell>
+                                            <TableCell>
+                                                <div class="space-y-1 text-sm">
+                                                    <div v-if="report.reporter">
+                                                        {{ report.reporter.nickname }}
+                                                    </div>
+                                                    <div v-else class="text-muted-foreground">Reporter removed</div>
+                                                    <div v-if="report.reporter?.email" class="text-xs text-muted-foreground">
+                                                        {{ report.reporter.email }}
+                                                    </div>
+                                                    <div v-if="report.reviewer" class="text-xs text-muted-foreground">
+                                                        Reviewed by {{ report.reviewer.nickname }}
+                                                    </div>
+                                                </div>
+                                            </TableCell>
+                                            <TableCell>
+                                                <div class="space-y-1 text-sm">
+                                                    <div v-if="report.created_at">
+                                                        {{ fromNow(report.created_at) }}
+                                                    </div>
+                                                    <div v-else class="text-muted-foreground">Unknown</div>
+                                                    <div v-if="report.reviewed_at" class="text-xs text-muted-foreground">
+                                                        Updated {{ fromNow(report.reviewed_at) }}
+                                                    </div>
+                                                </div>
+                                            </TableCell>
+                                            <TableCell class="text-right">
+                                                <div class="flex justify-end gap-2">
+                                                    <Button size="sm" variant="outline" @click="openModerationDialog(report, 'reviewed')">
+                                                        Mark reviewed
+                                                    </Button>
+                                                    <Button size="sm" variant="ghost" @click="openModerationDialog(report, 'dismissed')">
+                                                        Dismiss
+                                                    </Button>
+                                                </div>
+                                            </TableCell>
+                                        </TableRow>
+                                    </TableBody>
+                                </Table>
+                            </div>
+
+                            <div class="flex flex-col items-start gap-2 md:flex-row md:items-center md:justify-between">
+                                <p class="text-sm text-muted-foreground">{{ reportsRangeLabel }}</p>
+
+                                <Pagination v-if="reportsMeta.total > reportsMeta.per_page" class="w-full justify-end md:w-auto">
+                                    <PaginationList v-slot="{ items }" class="flex items-center gap-1">
+                                        <PaginationFirst
+                                            :href="props.reports.links?.first ?? undefined"
+                                            :disabled="reportsMeta.current_page === 1"
+                                            @click.prevent="setReportsPage(1)"
+                                        />
+                                        <PaginationPrev
+                                            :href="props.reports.links?.prev ?? undefined"
+                                            :disabled="reportsMeta.current_page === 1"
+                                            @click.prevent="setReportsPage(Math.max(reportsMeta.current_page - 1, 1))"
+                                        />
+                                        <template v-for="(item, index) in items" :key="index">
+                                            <PaginationListItem
+                                                v-if="item.type === 'page'"
+                                                :value="item.value"
+                                                :is-active="item.value === reportsMeta.current_page"
+                                                @click="setReportsPage(item.value)"
+                                            >
+                                                {{ item.value }}
+                                            </PaginationListItem>
+                                            <PaginationEllipsis v-else />
+                                        </template>
+                                        <PaginationNext
+                                            :href="props.reports.links?.next ?? undefined"
+                                            :disabled="reportsMeta.current_page >= reportsMeta.last_page"
+                                            @click.prevent="setReportsPage(Math.min(reportsMeta.current_page + 1, reportsMeta.last_page))"
+                                        />
+                                        <PaginationLast
+                                            :href="props.reports.links?.last ?? undefined"
+                                            :disabled="reportsMeta.current_page >= reportsMeta.last_page"
+                                            @click.prevent="setReportsPage(reportsMeta.last_page)"
+                                        />
+                                    </PaginationList>
+                                </Pagination>
+                            </div>
+                        </div>
+
+                        <div v-else class="rounded-lg border border-dashed bg-muted/30">
+                            <PlaceholderPattern class="rounded-lg">
+                                <div class="flex flex-col items-center justify-center gap-4 px-12 py-16 text-center">
+                                    <ShieldCheck class="h-12 w-12 text-muted-foreground" />
+                                    <div class="space-y-2">
+                                        <h2 class="text-lg font-semibold">No reports match your filters</h2>
+                                        <p class="text-sm text-muted-foreground">
+                                            Adjust the filters above or check back later to review new forum reports.
+                                        </p>
+                                    </div>
+                                    <Button variant="outline" @click="clearFilters">Reset filters</Button>
+                                </div>
+                            </PlaceholderPattern>
+                        </div>
+                    </div>
+                </section>
+            </div>
+        </AdminLayout>
+
+        <Dialog :open="moderationDialogOpen" @update:open="(open) => (open ? null : closeModerationDialog())">
+            <DialogContent class="sm:max-w-lg">
+                <DialogHeader>
+                    <DialogTitle>
+                        {{ moderationStatus === 'reviewed' ? 'Mark report as reviewed' : 'Dismiss report' }}
+                    </DialogTitle>
+                    <DialogDescription>
+                        Select an optional moderation action to apply before updating the report status.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div class="space-y-4">
+                    <div>
+                        <Label for="moderation-action">Moderation action</Label>
+                        <select
+                            id="moderation-action"
+                            v-model="moderationAction"
+                            class="mt-1 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                        >
+                            <option v-for="option in moderationOptions" :key="option.value" :value="option.value">
+                                {{ option.label }}
+                            </option>
+                        </select>
+                    </div>
+
+                    <div class="rounded-md border bg-muted/30 p-3 text-sm text-muted-foreground">
+                        <p v-if="moderationTarget?.thread" class="font-medium">{{ moderationTarget.thread.title }}</p>
+                        <p v-else>Associated content is no longer available.</p>
+                    </div>
+                </div>
+
+                <DialogFooter class="gap-2">
+                    <Button type="button" variant="ghost" @click="closeModerationDialog">Cancel</Button>
+                    <Button type="button" @click="submitModeration">
+                        {{ moderationStatus === 'reviewed' ? 'Mark as reviewed' : 'Dismiss report' }}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/ForumReports.vue
+++ b/resources/js/pages/acp/ForumReports.vue
@@ -461,21 +461,28 @@ const hasReports = computed(() => (props.reports.data?.length ?? 0) > 0);
                                 <Table>
                                     <TableHeader>
                                         <TableRow>
-                                            <TableHead class="w-32">Type</TableHead>
+                                            <TableHead class="w-40">Type & reason</TableHead>
                                             <TableHead>Content</TableHead>
-                                            <TableHead class="w-40">Reason</TableHead>
                                             <TableHead class="w-48">Reporter</TableHead>
                                             <TableHead class="w-16 text-right">Actions</TableHead>
                                         </TableRow>
                                     </TableHeader>
                                     <TableBody>
                                         <TableRow v-for="report in props.reports.data" :key="`${report.type}-${report.id}`" class="align-top">
-                                            <TableCell class="font-medium">
-                                                <div class="flex items-center gap-2">
-                                                    <component :is="statusIcons[report.status]" class="h-4 w-4" />
-                                                    <div class="space-y-1">
-                                                        <div>{{ typeLabels[report.type] }}</div>
-                                                        <div class="text-xs text-muted-foreground">{{ statusLabels[report.status] }}</div>
+                                            <TableCell>
+                                                <div class="space-y-2">
+                                                    <div class="flex items-center gap-2">
+                                                        <component :is="statusIcons[report.status]" class="h-4 w-4" />
+                                                        <div class="space-y-1">
+                                                            <div class="font-medium">{{ typeLabels[report.type] }}</div>
+                                                            <div class="text-xs text-muted-foreground">{{ statusLabels[report.status] }}</div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="rounded-md bg-muted/30 px-2 py-1 text-xs">
+                                                        <div class="font-medium">{{ reasonLookup[report.reason_category ?? ''] ?? 'Not specified' }}</div>
+                                                        <div v-if="report.reason_category" class="text-muted-foreground">
+                                                            {{ report.reason_category }}
+                                                        </div>
                                                     </div>
                                                 </div>
                                             </TableCell>
@@ -518,16 +525,6 @@ const hasReports = computed(() => (props.reports.data?.length ?? 0) > 0);
 
                                                     <div v-if="report.evidence_url" class="text-xs">
                                                         <a :href="report.evidence_url" class="text-primary hover:underline" target="_blank" rel="noopener">Evidence link</a>
-                                                    </div>
-                                                </div>
-                                            </TableCell>
-                                            <TableCell>
-                                                <div class="space-y-1 text-sm">
-                                                    <div class="font-medium">
-                                                        {{ reasonLookup[report.reason_category ?? ''] ?? 'Not specified' }}
-                                                    </div>
-                                                    <div v-if="report.reason_category" class="text-xs text-muted-foreground">
-                                                        {{ report.reason_category }}
                                                     </div>
                                                 </div>
                                             </TableCell>

--- a/resources/js/pages/acp/Forums.vue
+++ b/resources/js/pages/acp/Forums.vue
@@ -7,7 +7,7 @@ import { Head, Link, router } from '@inertiajs/vue3';
 import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
 import {
     Folder, MessageSquare, CheckCircle, Ellipsis, EyeOff, Shield,
-    Trash2, MoveUp, MoveDown, Pencil, MessageSquareShare, Lock, Layers,
+    Trash2, MoveUp, MoveDown, Pencil, MessageSquareShare, Layers,
     PlusCircle
 } from 'lucide-vue-next';
 import Button from '@/components/ui/button/Button.vue';

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Admin\TokenController;
 use App\Http\Controllers\Admin\UsersController as AdminUserController;
 use App\Http\Controllers\Admin\ForumBoardController;
 use App\Http\Controllers\Admin\ForumCategoryController;
+use App\Http\Controllers\Admin\ForumReportController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -48,6 +49,9 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
     Route::put('acp/blogs/{blog}/unarchive', [AdminBlogController::class, 'unarchive'])->name('acp.blogs.unarchive');
 
     Route::get('acp/forums', [ForumCategoryController::class, 'index'])->name('acp.forums.index');
+    Route::get('acp/forums/reports', [ForumReportController::class, 'index'])->name('acp.forums.reports.index');
+    Route::patch('acp/forums/reports/threads/{report}', [ForumReportController::class, 'updateThread'])->name('acp.forums.reports.threads.update');
+    Route::patch('acp/forums/reports/posts/{report}', [ForumReportController::class, 'updatePost'])->name('acp.forums.reports.posts.update');
     Route::get('acp/forums/categories/create', [ForumCategoryController::class, 'create'])->name('acp.forums.categories.create');
     Route::post('acp/forums/categories', [ForumCategoryController::class, 'store'])->name('acp.forums.categories.store');
     Route::get('acp/forums/categories/{category}/edit', [ForumCategoryController::class, 'edit'])->name('acp.forums.categories.edit');

--- a/tests/Feature/Admin/ForumReportsTest.php
+++ b/tests/Feature/Admin/ForumReportsTest.php
@@ -108,7 +108,7 @@ class ForumReportsTest extends TestCase
 
         $response->assertInertia(fn (Assert $page) => $page
             ->component('acp/ForumReports')
-            ->where('reports.data', function (array $reports) use ($threadReport, $postReport) {
+            ->where('reports.data', function ($reports) use ($threadReport, $postReport) {
                 $collection = collect($reports);
 
                 return $collection->contains(fn ($report) => $report['id'] === $threadReport->id && $report['type'] === 'thread')
@@ -133,7 +133,7 @@ class ForumReportsTest extends TestCase
 
         $response = $this->actingAs($moderator)
             ->from(route('acp.forums.reports.index'))
-            ->patch(route('acp.forums.reports.threads.update', $report), [
+            ->patch(route('acp.forums.reports.threads.update', ['report' => $report->id]), [
                 'status' => ForumThreadReport::STATUS_REVIEWED,
                 'moderation_action' => 'lock_thread',
             ]);
@@ -173,7 +173,7 @@ class ForumReportsTest extends TestCase
 
         $response = $this->actingAs($moderator)
             ->from(route('acp.forums.reports.index'))
-            ->patch(route('acp.forums.reports.posts.update', $report), [
+            ->patch(route('acp.forums.reports.posts.update', ['report' => $report->id]), [
                 'status' => ForumPostReport::STATUS_DISMISSED,
                 'moderation_action' => 'delete_post',
             ]);

--- a/tests/Feature/Admin/ForumReportsTest.php
+++ b/tests/Feature/Admin/ForumReportsTest.php
@@ -186,7 +186,7 @@ class ForumReportsTest extends TestCase
         $this->assertSame(ForumPostReport::STATUS_DISMISSED, $report->status);
         $this->assertNotNull($report->reviewed_at);
         $this->assertSame($moderator->id, $report->reviewed_by);
-        $this->assertDatabaseMissing('forum_posts', [
+        $this->assertSoftDeleted('forum_posts', [
             'id' => $post->id,
         ]);
     }

--- a/tests/Feature/Admin/ForumReportsTest.php
+++ b/tests/Feature/Admin/ForumReportsTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\ForumBoard;
+use App\Models\ForumCategory;
+use App\Models\ForumPost;
+use App\Models\ForumPostReport;
+use App\Models\ForumThread;
+use App\Models\ForumThreadReport;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Inertia\Testing\AssertableInertia as Assert;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class ForumReportsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Role::create(['name' => 'moderator', 'guard_name' => 'web']);
+        Permission::create(['name' => 'forums.acp.view', 'guard_name' => 'web']);
+    }
+
+    private function createModerator(): User
+    {
+        $user = User::factory()->create();
+
+        $role = Role::findByName('moderator');
+        $permission = Permission::findByName('forums.acp.view');
+
+        $role->givePermissionTo($permission);
+        $user->assignRole($role);
+
+        return $user;
+    }
+
+    private function seedForumHierarchy(User $author): ForumThread
+    {
+        $category = ForumCategory::create([
+            'title' => 'General Discussion',
+            'slug' => 'general-discussion',
+            'description' => 'Community chatter',
+            'position' => 1,
+        ]);
+
+        $board = ForumBoard::create([
+            'forum_category_id' => $category->id,
+            'title' => 'Announcements',
+            'slug' => 'announcements',
+            'description' => 'All announcements',
+            'position' => 1,
+        ]);
+
+        return ForumThread::create([
+            'forum_board_id' => $board->id,
+            'user_id' => $author->id,
+            'title' => 'Report me',
+            'slug' => Str::slug('Report me'),
+            'excerpt' => 'Thread under review',
+            'is_locked' => false,
+            'is_pinned' => false,
+            'is_published' => true,
+            'views' => 0,
+        ]);
+    }
+
+    public function test_moderator_can_view_pending_reports(): void
+    {
+        $moderator = $this->createModerator();
+        $reporter = User::factory()->create();
+        $postAuthor = User::factory()->create();
+
+        $thread = $this->seedForumHierarchy($postAuthor);
+
+        $post = ForumPost::create([
+            'forum_thread_id' => $thread->id,
+            'user_id' => $postAuthor->id,
+            'body' => 'This is a suspicious reply.',
+        ]);
+
+        $threadReport = ForumThreadReport::create([
+            'forum_thread_id' => $thread->id,
+            'reporter_id' => $reporter->id,
+            'reason_category' => 'spam',
+            'reason' => 'Looks like spam content.',
+            'status' => ForumThreadReport::STATUS_PENDING,
+        ]);
+
+        $postReport = ForumPostReport::create([
+            'forum_post_id' => $post->id,
+            'reporter_id' => $reporter->id,
+            'reason_category' => 'abuse',
+            'reason' => 'Contains hateful language.',
+            'status' => ForumPostReport::STATUS_PENDING,
+        ]);
+
+        $response = $this->actingAs($moderator)
+            ->get(route('acp.forums.reports.index'));
+
+        $response->assertStatus(200);
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('acp/ForumReports')
+            ->where('reports.data', function (array $reports) use ($threadReport, $postReport) {
+                $collection = collect($reports);
+
+                return $collection->contains(fn ($report) => $report['id'] === $threadReport->id && $report['type'] === 'thread')
+                    && $collection->contains(fn ($report) => $report['id'] === $postReport->id && $report['type'] === 'post');
+            })
+        );
+    }
+
+    public function test_moderator_can_review_thread_report_and_lock_thread(): void
+    {
+        $moderator = $this->createModerator();
+        $reporter = User::factory()->create();
+
+        $thread = $this->seedForumHierarchy($reporter);
+
+        $report = ForumThreadReport::create([
+            'forum_thread_id' => $thread->id,
+            'reporter_id' => $reporter->id,
+            'reason_category' => 'spam',
+            'status' => ForumThreadReport::STATUS_PENDING,
+        ]);
+
+        $response = $this->actingAs($moderator)
+            ->from(route('acp.forums.reports.index'))
+            ->patch(route('acp.forums.reports.threads.update', $report), [
+                'status' => ForumThreadReport::STATUS_REVIEWED,
+                'moderation_action' => 'lock_thread',
+            ]);
+
+        $response->assertRedirect(route('acp.forums.reports.index'));
+        $response->assertSessionHas('success', 'Thread report updated.');
+
+        $report->refresh();
+        $thread->refresh();
+
+        $this->assertSame(ForumThreadReport::STATUS_REVIEWED, $report->status);
+        $this->assertNotNull($report->reviewed_at);
+        $this->assertSame($moderator->id, $report->reviewed_by);
+        $this->assertTrue($thread->is_locked);
+    }
+
+    public function test_moderator_can_dismiss_post_report_and_delete_post(): void
+    {
+        $moderator = $this->createModerator();
+        $reporter = User::factory()->create();
+        $postAuthor = User::factory()->create();
+
+        $thread = $this->seedForumHierarchy($reporter);
+
+        $post = ForumPost::create([
+            'forum_thread_id' => $thread->id,
+            'user_id' => $postAuthor->id,
+            'body' => 'A questionable post needing review.',
+        ]);
+
+        $report = ForumPostReport::create([
+            'forum_post_id' => $post->id,
+            'reporter_id' => $reporter->id,
+            'reason_category' => 'abuse',
+            'status' => ForumPostReport::STATUS_PENDING,
+        ]);
+
+        $response = $this->actingAs($moderator)
+            ->from(route('acp.forums.reports.index'))
+            ->patch(route('acp.forums.reports.posts.update', $report), [
+                'status' => ForumPostReport::STATUS_DISMISSED,
+                'moderation_action' => 'delete_post',
+            ]);
+
+        $response->assertRedirect(route('acp.forums.reports.index'));
+        $response->assertSessionHas('success', 'Post report updated.');
+
+        $report->refresh();
+
+        $this->assertSame(ForumPostReport::STATUS_DISMISSED, $report->status);
+        $this->assertNotNull($report->reviewed_at);
+        $this->assertSame($moderator->id, $report->reviewed_by);
+        $this->assertDatabaseMissing('forum_posts', [
+            'id' => $post->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add an ACP forum reports view with filtering and moderation dialogs for thread and post reports
- add backend report status tracking plus moderator actions for reviewing or dismissing reports
- cover the workflow with feature tests and guard the new routes for moderator access

## Testing
- php artisan test *(fails: composer install requires GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db765ce404832c8de9c7101fb58032