### PR TITLE
Fix email verification middleware alias configuration

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -41,9 +41,6 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'verified' => EnsureEmailIsVerifiedIfRequired::class,
             'token.activity' => LogTokenActivity::class,
-        ]);
-
-        $middleware->alias([
             'role' => RoleMiddleware::class,
             'permission' => PermissionMiddleware::class,
             'role_or_permission' => RoleOrPermissionMiddleware::class,


### PR DESCRIPTION
## Summary
- ensure the custom verified middleware alias is registered alongside other aliases to respect the email verification setting

## Testing
- not run (environment network restrictions prevented installing Composer dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68dc47ca4f40832ca9ac72c3b85562db