### PR TITLE
Add admin blog tag management UI and refreshable tag options

### DIFF
--- a/app/Http/Controllers/Admin/BlogTagController.php
+++ b/app/Http/Controllers/Admin/BlogTagController.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\BlogTagRequest;
+use App\Models\BlogTag;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Inertia\Response;
+
+class BlogTagController extends Controller
+{
+    public function index(Request $request): Response|JsonResponse
+    {
+        $tags = BlogTag::query()
+            ->withCount('blogs')
+            ->orderBy('name')
+            ->get()
+            ->map(fn (BlogTag $tag) => [
+                'id' => $tag->id,
+                'name' => $tag->name,
+                'slug' => $tag->slug,
+                'blogs_count' => $tag->blogs_count ?? 0,
+                'created_at' => optional($tag->created_at)->toIso8601String(),
+                'updated_at' => optional($tag->updated_at)->toIso8601String(),
+            ])
+            ->values()
+            ->all();
+
+        if ($request->wantsJson()) {
+            return response()->json(['tags' => $tags]);
+        }
+
+        return inertia('acp/BlogTags', [
+            'tags' => $tags,
+        ]);
+    }
+
+    public function create(): Response
+    {
+        return inertia('acp/BlogTagCreate');
+    }
+
+    public function store(BlogTagRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        BlogTag::create([
+            'name' => $validated['name'],
+            'slug' => $this->resolveSlug($validated['slug'] ?? null, $validated['name']),
+        ]);
+
+        return redirect()
+            ->route('acp.blog-tags.index')
+            ->with('success', 'Tag created successfully.');
+    }
+
+    public function edit(BlogTag $tag): Response
+    {
+        $tag->loadCount('blogs');
+
+        return inertia('acp/BlogTagEdit', [
+            'tag' => [
+                'id' => $tag->id,
+                'name' => $tag->name,
+                'slug' => $tag->slug,
+                'created_at' => optional($tag->created_at)->toIso8601String(),
+                'updated_at' => optional($tag->updated_at)->toIso8601String(),
+                'blogs_count' => $tag->blogs_count ?? 0,
+            ],
+        ]);
+    }
+
+    public function update(BlogTagRequest $request, BlogTag $tag): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        $tag->forceFill([
+            'name' => $validated['name'],
+            'slug' => $this->resolveSlug($validated['slug'] ?? null, $validated['name'], $tag->id),
+        ])->save();
+
+        return redirect()
+            ->route('acp.blog-tags.index')
+            ->with('success', 'Tag updated successfully.');
+    }
+
+    public function destroy(BlogTag $tag): RedirectResponse
+    {
+        $tag->delete();
+
+        return redirect()
+            ->route('acp.blog-tags.index')
+            ->with('success', 'Tag deleted successfully.');
+    }
+
+    protected function resolveSlug(?string $slug, string $name, ?int $ignoreId = null): string
+    {
+        $candidate = Str::slug($slug ?: $name);
+
+        if ($candidate === '') {
+            $candidate = Str::random(8);
+        }
+
+        $original = $candidate;
+        $suffix = 1;
+
+        $query = BlogTag::query()->where('slug', $candidate);
+
+        if ($ignoreId) {
+            $query->where('id', '!=', $ignoreId);
+        }
+
+        while ($query->exists()) {
+            $candidate = $original.'-'.$suffix++;
+
+            $query = BlogTag::query()->where('slug', $candidate);
+
+            if ($ignoreId) {
+                $query->where('id', '!=', $ignoreId);
+            }
+        }
+
+        return $candidate;
+    }
+}

--- a/app/Http/Requests/Admin/BlogTagRequest.php
+++ b/app/Http/Requests/Admin/BlogTagRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class BlogTagRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('slug') && $this->input('slug') === '') {
+            $this->merge(['slug' => null]);
+        }
+    }
+
+    public function rules(): array
+    {
+        $tag = $this->route('tag');
+
+        $tagId = $tag instanceof Model
+            ? $tag->getKey()
+            : (is_numeric($tag) ? (int) $tag : null);
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'nullable',
+                'string',
+                'max:255',
+                Rule::unique('blog_tags', 'slug')->ignore($tagId),
+            ],
+        ];
+    }
+}

