### PR TITLE
Add customer satisfaction ratings for support tickets

### DIFF
--- a/app/Http/Requests/StorePublicSupportTicketRatingRequest.php
+++ b/app/Http/Requests/StorePublicSupportTicketRatingRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\SupportTicket;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+
+class StorePublicSupportTicketRatingRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $ticket = $this->route('ticket');
+
+        return $ticket instanceof SupportTicket
+            && $this->user()
+            && $ticket->user_id === $this->user()->id;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'rating' => ['required', 'integer', Rule::in([1, 2, 3, 4, 5])],
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            $ticket = $this->route('ticket');
+
+            if (! $ticket instanceof SupportTicket) {
+                return;
+            }
+
+            if ($ticket->status !== 'closed') {
+                $validator->errors()->add('rating', 'You can only rate a ticket after it has been closed.');
+            }
+
+            if ($ticket->customer_satisfaction_rating !== null) {
+                $validator->errors()->add('rating', 'This ticket has already been rated.');
+            }
+        });
+    }
+}

--- a/resources/js/pages/Support.vue
+++ b/resources/js/pages/Support.vue
@@ -48,6 +48,7 @@ interface Ticket {
     created_at: string | null;
     updated_at: string | null;
     assignee: TicketAssignee | null;
+    customer_satisfaction_rating: number | null;
 }
 
 interface FAQ {
@@ -359,6 +360,9 @@ const formatDate = (value: string | null) => {
     }).format(date);
 };
 
+const formatRating = (rating: number | null) =>
+    typeof rating === 'number' ? `${rating}/5` : '—';
+
 </script>
 
 <template>
@@ -460,6 +464,7 @@ const formatDate = (value: string | null) => {
                                         <TableHead class="text-center">Priority</TableHead>
                                         <TableHead class="text-center">Assigned</TableHead>
                                         <TableHead class="text-center">Created At</TableHead>
+                                        <TableHead class="text-center">Rating</TableHead>
                                         <TableHead class="text-center">Actions</TableHead>
                                     </TableRow>
                                 </TableHeader>
@@ -500,6 +505,7 @@ const formatDate = (value: string | null) => {
                                         </TableCell>
                                         <TableCell class="text-center">{{ ticket.assignee?.nickname || '—' }}</TableCell>
                                         <TableCell class="text-center">{{ formatDate(ticket.created_at) }}</TableCell>
+                                        <TableCell class="text-center">{{ formatRating(ticket.customer_satisfaction_rating) }}</TableCell>
                                         <TableCell class="text-center">
                                             <DropdownMenu>
                                                 <DropdownMenuTrigger as-child @click.stop>
@@ -525,7 +531,7 @@ const formatDate = (value: string | null) => {
                                         </TableCell>
                                     </TableRow>
                                     <TableRow v-if="ticketItems.length === 0">
-                                        <TableCell colspan="7" class="text-center text-sm text-gray-600 dark:text-gray-300">
+                                        <TableCell colspan="8" class="text-center text-sm text-gray-600 dark:text-gray-300">
                                             No tickets found.
                                         </TableCell>
                                     </TableRow>

--- a/routes/web.php
+++ b/routes/web.php
@@ -85,6 +85,9 @@ Route::middleware('auth')->group(function () {
 
     Route::post('support/tickets/{ticket}/messages', [SupportCenterController::class, 'storeMessage'])
         ->name('support.tickets.messages.store');
+
+    Route::post('support/tickets/{ticket}/rating', [SupportCenterController::class, 'storeRating'])
+        ->name('support.tickets.rating.store');
 });
 
 //AUTH REQUIRED PAGES

--- a/tests/Feature/Support/SupportTicketRatingTest.php
+++ b/tests/Feature/Support/SupportTicketRatingTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature\Support;
+
+use App\Models\SupportTicket;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SupportTicketRatingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ticket_owner_can_submit_rating_after_closure(): void
+    {
+        $user = User::factory()->create();
+
+        $ticket = SupportTicket::create([
+            'user_id' => $user->id,
+            'subject' => 'Resolved issue',
+            'body' => 'Thank you for fixing this.',
+            'status' => 'closed',
+            'priority' => 'medium',
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->post(route('support.tickets.rating.store', $ticket), [
+                'rating' => 5,
+            ]);
+
+        $response->assertRedirect(route('support.tickets.show', $ticket));
+        $response->assertSessionHas('success', 'Thanks for sharing your feedback.');
+
+        $this->assertSame(5, $ticket->fresh()->customer_satisfaction_rating);
+    }
+
+    public function test_ticket_owner_cannot_rate_before_closure(): void
+    {
+        $user = User::factory()->create();
+
+        $ticket = SupportTicket::create([
+            'user_id' => $user->id,
+            'subject' => 'Still open',
+            'body' => 'Waiting on resolution.',
+            'status' => 'open',
+            'priority' => 'medium',
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->from(route('support.tickets.show', $ticket))
+            ->post(route('support.tickets.rating.store', $ticket), [
+                'rating' => 4,
+            ]);
+
+        $response->assertRedirect(route('support.tickets.show', $ticket));
+        $response->assertSessionHasErrors('rating');
+
+        $this->assertNull($ticket->fresh()->customer_satisfaction_rating);
+    }
+
+    public function test_ticket_owner_cannot_rate_more_than_once(): void
+    {
+        $user = User::factory()->create();
+
+        $ticket = SupportTicket::create([
+            'user_id' => $user->id,
+            'subject' => 'Already rated',
+            'body' => 'Issue was resolved.',
+            'status' => 'closed',
+            'priority' => 'medium',
+            'customer_satisfaction_rating' => 3,
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->from(route('support.tickets.show', $ticket))
+            ->post(route('support.tickets.rating.store', $ticket), [
+                'rating' => 5,
+            ]);
+
+        $response->assertRedirect(route('support.tickets.show', $ticket));
+        $response->assertSessionHasErrors('rating');
+
+        $this->assertSame(3, $ticket->fresh()->customer_satisfaction_rating);
+    }
+
+    public function test_non_owner_cannot_submit_rating(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $ticket = SupportTicket::create([
+            'user_id' => $otherUser->id,
+            'subject' => 'Closed issue',
+            'body' => 'Resolved elsewhere.',
+            'status' => 'closed',
+            'priority' => 'low',
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->post(route('support.tickets.rating.store', $ticket), [
+                'rating' => 2,
+            ]);
+
+        $response->assertForbidden();
+        $this->assertNull($ticket->fresh()->customer_satisfaction_rating);
+    }
+}


### PR DESCRIPTION
## Summary
- add a customer satisfaction card to the support ticket view so requestors can rate closed tickets and see their existing score
- expose ticket ratings across the public support listing and controller payloads backed by a dedicated rating endpoint
- validate and persist ratings on the server and cover the flow with feature tests that guard against duplicates and unauthorized access

## Testing
- not run (composer install requires a GitHub token in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ddd36bf684832cbe23aac57c16d9c1