### PR TITLE
Add FAQ management actions to support ACP

### DIFF
--- a/routes/admin.php
+++ b/routes/admin.php
@@ -85,6 +85,9 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
     Route::post('acp/support/faqs', [SupportController::class,'storeFaq'])->name('acp.support.faqs.store');
     Route::put('acp/support/faqs/{faq}', [SupportController::class,'updateFaq'])->name('acp.support.faqs.update');
     Route::delete('acp/support/faqs/{faq}', [SupportController::class,'destroyFaq'])->name('acp.support.faqs.destroy');
+    Route::patch('acp/support/faqs/{faq}/reorder', [SupportController::class,'reorderFaq'])->name('acp.support.faqs.reorder');
+    Route::patch('acp/support/faqs/{faq}/publish', [SupportController::class,'publishFaq'])->name('acp.support.faqs.publish');
+    Route::patch('acp/support/faqs/{faq}/unpublish', [SupportController::class,'unpublishFaq'])->name('acp.support.faqs.unpublish');
 
     Route::get('acp/system', [SystemSettingsController::class, 'index'])->name('acp.system');
     Route::put('acp/system', [SystemSettingsController::class, 'update'])->name('acp.system.update');


### PR DESCRIPTION
## Summary
- add admin routes for FAQ reorder and publish state management
- implement SupportController handlers for reordering and publishing FAQs with validation feedback
- wire the Support ACP FAQ actions to the new endpoints and surface toast notifications after each action

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dda80f04f4832cbbe8e72bb872d94c