--- a/resources/js/pages/acp/BlogCreate.vue
+++ b/resources/js/pages/acp/BlogCreate.vue
@@ -67,6 +67,94 @@ const previewOpen = ref(false);
 
 const { formatDate } = useUserTimezone();
 
+const tagOptions = ref<BlogTaxonomyOption[]>([]);
+const refreshingTags = ref(false);
+const refreshTagsError = ref('');
+
+const normalizeTagData = (input: unknown[]): BlogTaxonomyOption[] => {
+    return input
+        .map((raw) => {
+            if (!raw || typeof raw !== 'object') {
+                return null;
+            }
+
+            const candidate = raw as Record<string, unknown>;
+            const id = candidate.id;
+            const name = candidate.name;
+            const slug = candidate.slug;
+
+            if (typeof id !== 'number' || typeof name !== 'string' || typeof slug !== 'string') {
+                return null;
+            }
+
+            return { id, name, slug };
+        })
+        .filter((tag): tag is BlogTaxonomyOption => Boolean(tag));
+};
+
+const applyTagOptions = (tags: BlogTaxonomyOption[]) => {
+    const normalized = tags.map((tag) => ({ ...tag }));
+    tagOptions.value = normalized;
+
+    const validIds = new Set(normalized.map((tag) => tag.id));
+    form.tag_ids = form.tag_ids.filter((id) => validIds.has(id));
+};
+
+applyTagOptions([...props.tags]);
+
+watch(
+    () => props.tags,
+    (tags) => {
+        applyTagOptions([...tags]);
+    },
+    { deep: true },
+);
+
+const extractRawTags = (payload: unknown): unknown[] => {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && typeof payload === 'object' && 'tags' in payload) {
+        const tagsValue = (payload as Record<string, unknown>).tags;
+
+        return Array.isArray(tagsValue) ? tagsValue : [];
+    }
+
+    return [];
+};
+
+const refreshTags = async () => {
+    if (refreshingTags.value) {
+        return;
+    }
+
+    refreshingTags.value = true;
+    refreshTagsError.value = '';
+
+    try {
+        const response = await fetch(route('acp.blog-tags.index'), {
+            headers: {
+                Accept: 'application/json',
+                'X-Requested-With': 'XMLHttpRequest',
+            },
+        });
+
+        if (!response.ok) {
+            throw new Error(`Request failed with status ${response.status}`);
+        }
+
+        const payload: unknown = await response.json();
+        const normalized = normalizeTagData(extractRawTags(payload));
+        applyTagOptions(normalized);
+    } catch (error) {
+        console.error('Failed to refresh tags', error);
+        refreshTagsError.value = 'Unable to refresh tags. Please try again.';
+    } finally {
+        refreshingTags.value = false;
+    }
+};
+
 const formatForInput = (date: Date) => {
     const pad = (value: number) => value.toString().padStart(2, '0');
     const year = date.getFullYear();
@@ -107,7 +195,7 @@ const previewCover = computed(() => previewCoverImage.value ?? '/images/default-
 const selectedCategories = computed(() =>
     props.categories.filter((category) => form.category_ids.includes(category.id)),
 );
-const selectedTags = computed(() => props.tags.filter((tag) => form.tag_ids.includes(tag.id)));
+const selectedTags = computed(() => tagOptions.value.filter((tag) => form.tag_ids.includes(tag.id)));
 const previewScheduledMessage = computed(() => {
     if (form.status === 'scheduled' && form.scheduled_for) {
         return `Scheduled for ${formatDate(form.scheduled_for, 'MMMM D, YYYY h:mm A')}`;
@@ -288,14 +376,29 @@ const handleSubmit = () => {
                                     <InputError :message="form.errors.category_ids" />
                                 </div>
 
-                                <div class="space-y-2">
-                                    <Label>Tags</Label>
-                                    <p class="text-sm text-muted-foreground">
-                                        Add optional tags to highlight key topics or campaigns.
-                                    </p>
+                                <div class="space-y-3">
+                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                        <div>
+                                            <Label>Tags</Label>
+                                            <p class="text-sm text-muted-foreground">
+                                                Add optional tags to highlight key topics or campaigns.
+                                            </p>
+                                        </div>
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            size="sm"
+                                            class="self-start"
+                                            :disabled="refreshingTags"
+                                            @click="refreshTags"
+                                        >
+                                            <span v-if="refreshingTags">Refreshing…</span>
+                                            <span v-else>Refresh tags</span>
+                                        </Button>
+                                    </div>
                                     <div class="grid gap-2 sm:grid-cols-2">
                                         <label
-                                            v-for="tag in props.tags"
+                                            v-for="tag in tagOptions"
                                             :key="tag.id"
                                             class="flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm"
                                         >
@@ -307,10 +410,11 @@ const handleSubmit = () => {
                                             />
                                             <span>{{ tag.name }}</span>
                                         </label>
-                                        <p v-if="props.tags.length === 0" class="text-sm text-muted-foreground sm:col-span-2">
+                                        <p v-if="tagOptions.length === 0" class="text-sm text-muted-foreground sm:col-span-2">
                                             No tags available yet. Seed some to enable richer filtering.
                                         </p>
                                     </div>
+                                    <p v-if="refreshTagsError" class="text-xs text-red-500">{{ refreshTagsError }}</p>
                                     <InputError :message="form.errors.tag_ids" />
                                 </div>
                             </div>

--- a/resources/js/pages/acp/BlogTagCreate.vue
+++ b/resources/js/pages/acp/BlogTagCreate.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { Head, Link, useForm } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import InputError from '@/components/InputError.vue';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Blogs ACP', href: route('acp.blogs.index') },
+    { title: 'Manage tags', href: route('acp.blog-tags.index') },
+    { title: 'Create tag', href: route('acp.blog-tags.create') },
+];
+
+const form = useForm({
+    name: '',
+    slug: '',
+});
+
+const handleSubmit = () => {
+    form.post(route('acp.blog-tags.store'), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Create blog tag" />
+
+        <AdminLayout>
+            <form class="flex flex-1 flex-col gap-6" @submit.prevent="handleSubmit">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">Create blog tag</h1>
+                        <p class="text-sm text-muted-foreground">
+                            Define a reusable tag to help writers highlight key topics across the blog.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2">
+                        <Button variant="outline" as-child>
+                            <Link :href="route('acp.blog-tags.index')">Cancel</Link>
+                        </Button>
+                        <Button type="submit" :disabled="form.processing">Save tag</Button>
+                    </div>
+                </div>
+
+                <Card>
+                    <CardHeader class="relative overflow-hidden">
+                        <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                        <div class="relative space-y-1">
+                            <CardTitle>Tag details</CardTitle>
+                            <CardDescription>
+                                Provide a clear name and optional slug. The slug defaults to a URL-friendly version of the name.
+                            </CardDescription>
+                        </div>
+                    </CardHeader>
+                    <CardContent class="space-y-6">
+                        <div class="grid gap-2">
+                            <Label for="name">Name</Label>
+                            <Input id="name" v-model="form.name" type="text" autocomplete="off" required />
+                            <InputError :message="form.errors.name" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="slug">Slug</Label>
+                            <Input
+                                id="slug"
+                                v-model="form.slug"
+                                type="text"
+                                autocomplete="off"
+                                placeholder="Leave blank to auto-generate from the name"
+                            />
+                            <InputError :message="form.errors.slug" />
+                        </div>
+                    </CardContent>
+                    <CardFooter class="justify-end gap-2">
+                        <Button type="submit" :disabled="form.processing">Save tag</Button>
+                    </CardFooter>
+                </Card>
+            </form>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/BlogTagEdit.vue
+++ b/resources/js/pages/acp/BlogTagEdit.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { Head, Link, useForm } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import InputError from '@/components/InputError.vue';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+
+interface TagPayload {
+    id: number;
+    name: string;
+    slug: string;
+    blogs_count: number;
+    created_at: string | null;
+    updated_at: string | null;
+}
+
+const props = defineProps<{
+    tag: TagPayload;
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Blogs ACP', href: route('acp.blogs.index') },
+    { title: 'Manage tags', href: route('acp.blog-tags.index') },
+    { title: props.tag.name, href: route('acp.blog-tags.edit', { tag: props.tag.id }) },
+];
+
+const form = useForm({
+    name: props.tag.name,
+    slug: props.tag.slug,
+});
+
+const handleSubmit = () => {
+    form.put(route('acp.blog-tags.update', { tag: props.tag.id }), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head :title="`Edit ${props.tag.name}`" />
+
+        <AdminLayout>
+            <form class="flex flex-1 flex-col gap-6" @submit.prevent="handleSubmit">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">Edit blog tag</h1>
+                        <p class="text-sm text-muted-foreground">
+                            Update the tag name or slug. {{ props.tag.blogs_count }} blog post{{ props.tag.blogs_count === 1 ? '' : 's' }} currently use this tag.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2">
+                        <Button variant="outline" as-child>
+                            <Link :href="route('acp.blog-tags.index')">Back</Link>
+                        </Button>
+                        <Button type="submit" :disabled="form.processing">Update tag</Button>
+                    </div>
+                </div>
+
+                <Card>
+                    <CardHeader class="relative overflow-hidden">
+                        <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                        <div class="relative space-y-1">
+                            <CardTitle>Tag details</CardTitle>
+                            <CardDescription>
+                                Adjust the display name and slug. The slug determines how the tag appears in URLs and filters.
+                            </CardDescription>
+                        </div>
+                    </CardHeader>
+                    <CardContent class="space-y-6">
+                        <div class="grid gap-2">
+                            <Label for="name">Name</Label>
+                            <Input id="name" v-model="form.name" type="text" autocomplete="off" required />
+                            <InputError :message="form.errors.name" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="slug">Slug</Label>
+                            <Input
+                                id="slug"
+                                v-model="form.slug"
+                                type="text"
+                                autocomplete="off"
+                                placeholder="Leave blank to auto-generate from the name"
+                            />
+                            <InputError :message="form.errors.slug" />
+                        </div>
+                    </CardContent>
+                    <CardFooter class="justify-end gap-2">
+                        <Button type="submit" :disabled="form.processing">Update tag</Button>
+                    </CardFooter>
+                </Card>
+            </form>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/BlogTags.vue
+++ b/resources/js/pages/acp/BlogTags.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+import { useUserTimezone } from '@/composables/useUserTimezone';
+import { Pencil, PlusCircle, Tag as TagIcon, Trash2 } from 'lucide-vue-next';
+
+type ManagedTag = {
+    id: number;
+    name: string;
+    slug: string;
+    blogs_count: number;
+    created_at: string | null;
+    updated_at: string | null;
+};
+
+const props = defineProps<{
+    tags: ManagedTag[];
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Blogs ACP', href: route('acp.blogs.index') },
+    { title: 'Manage tags', href: route('acp.blog-tags.index') },
+];
+
+const hasTags = computed(() => props.tags.length > 0);
+const { formatDate } = useUserTimezone();
+
+const deleteTag = (tagId: number) => {
+    if (!confirm('Are you sure you want to delete this tag? This action cannot be undone.')) {
+        return;
+    }
+
+    router.delete(route('acp.blog-tags.destroy', { tag: tagId }), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Manage blog tags" />
+
+        <AdminLayout>
+            <Card class="flex-1">
+                <CardHeader class="relative overflow-hidden">
+                    <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                    <div class="relative flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <CardTitle class="flex items-center gap-2">
+                                <TagIcon class="h-5 w-5" />
+                                Blog tags
+                            </CardTitle>
+                            <CardDescription>
+                                Create, edit, and organize the tags available to writers when publishing blog posts.
+                            </CardDescription>
+                        </div>
+                        <Button variant="secondary" as-child>
+                            <Link :href="route('acp.blog-tags.create')">
+                                <PlusCircle class="h-4 w-4" />
+                                Create tag
+                            </Link>
+                        </Button>
+                    </div>
+                </CardHeader>
+                <CardContent>
+                    <div v-if="!hasTags" class="rounded-lg border border-dashed border-muted-foreground/40 p-6 text-center text-sm text-muted-foreground">
+                        No tags have been created yet. Use the button above to add the first blog tag.
+                    </div>
+
+                    <div v-else class="overflow-x-auto">
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead class="w-1/4">Name</TableHead>
+                                    <TableHead class="w-1/4">Slug</TableHead>
+                                    <TableHead class="text-center">Blog usage</TableHead>
+                                    <TableHead class="text-center">Created</TableHead>
+                                    <TableHead class="text-center">Updated</TableHead>
+                                    <TableHead class="text-right">Actions</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                <TableRow v-for="tag in props.tags" :key="tag.id">
+                                    <TableCell class="font-medium">{{ tag.name }}</TableCell>
+                                    <TableCell>
+                                        <span class="rounded bg-muted px-2 py-1 text-xs font-mono">{{ tag.slug }}</span>
+                                    </TableCell>
+                                    <TableCell class="text-center">
+                                        <span class="font-semibold">{{ tag.blogs_count }}</span>
+                                        <span class="ml-1 text-xs text-muted-foreground">post{{ tag.blogs_count === 1 ? '' : 's' }}</span>
+                                    </TableCell>
+                                    <TableCell class="text-center">
+                                        {{ tag.created_at ? formatDate(tag.created_at, 'MMM D, YYYY h:mm A') : '—' }}
+                                    </TableCell>
+                                    <TableCell class="text-center">
+                                        {{ tag.updated_at ? formatDate(tag.updated_at, 'MMM D, YYYY h:mm A') : '—' }}
+                                    </TableCell>
+                                    <TableCell class="flex justify-end gap-2">
+                                        <Button variant="outline" size="sm" as-child>
+                                            <Link :href="route('acp.blog-tags.edit', { tag: tag.id })">
+                                                <Pencil class="h-4 w-4" />
+                                                Edit
+                                            </Link>
+                                        </Button>
+                                        <Button variant="destructive" size="sm" @click="deleteTag(tag.id)">
+                                            <Trash2 class="h-4 w-4" />
+                                            Delete
+                                        </Button>
+                                    </TableCell>
+                                </TableRow>
+                            </TableBody>
+                        </Table>
+                    </div>
+                </CardContent>
+            </Card>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/Blogs.vue
+++ b/resources/js/pages/acp/Blogs.vue
@@ -61,6 +61,7 @@ const createBlogs = computed(() => hasPermission('blogs.acp.create'));
 const editBlogs = computed(() => hasPermission('blogs.acp.edit'));
 const publishBlogs = computed(() => hasPermission('blogs.acp.publish'));
 const deleteBlogs = computed(() => hasPermission('blogs.acp.delete'));
+const manageTags = computed(() => createBlogs.value || editBlogs.value);
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -247,20 +248,26 @@ const deletePost = (postId: number) => {
 
                 <!-- Blog Posts Management Section -->
                 <div class="rounded-xl border border-sidebar-border/70 dark:border-sidebar-border p-4">
-                    <div class="flex flex-col md:flex-row md:items-center md:justify-between mb-4">
-                        <h2 class="text-lg font-semibold mb-2 md:mb-0">Blog Posts</h2>
-                        <div class="flex space-x-2">
+                    <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between mb-4">
+                        <h2 class="text-lg font-semibold">Blog Posts</h2>
+                        <div class="flex flex-col gap-2 md:w-auto md:flex-row md:items-center md:gap-2">
                             <Input
                                 v-model="searchQuery"
                                 placeholder="Search Blogs..."
-                                class="w-full rounded-md"
+                                class="w-full rounded-md md:w-64"
                             />
-                            <!-- Create New Post Button visible only if permission is granted -->
-                            <Link :href="route('acp.blogs.create')" v-if="createBlogs">
-                                <Button variant="secondary" class="text-sm text-white bg-green-500 hover:bg-green-600">
-                                    Create New Post
-                                </Button>
-                            </Link>
+                            <div class="flex flex-wrap justify-end gap-2">
+                                <Link v-if="manageTags" :href="route('acp.blog-tags.index')">
+                                    <Button variant="outline" class="text-sm">
+                                        Manage Tags
+                                    </Button>
+                                </Link>
+                                <Link v-if="createBlogs" :href="route('acp.blogs.create')">
+                                    <Button variant="secondary" class="text-sm text-white bg-green-500 hover:bg-green-600">
+                                        Create New Post
+                                    </Button>
+                                </Link>
+                            </div>
                         </div>
                     </div>
                     <div class="overflow-x-auto">

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Admin\AdminController;
 use App\Http\Controllers\Admin\BlogController as AdminBlogController;
+use App\Http\Controllers\Admin\BlogTagController;
 use App\Http\Controllers\Admin\ACLController as AdminACLController;
 use App\Http\Controllers\Admin\SupportController;
 use App\Http\Controllers\Admin\SystemSettingsController;
@@ -47,6 +48,14 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
     Route::put('acp/blogs/{blog}/unpublish', [AdminBlogController::class, 'unpublish'])->name('acp.blogs.unpublish');
     Route::put('acp/blogs/{blog}/archive', [AdminBlogController::class, 'archive'])->name('acp.blogs.archive');
     Route::put('acp/blogs/{blog}/unarchive', [AdminBlogController::class, 'unarchive'])->name('acp.blogs.unarchive');
+
+    // Admin Blog Tag Management Routes
+    Route::get('acp/blog-tags', [BlogTagController::class, 'index'])->name('acp.blog-tags.index');
+    Route::get('acp/blog-tags/create', [BlogTagController::class, 'create'])->name('acp.blog-tags.create');
+    Route::post('acp/blog-tags', [BlogTagController::class, 'store'])->name('acp.blog-tags.store');
+    Route::get('acp/blog-tags/{tag}/edit', [BlogTagController::class, 'edit'])->name('acp.blog-tags.edit');
+    Route::put('acp/blog-tags/{tag}', [BlogTagController::class, 'update'])->name('acp.blog-tags.update');
+    Route::delete('acp/blog-tags/{tag}', [BlogTagController::class, 'destroy'])->name('acp.blog-tags.destroy');
 
     Route::get('acp/forums', [ForumCategoryController::class, 'index'])->name('acp.forums.index');
     Route::get('acp/forums/reports', [ForumReportController::class, 'index'])->name('acp.forums.reports.index');

--- a/tests/Feature/Admin/BlogTagManagementTest.php
+++ b/tests/Feature/Admin/BlogTagManagementTest.php
@@ -160,7 +160,7 @@ class BlogTagManagementTest extends TestCase
         $response->assertOk();
         $response->assertInertia(fn (Assert $page) => $page
             ->component('acp/BlogCreate')
-            ->where('tags', fn (array $tags) => collect($tags)->pluck('id')->contains($tag->id))
+            ->where('tags', fn ($tags) => collect($tags)->pluck('id')->contains($tag->id))
         );
     }
 }

--- a/tests/Feature/Admin/BlogTagManagementTest.php
+++ b/tests/Feature/Admin/BlogTagManagementTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Blog;
+use App\Models\BlogTag;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class BlogTagManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingAsAdmin(): User
+    {
+        $user = User::factory()->create();
+        $role = Role::firstOrCreate(['name' => 'admin']);
+        $user->assignRole($role);
+
+        $this->actingAs($user);
+
+        return $user;
+    }
+
+    public function test_admin_can_view_tag_index_page(): void
+    {
+        $this->actingAsAdmin();
+
+        $alpha = BlogTag::factory()->create(['name' => 'Alpha', 'slug' => 'alpha']);
+        $bravo = BlogTag::factory()->create(['name' => 'Bravo', 'slug' => 'bravo']);
+
+        $response = $this->get(route('acp.blog-tags.index'));
+
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('acp/BlogTags')
+            ->has('tags', 2)
+            ->where('tags.0.name', 'Alpha')
+            ->where('tags.1.name', 'Bravo')
+        );
+    }
+
+    public function test_tag_index_returns_json_payload(): void
+    {
+        $this->actingAsAdmin();
+
+        $tag = BlogTag::factory()->create(['name' => 'Campaigns', 'slug' => 'campaigns']);
+        $blog = Blog::factory()->create();
+        $blog->tags()->attach($tag);
+
+        $response = $this->getJson(route('acp.blog-tags.index'));
+
+        $response->assertOk()
+            ->assertJsonPath('tags.0.name', 'Campaigns')
+            ->assertJsonPath('tags.0.blogs_count', 1);
+    }
+
+    public function test_admin_can_create_tag(): void
+    {
+        $this->actingAsAdmin();
+
+        $response = $this->post(route('acp.blog-tags.store'), [
+            'name' => 'Laravel Tips',
+            'slug' => '',
+        ]);
+
+        $response->assertRedirect(route('acp.blog-tags.index'));
+
+        $this->assertDatabaseHas('blog_tags', [
+            'name' => 'Laravel Tips',
+            'slug' => 'laravel-tips',
+        ]);
+    }
+
+    public function test_tag_slug_must_be_unique(): void
+    {
+        $this->actingAsAdmin();
+
+        BlogTag::factory()->create(['slug' => 'duplicate']);
+
+        $response = $this->from(route('acp.blog-tags.create'))->post(route('acp.blog-tags.store'), [
+            'name' => 'Another Tag',
+            'slug' => 'duplicate',
+        ]);
+
+        $response->assertRedirect(route('acp.blog-tags.create'));
+        $response->assertSessionHasErrors('slug');
+    }
+
+    public function test_admin_can_update_tag(): void
+    {
+        $this->actingAsAdmin();
+
+        $tag = BlogTag::factory()->create([
+            'name' => 'Original',
+            'slug' => 'original',
+        ]);
+
+        $response = $this->put(route('acp.blog-tags.update', $tag), [
+            'name' => 'Updated Name',
+            'slug' => '',
+        ]);
+
+        $response->assertRedirect(route('acp.blog-tags.index'));
+
+        $tag->refresh();
+        $this->assertSame('Updated Name', $tag->name);
+        $this->assertSame('updated-name', $tag->slug);
+    }
+
+    public function test_admin_can_reuse_slug_on_same_tag(): void
+    {
+        $this->actingAsAdmin();
+
+        $tag = BlogTag::factory()->create([
+            'name' => 'Announcements',
+            'slug' => 'announcements',
+        ]);
+
+        $response = $this->put(route('acp.blog-tags.update', $tag), [
+            'name' => 'Announcements',
+            'slug' => 'announcements',
+        ]);
+
+        $response->assertRedirect(route('acp.blog-tags.index'));
+        $this->assertDatabaseHas('blog_tags', [
+            'id' => $tag->id,
+            'slug' => 'announcements',
+        ]);
+    }
+
+    public function test_admin_can_delete_tag(): void
+    {
+        $this->actingAsAdmin();
+
+        $tag = BlogTag::factory()->create();
+        $blog = Blog::factory()->create();
+        $blog->tags()->attach($tag);
+
+        $response = $this->from(route('acp.blog-tags.index'))
+            ->delete(route('acp.blog-tags.destroy', $tag));
+
+        $response->assertRedirect(route('acp.blog-tags.index'));
+
+        $this->assertDatabaseMissing('blog_tags', ['id' => $tag->id]);
+        $this->assertDatabaseMissing('blog_blog_tag', ['blog_tag_id' => $tag->id]);
+    }
+
+    public function test_blog_create_page_includes_available_tags(): void
+    {
+        $this->actingAsAdmin();
+
+        $tag = BlogTag::factory()->create(['name' => 'Fresh Tag', 'slug' => 'fresh-tag']);
+
+        $response = $this->get(route('acp.blogs.create'));
+
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('acp/BlogCreate')
+            ->where('tags', fn (array $tags) => collect($tags)->pluck('id')->contains($tag->id))
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add admin routes plus a controller and form request for managing blog tags, including a JSON index for option refreshes
- build Inertia views to list, create, and edit tags and update blog create/edit forms to refresh tag options on demand
- extend the blogs ACP page with a manage-tags shortcut and cover the new flow with feature tests

## Testing
- not run (composer install blocked by outbound network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68ddd354937c832ca551b643701f07f9