### PR TITLE
Allow choosing support ticket priority

### DIFF
--- a/tests/Feature/Support/SupportTicketQuickActionsTest.php
+++ b/tests/Feature/Support/SupportTicketQuickActionsTest.php
@@ -77,6 +77,34 @@ class SupportTicketQuickActionsTest extends TestCase
         $this->assertSame('high', $ticket->fresh()->priority);
     }
 
+    public function test_admin_can_lower_ticket_priority(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('admin');
+
+        $requestor = User::factory()->create();
+
+        $ticket = SupportTicket::create([
+            'user_id' => $requestor->id,
+            'subject' => 'Review ticket priority',
+            'body' => 'Ticket priority should be decreased.',
+            'status' => 'open',
+            'priority' => 'high',
+        ]);
+
+        $response = $this
+            ->actingAs($admin)
+            ->from(route('acp.support.index'))
+            ->put(route('acp.support.tickets.priority', $ticket), [
+                'priority' => 'low',
+            ]);
+
+        $response->assertRedirect(route('acp.support.index'));
+        $response->assertSessionHas('success', 'Ticket priority updated.');
+
+        $this->assertSame('low', $ticket->fresh()->priority);
+    }
+
     public function test_admin_can_toggle_ticket_status(): void
     {
         Carbon::setTestNow('2025-02-15 12:00:00');


### PR DESCRIPTION
## Summary
- replace the quick action priority bump with a selector so admins can pick any level
- refresh the dialog copy and guard against no-op submissions while reusing the priority endpoint
- add a feature test covering lowering a ticket's priority

## Testing
- php artisan test --filter=SupportTicketQuickActionsTest *(fails: missing vendor dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddecfeb280832cac4dbf588feca9a0