### PR TITLE
Add admin support ticket thread view and reply handling

### DIFF
--- a/app/Http/Requests/Admin/StoreSupportTicketMessageRequest.php
+++ b/app/Http/Requests/Admin/StoreSupportTicketMessageRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use App\Models\SupportTicket;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreSupportTicketMessageRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $ticket = $this->route('ticket');
+
+        return $ticket instanceof SupportTicket
+            && $this->user()
+            && $this->user()->can('support.acp.reply');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'body' => ['required', 'string', 'min:3', 'max:5000'],
+            'attachments' => ['nullable', 'array', 'max:5'],
+            'attachments.*' => [
+                'file',
+                'max:10240',
+                'mimetypes:image/jpeg,image/png,image/gif,image/webp,application/pdf,text/plain,text/csv,application/zip,application/json,application/x-ndjson,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            ],
+        ];
+    }
+}

--- a/resources/js/pages/acp/Support.vue
+++ b/resources/js/pages/acp/Support.vue
@@ -51,6 +51,7 @@ const { fromNow, formatDate } = useUserTimezone();
 
 // Permission checks
 const { hasPermission } = usePermissions();
+const viewSupport = computed(() => hasPermission('support.acp.view'));
 const createSupport = computed(() => hasPermission('support.acp.create'));
 const editSupport = computed(() => hasPermission('support.acp.edit'));
 const deleteSupport = computed(() => hasPermission('support.acp.delete'));
