### PR TITLE
Fix RichTextEditor class binding expression

### DIFF
--- a/resources/js/components/editor/RichTextEditor.vue
+++ b/resources/js/components/editor/RichTextEditor.vue
@@ -242,7 +242,7 @@ const toolbarButtonClass = (active: boolean) =>
 </script>
 
 <template>
-  <div :id="id" :class="cn('flex flex-col gap-2', class)">
+  <div :id="id" :class="cn('flex flex-col gap-2', props.class)">
     <div class="overflow-hidden rounded-lg border border-border bg-card">
       <div class="flex flex-wrap items-center gap-1 border-b border-border bg-muted/40 px-2 py-1">
         <div class="flex flex-wrap items-center gap-1">


### PR DESCRIPTION
## Summary
- update the RichTextEditor root container to reference the class prop via props.class
- resolve the Vite template parsing error caused by using the reserved word `class` in the binding expression

## Testing
- npm run build *(fails: missing vendor/tightenco/ziggy resource in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc7215f07c832c86f783b27ae7a1eb