### PR TITLE
Show API token secret after creation

### DIFF
--- a/app/Http/Controllers/Admin/TokenController.php
+++ b/app/Http/Controllers/Admin/TokenController.php
@@ -110,14 +110,15 @@ class TokenController extends Controller
 
         $user = User::findOrFail($data['user_id']);
 
-        $user->createToken(
+        $newToken = $user->createToken(
             $data['name'],
             $data['abilities'] ?? ['*'],
             $data['expires_at'] ? Carbon::parse($data['expires_at']) : null
         );
 
         return redirect()->route('acp.tokens.index')
-            ->with('success', 'Token created.');
+            ->with('success', 'Token created.')
+            ->with('plain_text_token', $newToken->plainTextToken);
     }
 
     /**

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -46,6 +46,11 @@ class HandleInertiaRequests extends Middleware
                 'message' => trim($message),
                 'author' => trim($author)
             ],
+            'flash' => [
+                'success' => $request->session()->get('success'),
+                'error' => $request->session()->get('error'),
+                'plain_text_token' => $request->session()->get('plain_text_token'),
+            ],
             'auth' => [
                 'user' => $request->user() ? $request->user()->load('roles') : null,
                 'permissions' => $request->user()


### PR DESCRIPTION
## Summary
- capture the new Sanctum token's plain-text secret when creating ACP tokens and flash it to the next request
- expose flash messages to the frontend so the ACP tokens page can display newly created secrets
- add an Inertia dialog that presents the token secret with copy-to-clipboard guidance after creation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc5c276250832c98900feb8b453ff3