### PR TITLE
Fix EnsureEmailIsVerifiedIfRequired handle signature compatibility

### DIFF
--- a/app/Http/Middleware/EnsureEmailIsVerifiedIfRequired.php
+++ b/app/Http/Middleware/EnsureEmailIsVerifiedIfRequired.php
@@ -5,15 +5,13 @@ namespace App\Http\Middleware;
 use App\Support\EmailVerification;
 use Closure;
 use Illuminate\Auth\Middleware\EnsureEmailIsVerified as BaseMiddleware;
-use Illuminate\Http\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 class EnsureEmailIsVerifiedIfRequired extends BaseMiddleware
 {
     /**
      * Handle an incoming request.
      */
-    public function handle(Request $request, Closure $next, ?string $redirectToRoute = null): Response
+    public function handle($request, Closure $next, $redirectToRoute = null)
     {
         if (! EmailVerification::isRequired()) {
             return $next($request);


### PR DESCRIPTION
## Summary
- update EnsureEmailIsVerifiedIfRequired::handle signature to match the parent middleware
- remove strict request/response type hints that caused the runtime fatal error

## Testing
- ./vendor/bin/phpunit *(fails: binary missing because Composer dependencies could not be installed without GitHub credentials)*
- composer install *(fails: requires GitHub token for package downloads in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc49595e94832c989b00711698061e