### PR TITLE
Include ExternalLink icon in ACP forums action menu

### DIFF
--- a/resources/js/pages/acp/Forums.vue
+++ b/resources/js/pages/acp/Forums.vue
@@ -8,7 +8,7 @@ import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
 import {
     Folder, MessageSquare, CheckCircle, Ellipsis, EyeOff, Shield,
     Trash2, MoveUp, MoveDown, Pencil, MessageSquareShare, Layers,
-    PlusCircle
+    PlusCircle, ExternalLink
 } from 'lucide-vue-next';
 import Button from '@/components/ui/button/Button.vue';
 import {


### PR DESCRIPTION
## Summary
- add the missing ExternalLink icon to the ACP forums page to avoid console warnings when rendering the action menu

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dda292bcd8832cadb17468167c049c