### PR TITLE
Add attachment uploads for new support tickets

### DIFF
--- a/app/Http/Requests/StorePublicSupportTicketRequest.php
+++ b/app/Http/Requests/StorePublicSupportTicketRequest.php
@@ -27,6 +27,12 @@ class StorePublicSupportTicketRequest extends FormRequest
             'body' => ['required', 'string'],
             'priority' => ['nullable', 'in:low,medium,high'],
             'user_id' => ['required', 'exists:users,id'],
+            'attachments' => ['nullable', 'array', 'max:5'],
+            'attachments.*' => [
+                'file',
+                'max:10240',
+                'mimetypes:image/jpeg,image/png,image/gif,image/webp,application/pdf,text/plain,text/csv,application/zip,application/json,application/x-ndjson,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            ],
         ];
     }
 }


### PR DESCRIPTION
## Summary
- add an attachment picker to the support ticket form that matches the ticket view UX
- validate and accept attachments when creating a support ticket on the backend
- persist uploaded files with the opening ticket message so they appear in the conversation

## Testing
- php artisan test *(fails: vendor/autoload.php missing because Composer dependencies require a GitHub token to install packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ddcdc29ee0832c8deff141edf043f3