### PR TITLE
Use dialogs for ACP forum moderation actions

### DIFF
--- a/app/Models/ForumCategory.php
+++ b/app/Models/ForumCategory.php
@@ -14,7 +14,13 @@ class ForumCategory extends Model
         'title',
         'slug',
         'description',
+        'access_permission',
+        'is_published',
         'position',
+    ];
+
+    protected $casts = [
+        'is_published' => 'boolean',
     ];
 
     public function boards(): HasMany

--- a/database/migrations/2025_05_01_001200_add_moderation_fields_to_forum_categories_table.php
+++ b/database/migrations/2025_05_01_001200_add_moderation_fields_to_forum_categories_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('forum_categories', function (Blueprint $table) {
+            if (!Schema::hasColumn('forum_categories', 'access_permission')) {
+                $table->string('access_permission')->nullable()->after('description');
+            }
+
+            if (!Schema::hasColumn('forum_categories', 'is_published')) {
+                $table->boolean('is_published')->default(true)->after('access_permission');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('forum_categories', function (Blueprint $table) {
+            if (Schema::hasColumn('forum_categories', 'is_published')) {
+                $table->dropColumn('is_published');
+            }
+
+            if (Schema::hasColumn('forum_categories', 'access_permission')) {
+                $table->dropColumn('access_permission');
+            }
+        });
+    }
+};

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -58,6 +58,10 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
     Route::put('acp/forums/categories/{category}', [ForumCategoryController::class, 'update'])->name('acp.forums.categories.update');
     Route::delete('acp/forums/categories/{category}', [ForumCategoryController::class, 'destroy'])->name('acp.forums.categories.destroy');
     Route::patch('acp/forums/categories/{category}/reorder', [ForumCategoryController::class, 'reorder'])->name('acp.forums.categories.reorder');
+    Route::patch('acp/forums/categories/{category}/permissions', [ForumCategoryController::class, 'updatePermissions'])->name('acp.forums.categories.permissions');
+    Route::patch('acp/forums/categories/{category}/publish', [ForumCategoryController::class, 'publish'])->name('acp.forums.categories.publish');
+    Route::patch('acp/forums/categories/{category}/unpublish', [ForumCategoryController::class, 'unpublish'])->name('acp.forums.categories.unpublish');
+    Route::patch('acp/forums/categories/{category}/migrate', [ForumCategoryController::class, 'migrate'])->name('acp.forums.categories.migrate');
 
     Route::get('acp/forums/boards/create', [ForumBoardController::class, 'create'])->name('acp.forums.boards.create');
     Route::post('acp/forums/boards', [ForumBoardController::class, 'store'])->name('acp.forums.boards.store');


### PR DESCRIPTION
## Summary
- replace browser prompts on the ACP forums page with dedicated dialog components
- add reactive state and form handling for permission updates, migrations, and deletions
- provide better UX by disabling actions during requests and surfacing toast errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dda7d29858832cba60371f40dc7883