@@ -555,7 +556,20 @@ const unpublishFaq = (faq: FaqItem) => {
                                                     </DropdownMenuTrigger>
                                                     <DropdownMenuContent>
                                                         <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                                                        <DropdownMenuSeparator v-if="assignSupport||prioritySupport" />
+                                                        <DropdownMenuGroup v-if="viewSupport">
+                                                            <Link :href="route('acp.support.tickets.show', { ticket: t.id })">
+                                                                <DropdownMenuItem>
+                                                                    <Eye class="mr-2" /> View conversation
+                                                                </DropdownMenuItem>
+                                                            </Link>
+                                                        </DropdownMenuGroup>
+                                                        <DropdownMenuSeparator
+                                                            v-if="
+                                                                viewSupport &&
+                                                                (assignSupport || prioritySupport || editSupport || statusSupport || deleteSupport)
+                                                            "
+                                                        />
+                                                        <DropdownMenuSeparator v-else-if="assignSupport||prioritySupport" />
                                                         <DropdownMenuGroup v-if="assignSupport||prioritySupport">
                                                         <DropdownMenuItem
                                                             v-if="assignSupport"

--- a/resources/js/pages/acp/SupportTicketView.vue
+++ b/resources/js/pages/acp/SupportTicketView.vue
@@ -1,0 +1,401 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { Head, Link, useForm } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import Button from '@/components/ui/button/Button.vue';
+import { Textarea } from '@/components/ui/textarea';
+import InputError from '@/components/InputError.vue';
+import Input from '@/components/ui/input/Input.vue';
+import { Paperclip } from 'lucide-vue-next';
+import { useUserTimezone } from '@/composables/useUserTimezone';
+
+interface TicketParticipant {
+    id: number;
+    nickname: string;
+    email: string;
+}
+
+interface TicketMessageAttachment {
+    id: number;
+    name: string;
+    size: number;
+    download_url: string;
+}
+
+interface TicketMessage {
+    id: number;
+    body: string;
+    created_at: string | null;
+    author: TicketParticipant | null;
+    is_from_support: boolean;
+    attachments: TicketMessageAttachment[];
+}
+
+const props = defineProps<{
+    ticket: {
+        id: number;
+        subject: string;
+        body: string;
+        status: 'open' | 'pending' | 'closed';
+        priority: 'low' | 'medium' | 'high';
+        created_at: string | null;
+        updated_at: string | null;
+        resolved_at: string | null;
+        resolved_by: number | null;
+        assignee: TicketParticipant | null;
+        resolver: TicketParticipant | null;
+        user: TicketParticipant | null;
+    };
+    messages: TicketMessage[];
+    canReply: boolean;
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Support ACP', href: route('acp.support.index') },
+    { title: `Ticket #${props.ticket.id}`, href: route('acp.support.tickets.show', { ticket: props.ticket.id }) },
+];
+
+const statusLabel = computed(() => props.ticket.status.replace(/^[a-z]/, (s) => s.toUpperCase()));
+const priorityLabel = computed(() => props.ticket.priority.replace(/^[a-z]/, (s) => s.toUpperCase()));
+
+const statusClasses = computed(() => {
+    switch (props.ticket.status) {
+        case 'open':
+            return 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300';
+        case 'pending':
+            return 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300';
+        case 'closed':
+            return 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300';
+        default:
+            return 'bg-gray-100 text-gray-700 dark:bg-gray-900/40 dark:text-gray-300';
+    }
+});
+
+const priorityClasses = computed(() => {
+    switch (props.ticket.priority) {
+        case 'high':
+            return 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300';
+        case 'medium':
+            return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300';
+        case 'low':
+            return 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300';
+        default:
+            return 'bg-gray-100 text-gray-700 dark:bg-gray-900/40 dark:text-gray-300';
+    }
+});
+
+const { formatDate, fromNow } = useUserTimezone();
+
+const formattedCreatedAt = computed(() => formatDate(props.ticket.created_at));
+const formattedUpdatedAt = computed(() => formatDate(props.ticket.updated_at));
+const formattedResolvedAt = computed(() => formatDate(props.ticket.resolved_at));
+
+interface ReplyFormPayload {
+    body: string;
+    attachments: File[];
+}
+
+const replyForm = useForm<ReplyFormPayload>({
+    body: '',
+    attachments: [],
+});
+
+const attachmentInput = ref<HTMLInputElement | null>(null);
+
+const handleAttachmentsChange = (event: Event) => {
+    const target = event.target as HTMLInputElement;
+
+    replyForm.attachments = target.files ? Array.from(target.files) : [];
+};
+
+const attachmentErrors = computed(() => {
+    const errorEntries = Object.entries(replyForm.errors).filter(([key]) =>
+        key === 'attachments' || key.startsWith('attachments.'),
+    );
+
+    return errorEntries.length > 0 ? errorEntries[0][1] : '';
+});
+
+const resetAttachmentsInput = () => {
+    if (attachmentInput.value) {
+        attachmentInput.value.value = '';
+    }
+};
+
+const submitReply = () => {
+    if (!props.canReply) {
+        return;
+    }
+
+    replyForm.transform((data) => {
+        if (!data.attachments || data.attachments.length === 0) {
+            const payload = { ...data };
+            delete payload.attachments;
+
+            return payload;
+        }
+
+        return data;
+    });
+
+    replyForm.post(route('acp.support.tickets.messages.store', { ticket: props.ticket.id }), {
+        preserveScroll: true,
+        forceFormData: true,
+        onSuccess: () => {
+            replyForm.reset('body', 'attachments');
+            resetAttachmentsInput();
+        },
+        onFinish: () => {
+            replyForm.transform((data) => ({ ...data }));
+        },
+    });
+};
+
+const sortedMessages = computed(() => {
+    const messages = props.messages ?? [];
+
+    return [...messages].sort((a, b) => {
+        const aTime = a.created_at ? new Date(a.created_at).getTime() : 0;
+        const bTime = b.created_at ? new Date(b.created_at).getTime() : 0;
+
+        return aTime - bTime;
+    });
+});
+
+const resolveAuthorLabel = (message: TicketMessage) => {
+    if (!message.author) {
+        return message.is_from_support
+            ? 'Support Team'
+            : props.ticket.user?.nickname ?? props.ticket.user?.email ?? 'Requester';
+    }
+
+    if (message.is_from_support) {
+        return message.author.nickname ?? message.author.email ?? 'Support Team';
+    }
+
+    return message.author.nickname ?? message.author.email ?? 'Requester';
+};
+
+const messageTimestamp = (value: string | null) => {
+    if (!value) {
+        return '';
+    }
+
+    return `${formatDate(value)} · ${fromNow(value)}`;
+};
+
+const formatFileSize = (bytes: number) => {
+    if (!bytes) {
+        return '0 B';
+    }
+
+    const units = ['B', 'KB', 'MB', 'GB'];
+    const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+    const size = bytes / Math.pow(1024, exponent);
+
+    const formatted = size >= 10 || exponent === 0 ? size.toFixed(0) : size.toFixed(1);
+
+    return `${formatted} ${units[exponent]}`;
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head :title="`Ticket #${props.ticket.id}`" />
+
+        <AdminLayout>
+            <div class="flex flex-1 flex-col gap-6">
+                <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div>
+                        <p class="text-sm text-muted-foreground">Ticket #{{ props.ticket.id }}</p>
+                        <h1 class="text-3xl font-semibold tracking-tight">{{ props.ticket.subject }}</h1>
+                        <p class="mt-2 max-w-2xl text-sm text-muted-foreground">
+                            Review the full correspondence and keep the requester updated from the admin console.
+                        </p>
+                    </div>
+                    <div class="flex flex-wrap items-center gap-3">
+                        <span class="rounded-full px-3 py-1 text-xs font-medium" :class="statusClasses">
+                            Status: {{ statusLabel }}
+                        </span>
+                        <span class="rounded-full px-3 py-1 text-xs font-medium" :class="priorityClasses">
+                            Priority: {{ priorityLabel }}
+                        </span>
+                        <Button variant="outline" as-child>
+                            <Link :href="route('acp.support.index')">Back to Support</Link>
+                        </Button>
+                    </div>
+                </div>
+
+                <div class="grid gap-6 lg:grid-cols-[minmax(0,_2fr)_minmax(0,_1fr)]">
+                    <Card class="flex flex-col">
+                        <CardHeader>
+                            <CardTitle>Conversation</CardTitle>
+                            <CardDescription>Messages exchanged between staff and the requester.</CardDescription>
+                        </CardHeader>
+                        <CardContent class="flex flex-1 flex-col gap-6">
+                            <div class="flex flex-col gap-4">
+                                <div
+                                    v-for="message in sortedMessages"
+                                    :key="message.id"
+                                    class="flex flex-col gap-1"
+                                    :class="message.is_from_support ? 'items-end' : 'items-start'"
+                                >
+                                    <div
+                                        class="max-w-xl rounded-lg px-4 py-3 text-sm leading-relaxed shadow-sm"
+                                        :class="message.is_from_support
+                                            ? 'bg-primary text-primary-foreground'
+                                            : 'bg-background border'
+                                        "
+                                    >
+                                        <div class="mb-2 flex items-center justify-between text-xs font-semibold uppercase tracking-wide">
+                                            <span>{{ resolveAuthorLabel(message) }}</span>
+                                            <span class="opacity-75">{{ messageTimestamp(message.created_at) }}</span>
+                                        </div>
+                                        <p class="whitespace-pre-line">{{ message.body }}</p>
+                                        <div v-if="message.attachments.length" class="mt-3 flex flex-col gap-2">
+                                            <div class="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide opacity-80">
+                                                <Paperclip class="h-3 w-3" />
+                                                <span>Attachments</span>
+                                            </div>
+                                            <ul class="flex flex-col gap-1 text-xs">
+                                                <li v-for="attachment in message.attachments" :key="attachment.id">
+                                                    <a
+                                                        :href="attachment.download_url"
+                                                        target="_blank"
+                                                        rel="noopener"
+                                                        class="flex items-center gap-2 underline underline-offset-4"
+                                                        :class="message.is_from_support
+                                                            ? 'text-primary-foreground hover:text-primary-foreground/80'
+                                                            : 'text-primary hover:text-primary/80'
+                                                        "
+                                                    >
+                                                        <span class="truncate">{{ attachment.name }}</span>
+                                                        <span class="whitespace-nowrap text-[0.7rem] opacity-80">
+                                                            {{ formatFileSize(attachment.size) }}
+                                                        </span>
+                                                    </a>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <p v-if="sortedMessages.length === 0" class="text-sm text-muted-foreground">
+                                    There are no messages on this ticket yet.
+                                </p>
+                            </div>
+
+                            <form v-if="props.canReply" class="mt-4 flex flex-col gap-3" @submit.prevent="submitReply">
+                                <label for="message" class="text-sm font-medium">Post a staff reply</label>
+                                <Textarea
+                                    id="message"
+                                    v-model="replyForm.body"
+                                    placeholder="Share updates, next steps, or troubleshooting guidance..."
+                                    class="min-h-32"
+                                    :disabled="replyForm.processing"
+                                    required
+                                />
+                                <InputError :message="replyForm.errors.body" />
+                                <div class="flex flex-col gap-2">
+                                    <Input
+                                        ref="attachmentInput"
+                                        id="attachments"
+                                        type="file"
+                                        multiple
+                                        :disabled="replyForm.processing"
+                                        accept="image/*,application/pdf,text/plain,text/csv,application/zip,application/json,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/x-ndjson"
+                                        @change="handleAttachmentsChange"
+                                    />
+                                    <p class="text-xs text-muted-foreground">
+                                        Attach relevant diagnostics or screenshots (up to 5 files, 10&nbsp;MB each).
+                                    </p>
+                                    <ul v-if="replyForm.attachments.length" class="flex flex-wrap gap-2 text-xs">
+                                        <li
+                                            v-for="file in replyForm.attachments"
+                                            :key="`${file.name}-${file.lastModified}`"
+                                            class="flex items-center gap-2 rounded-md border border-dashed border-muted bg-muted/40 px-2 py-1"
+                                        >
+                                            <Paperclip class="h-3 w-3" />
+                                            <span class="max-w-[10rem] truncate">{{ file.name }}</span>
+                                            <span class="text-muted-foreground">{{ formatFileSize(file.size) }}</span>
+                                        </li>
+                                    </ul>
+                                    <InputError :message="attachmentErrors" />
+                                </div>
+                                <div class="flex justify-end">
+                                    <Button type="submit" :disabled="replyForm.processing">
+                                        Send reply
+                                    </Button>
+                                </div>
+                            </form>
+
+                            <p v-else class="text-sm text-muted-foreground">
+                                Replies are disabled either because the ticket is closed or you lack reply permissions.
+                            </p>
+                        </CardContent>
+                    </Card>
+
+                    <div class="flex flex-col gap-6">
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Ticket details</CardTitle>
+                                <CardDescription>Key context for staff triage.</CardDescription>
+                            </CardHeader>
+                            <CardContent class="space-y-4 text-sm">
+                                <div>
+                                    <p class="text-xs uppercase text-muted-foreground">Requester</p>
+                                    <p class="font-medium text-foreground">
+                                        {{ props.ticket.user?.nickname ?? props.ticket.user?.email ?? 'Unknown user' }}
+                                    </p>
+                                    <p class="text-muted-foreground">{{ props.ticket.user?.email ?? '—' }}</p>
+                                </div>
+                                <div>
+                                    <p class="text-xs uppercase text-muted-foreground">Assigned agent</p>
+                                    <p class="font-medium text-foreground">
+                                        {{ props.ticket.assignee?.nickname ?? 'Unassigned' }}
+                                    </p>
+                                    <p class="text-muted-foreground">{{ props.ticket.assignee?.email ?? '—' }}</p>
+                                </div>
+                                <div>
+                                    <p class="text-xs uppercase text-muted-foreground">Created</p>
+                                    <p class="font-medium text-foreground">{{ formattedCreatedAt }}</p>
+                                    <p class="text-muted-foreground">{{ fromNow(props.ticket.created_at) }}</p>
+                                </div>
+                                <div>
+                                    <p class="text-xs uppercase text-muted-foreground">Last updated</p>
+                                    <p class="font-medium text-foreground">{{ formattedUpdatedAt }}</p>
+                                    <p class="text-muted-foreground">{{ fromNow(props.ticket.updated_at) }}</p>
+                                </div>
+                                <div>
+                                    <p class="text-xs uppercase text-muted-foreground">Resolved</p>
+                                    <p class="font-medium text-foreground">
+                                        {{ props.ticket.resolved_at ? formattedResolvedAt : 'Not resolved' }}
+                                    </p>
+                                    <p class="text-muted-foreground">
+                                        {{ props.ticket.resolver?.nickname ?? (props.ticket.resolved_at ? 'Unknown' : '—') }}
+                                    </p>
+                                </div>
+                            </CardContent>
+                        </Card>
+
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Original description</CardTitle>
+                                <CardDescription>The initial details provided by the requester.</CardDescription>
+                            </CardHeader>
+                            <CardContent>
+                                <p class="whitespace-pre-line text-sm leading-relaxed text-foreground">
+                                    {{ props.ticket.body }}
+                                </p>
+                            </CardContent>
+                        </Card>
+                    </div>
+                </div>
+            </div>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -71,8 +71,10 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
 
     // Tickets
     Route::get('acp/support/tickets/create', [SupportController::class,'createTicket'])->name('acp.support.tickets.create');
+    Route::get('acp/support/tickets/{ticket}', [SupportController::class,'showTicket'])->name('acp.support.tickets.show');
     Route::get('acp/support/tickets/{ticket}/edit', [SupportController::class,'editTicket'])->name('acp.support.tickets.edit');
     Route::post('acp/support/tickets', [SupportController::class,'storeTicket'])->name('acp.support.tickets.store');
+    Route::post('acp/support/tickets/{ticket}/messages', [SupportController::class,'storeTicketMessage'])->name('acp.support.tickets.messages.store');
     Route::put('acp/support/tickets/{ticket}', [SupportController::class,'updateTicket'])->name('acp.support.tickets.update');
     Route::delete('acp/support/tickets/{ticket}', [SupportController::class,'destroyTicket'])->name('acp.support.tickets.destroy');
     Route::put('acp/support/tickets/{ticket}/assign', [SupportController::class,'assignTicket'])->name('acp.support.tickets.assign');

--- a/tests/Feature/Admin/SupportTicketThreadTest.php
+++ b/tests/Feature/Admin/SupportTicketThreadTest.php
@@ -85,10 +85,12 @@ class SupportTicketThreadTest extends TestCase
             ->component('acp/SupportTicketView')
             ->where('ticket.id', $ticket->id)
             ->where('ticket.subject', 'Cannot access dashboard')
-            ->where('messages', function (array $messages) use ($customerMessage) {
+            ->where('messages', function ($messages) use ($customerMessage) {
+                $messages = collect($messages);
+
                 $this->assertCount(2, $messages);
 
-                $first = $messages[0];
+                $first = $messages->first();
                 $this->assertSame($customerMessage->id, $first['id']);
                 $this->assertSame('It started failing this morning.', $first['body']);
                 $this->assertFalse($first['is_from_support']);

--- a/tests/Feature/Admin/SupportTicketThreadTest.php
+++ b/tests/Feature/Admin/SupportTicketThreadTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\SupportTicket;
+use App\Models\SupportTicketMessage;
+use App\Models\SupportTicketMessageAttachment;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Inertia\Testing\AssertableInertia as Assert;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class SupportTicketThreadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Role::create(['name' => 'moderator', 'guard_name' => 'web']);
+        Permission::create(['name' => 'support.acp.view', 'guard_name' => 'web']);
+        Permission::create(['name' => 'support.acp.reply', 'guard_name' => 'web']);
+    }
+
+    private function createSupportAgent(array $permissions): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole('moderator');
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::findByName($permissionName);
+            $user->givePermissionTo($permission);
+        }
+
+        return $user;
+    }
+
+    public function test_support_agent_can_view_ticket_thread(): void
+    {
+        Storage::fake('public');
+
+        $agent = $this->createSupportAgent(['support.acp.view']);
+        $requester = User::factory()->create();
+
+        $ticket = SupportTicket::create([
+            'user_id' => $requester->id,
+            'subject' => 'Cannot access dashboard',
+            'body' => 'The dashboard throws a 500 error when I log in.',
+            'status' => 'open',
+            'priority' => 'medium',
+        ]);
+
+        $customerMessage = $ticket->messages()->create([
+            'user_id' => $requester->id,
+            'body' => 'It started failing this morning.',
+        ]);
+
+        $path = "support-attachments/{$ticket->id}/error.log";
+        Storage::disk('public')->put($path, 'stack trace');
+
+        $customerMessage->attachments()->create([
+            'disk' => 'public',
+            'path' => $path,
+            'name' => 'error.log',
+            'mime_type' => 'text/plain',
+            'size' => 42,
+        ]);
+
+        $ticket->messages()->create([
+            'user_id' => $agent->id,
+            'body' => 'We are investigating this now.',
+        ]);
+
+        $response = $this->actingAs($agent)
+            ->get(route('acp.support.tickets.show', $ticket));
+
+        $response->assertStatus(200);
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('acp/SupportTicketView')
+            ->where('ticket.id', $ticket->id)
+            ->where('ticket.subject', 'Cannot access dashboard')
+            ->where('messages', function (array $messages) use ($customerMessage) {
+                $this->assertCount(2, $messages);
+
+                $first = $messages[0];
+                $this->assertSame($customerMessage->id, $first['id']);
+                $this->assertSame('It started failing this morning.', $first['body']);
+                $this->assertFalse($first['is_from_support']);
+                $this->assertCount(1, $first['attachments']);
+
+                return true;
+            })
+            ->where('canReply', false)
+        );
+    }
+
+    public function test_support_agent_without_view_permission_cannot_view_ticket(): void
+    {
+        $agent = $this->createSupportAgent([]);
+        $requester = User::factory()->create();
+
+        $ticket = SupportTicket::create([
+            'user_id' => $requester->id,
+            'subject' => 'Permission denied test',
+            'body' => 'Ensure authorization works.',
+            'status' => 'open',
+            'priority' => 'low',
+        ]);
+
+        $response = $this->actingAs($agent)
+            ->get(route('acp.support.tickets.show', $ticket));
+
+        $response->assertForbidden();
+    }
+
+    public function test_support_agent_can_reply_with_attachments(): void
+    {
+        Storage::fake('public');
+
+        $agent = $this->createSupportAgent(['support.acp.view', 'support.acp.reply']);
+        $requester = User::factory()->create();
+
+        $ticket = SupportTicket::create([
+            'user_id' => $requester->id,
+            'subject' => 'Need onboarding help',
+            'body' => 'How do I configure SSO?',
+            'status' => 'open',
+            'priority' => 'high',
+        ]);
+
+        $payload = [
+            'body' => 'Please review the attached checklist.',
+            'attachments' => [UploadedFile::fake()->create('checklist.pdf', 200, 'application/pdf')],
+        ];
+
+        $response = $this->actingAs($agent)
+            ->from(route('acp.support.tickets.show', $ticket))
+            ->post(route('acp.support.tickets.messages.store', $ticket), $payload);
+
+        $response->assertRedirect(route('acp.support.tickets.show', $ticket));
+        $response->assertSessionHas('success', 'Reply sent.');
+
+        $message = SupportTicketMessage::query()
+            ->where('support_ticket_id', $ticket->id)
+            ->where('user_id', $agent->id)
+            ->latest()
+            ->first();
+
+        $this->assertNotNull($message);
+        $this->assertSame('Please review the attached checklist.', $message->body);
+
+        $message->load('attachments');
+
+        $this->assertCount(1, $message->attachments);
+
+        /** @var SupportTicketMessageAttachment $attachment */
+        $attachment = $message->attachments->first();
+
+        Storage::disk('public')->assertExists($attachment->path);
+        $this->assertSame('checklist.pdf', $attachment->name);
+        $this->assertSame('application/pdf', $attachment->mime_type);
+        $this->assertGreaterThan(0, $attachment->size);
+    }
+
+    public function test_support_agent_without_reply_permission_cannot_send_message(): void
+    {
+        $agent = $this->createSupportAgent(['support.acp.view']);
+        $requester = User::factory()->create();
+
+        $ticket = SupportTicket::create([
+            'user_id' => $requester->id,
+            'subject' => 'Reply permission test',
+            'body' => 'Verify reply guard.',
+            'status' => 'open',
+            'priority' => 'medium',
+        ]);
+
+        $response = $this->actingAs($agent)
+            ->post(route('acp.support.tickets.messages.store', $ticket), [
+                'body' => 'Attempting to respond without permission.',
+            ]);
+
+        $response->assertForbidden();
+        $this->assertDatabaseMissing('support_ticket_messages', [
+            'support_ticket_id' => $ticket->id,
+            'user_id' => $agent->id,
+            'body' => 'Attempting to respond without permission.',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add admin support ticket show and reply endpoints with shared attachment handling
- introduce an ACP conversation view that lets staff review ticket history and respond via Inertia
- cover support role authorization and reply flows with new feature tests

## Testing
- php artisan test --filter=SupportTicketThreadTest *(blocked: Composer install requires GitHub token in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd3659014832ca2d453f1aceaedbc