### PR TITLE
Add attachment support to support ticket conversations

### DIFF
--- a/app/Http/Requests/StorePublicSupportTicketMessageRequest.php
+++ b/app/Http/Requests/StorePublicSupportTicketMessageRequest.php
@@ -20,6 +20,12 @@ class StorePublicSupportTicketMessageRequest extends FormRequest
     {
         return [
             'body' => ['required', 'string', 'min:3', 'max:5000'],
+            'attachments' => ['nullable', 'array', 'max:5'],
+            'attachments.*' => [
+                'file',
+                'max:10240',
+                'mimetypes:image/jpeg,image/png,image/gif,image/webp,application/pdf,text/plain,text/csv,application/zip,application/json,application/x-ndjson,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            ],
         ];
     }
 }

--- a/app/Models/SupportTicketMessage.php
+++ b/app/Models/SupportTicketMessage.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class SupportTicketMessage extends Model
 {
@@ -21,5 +22,10 @@ class SupportTicketMessage extends Model
     public function author(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function attachments(): HasMany
+    {
+        return $this->hasMany(SupportTicketMessageAttachment::class);
     }
 }

--- a/app/Models/SupportTicketMessageAttachment.php
+++ b/app/Models/SupportTicketMessageAttachment.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SupportTicketMessageAttachment extends Model
+{
+    protected $fillable = [
+        'support_ticket_message_id',
+        'disk',
+        'path',
+        'name',
+        'mime_type',
+        'size',
+    ];
+
+    protected $casts = [
+        'size' => 'integer',
+    ];
+
+    public function message(): BelongsTo
+    {
+        return $this->belongsTo(SupportTicketMessage::class, 'support_ticket_message_id');
+    }
+}

--- a/database/migrations/2025_05_05_000000_create_support_ticket_message_attachments_table.php
+++ b/database/migrations/2025_05_05_000000_create_support_ticket_message_attachments_table.php
@@ -9,8 +9,10 @@ return new class extends Migration {
     {
         Schema::create('support_ticket_message_attachments', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('support_ticket_message_id')
-                ->constrained()
+            $table->foreignId('support_ticket_message_id');
+            $table->foreign('support_ticket_message_id', 'st_msg_attachment_message_fk')
+                ->references('id')
+                ->on('support_ticket_messages')
                 ->cascadeOnDelete();
             $table->string('disk');
             $table->string('path');

--- a/database/migrations/2025_05_05_000000_create_support_ticket_message_attachments_table.php
+++ b/database/migrations/2025_05_05_000000_create_support_ticket_message_attachments_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('support_ticket_message_attachments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('support_ticket_message_id')
+                ->constrained()
+                ->cascadeOnDelete();
+            $table->string('disk');
+            $table->string('path');
+            $table->string('name');
+            $table->string('mime_type')->nullable();
+            $table->unsignedBigInteger('size')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('support_ticket_message_attachments');
+    }
+};


### PR DESCRIPTION
## Summary
- create a dedicated attachments table and model for support ticket messages
- validate and persist uploaded files when users reply to a ticket
- update the support ticket view to upload, preview, and list downloadable attachments in the conversation

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc49bd6578832cb7eec5337a4286cf