### PR TITLE
Add admin user banning capabilities

### DIFF
--- a/app/Http/Middleware/PreventBannedUser.php
+++ b/app/Http/Middleware/PreventBannedUser.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class PreventBannedUser
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if ($user?->is_banned) {
+            Auth::logout();
+
+            if (method_exists($user, 'currentAccessToken') && ($token = $user->currentAccessToken())) {
+                $token->delete();
+            }
+
+            if ($request->hasSession()) {
+                $request->session()->invalidate();
+                $request->session()->regenerateToken();
+            }
+
+            if ($request->expectsJson()) {
+                abort(403, trans('auth.banned'));
+            }
+
+            return redirect()->route('login')->withErrors([
+                'email' => trans('auth.banned'),
+            ]);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -50,6 +50,16 @@ class LoginRequest extends FormRequest
         }
 
         RateLimiter::clear($this->throttleKey());
+
+        $user = $this->user();
+
+        if ($user?->is_banned) {
+            Auth::logout();
+
+            throw ValidationException::withMessages([
+                'email' => trans('auth.banned'),
+            ]);
+        }
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Auth\MustVerifyEmail as MustVerifyEmailTrait;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -27,6 +28,8 @@ class User extends Authenticatable implements MustVerifyEmail
         'email_verified_at',
         'is_banned',
         'last_activity_at',
+        'banned_at',
+        'banned_by_id',
     ];
 
     /**
@@ -50,6 +53,7 @@ class User extends Authenticatable implements MustVerifyEmail
             'email_verified_at' => 'datetime',
             'is_banned' => 'boolean',
             'last_activity_at' => 'datetime',
+            'banned_at' => 'datetime',
         ];
     }
 
@@ -71,6 +75,11 @@ class User extends Authenticatable implements MustVerifyEmail
     public function blogComments(): HasMany
     {
         return $this->hasMany(BlogComment::class);
+    }
+
+    public function bannedBy(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'banned_by_id');
     }
 }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -5,6 +5,7 @@ use App\Http\Middleware\EnsureSiteIsAvailable;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\LogTokenActivity;
+use App\Http\Middleware\PreventBannedUser;
 use App\Http\Middleware\UpdateLastActivity;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -25,18 +26,27 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->encryptCookies(except: ['appearance']);
 
-        $middleware->api(prepend: [
-            EnsureFrontendRequestsAreStateful::class,
-        ]);
+        $middleware->api(
+            prepend: [
+                EnsureFrontendRequestsAreStateful::class,
+            ],
+            append: [
+                PreventBannedUser::class,
+            ]
+        );
 
         $middleware->web(
+            prepend: [
+                PreventBannedUser::class,
+            ],
             append: [
                 EnsureSiteIsAvailable::class,
                 HandleAppearance::class,
                 HandleInertiaRequests::class,
                 AddLinkHeadersForPreloadedAssets::class,
                 UpdateLastActivity::class,
-            ]);
+            ]
+        );
 
         $middleware->alias([
             'verified' => EnsureEmailIsVerifiedIfRequired::class,

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,6 +29,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'is_banned' => false,
         ];
     }
 

--- a/database/migrations/2025_05_10_000000_add_ban_metadata_to_users_table.php
+++ b/database/migrations/2025_05_10_000000_add_ban_metadata_to_users_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (! Schema::hasColumn('users', 'banned_at')) {
+                $table->timestamp('banned_at')
+                    ->nullable()
+                    ->after('is_banned');
+            }
+
+            if (! Schema::hasColumn('users', 'banned_by_id')) {
+                $table->foreignId('banned_by_id')
+                    ->nullable()
+                    ->after('banned_at')
+                    ->constrained('users')
+                    ->nullOnDelete();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'banned_by_id')) {
+                $table->dropConstrainedForeignId('banned_by_id');
+            }
+
+            if (Schema::hasColumn('users', 'banned_at')) {
+                $table->dropColumn('banned_at');
+            }
+        });
+    }
+};

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
@@ -11,10 +12,10 @@ class RolePermissionSeeder extends Seeder
     public function run()
     {
         // Create roles
-        $adminRole = Role::create(['name' => 'admin']);
-        $editorRole = Role::create(['name' => 'editor']);
-        $moderatorRole = Role::create(['name' => 'moderator']);
-        $userRole = Role::create(['name' => 'user']);
+        $adminRole = Role::firstOrCreate(['name' => 'admin']);
+        $editorRole = Role::firstOrCreate(['name' => 'editor']);
+        $moderatorRole = Role::firstOrCreate(['name' => 'moderator']);
+        $userRole = Role::firstOrCreate(['name' => 'user']);
 
         // Create permissions (adjust as needed)
         $permissions = [
@@ -28,32 +29,32 @@ class RolePermissionSeeder extends Seeder
         ];
 
         foreach ($permissions as $permission) {
-            Permission::create(['name' => $permission.'.acp.view']);
-            Permission::create(['name' => $permission.'.acp.create']);
-            Permission::create(['name' => $permission.'.acp.edit']);
+            Permission::firstOrCreate(['name' => $permission.'.acp.view']);
+            Permission::firstOrCreate(['name' => $permission.'.acp.create']);
+            Permission::firstOrCreate(['name' => $permission.'.acp.edit']);
             if ($permission == 'blogs') {
-                Permission::create(['name' => $permission.'.acp.publish']);
+                Permission::firstOrCreate(['name' => $permission.'.acp.publish']);
             }
             if ($permission == 'forums') {
-                Permission::create(['name' => $permission.'.acp.move']);
-                Permission::create(['name' => $permission.'.acp.publish']);
-                Permission::create(['name' => $permission.'.acp.lock']);
-                Permission::create(['name' => $permission.'.acp.pin']);
-                Permission::create(['name' => $permission.'.acp.migrate']);
-                Permission::create(['name' => $permission.'.acp.permissions']);
+                Permission::firstOrCreate(['name' => $permission.'.acp.move']);
+                Permission::firstOrCreate(['name' => $permission.'.acp.publish']);
+                Permission::firstOrCreate(['name' => $permission.'.acp.lock']);
+                Permission::firstOrCreate(['name' => $permission.'.acp.pin']);
+                Permission::firstOrCreate(['name' => $permission.'.acp.migrate']);
+                Permission::firstOrCreate(['name' => $permission.'.acp.permissions']);
             }
             if ($permission == 'users') {
-                Permission::create(['name' => $permission.'.acp.verify']);
-                Permission::create(['name' => $permission.'.acp.ban']);
+                Permission::firstOrCreate(['name' => $permission.'.acp.verify']);
+                Permission::firstOrCreate(['name' => $permission.'.acp.ban']);
             }
             if ($permission == 'support') {
-                Permission::create(['name' => $permission.'.acp.assign']);
-                Permission::create(['name' => $permission.'.acp.move']);
-                Permission::create(['name' => $permission.'.acp.publish']);
-                Permission::create(['name' => $permission.'.acp.priority']);
-                Permission::create(['name' => $permission.'.acp.status']);
+                Permission::firstOrCreate(['name' => $permission.'.acp.assign']);
+                Permission::firstOrCreate(['name' => $permission.'.acp.move']);
+                Permission::firstOrCreate(['name' => $permission.'.acp.publish']);
+                Permission::firstOrCreate(['name' => $permission.'.acp.priority']);
+                Permission::firstOrCreate(['name' => $permission.'.acp.status']);
             }
-            Permission::create(['name' => $permission.'.acp.delete']);
+            Permission::firstOrCreate(['name' => $permission.'.acp.delete']);
         }
 
         // Optionally assign all permissions to admin
@@ -61,7 +62,7 @@ class RolePermissionSeeder extends Seeder
 
         // Assign the admin role to the user with ID 1, if the user exists
         $user = User::find(1);
-        if ($user) {
+        if ($user && !$user->hasRole($adminRole)) {
             $user->assignRole($adminRole);
         }
     }

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -44,6 +44,7 @@ class RolePermissionSeeder extends Seeder
             }
             if ($permission == 'users') {
                 Permission::create(['name' => $permission.'.acp.verify']);
+                Permission::create(['name' => $permission.'.acp.ban']);
             }
             if ($permission == 'support') {
                 Permission::create(['name' => $permission.'.acp.assign']);

--- a/lang/en/auth.php
+++ b/lang/en/auth.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'failed' => 'These credentials do not match our records.',
+    'password' => 'The provided password is incorrect.',
+    'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
+    'banned' => 'Your account has been banned.',
+];

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -25,6 +25,8 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
     Route::put('acp/users/{user}', [AdminUserController::class, 'update'])->name('acp.users.update');
     Route::delete('acp/users/{user}', [AdminUserController::class, 'destroy'])->name('acp.users.destroy');
     Route::put('acp/users/{user}/verify', [AdminUserController::class, 'verify'])->name('acp.users.verify');
+    Route::put('acp/users/{user}/ban', [AdminUserController::class, 'ban'])->name('acp.users.ban');
+    Route::put('acp/users/{user}/unban', [AdminUserController::class, 'unban'])->name('acp.users.unban');
 
     // Admin Access Control Management Routes
     Route::get('acp/acl', [AdminACLController::class, 'index'])->name('acp.acl.index');

--- a/tests/Feature/Admin/UserBanManagementTest.php
+++ b/tests/Feature/Admin/UserBanManagementTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class UserBanManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createBanPermission(): Permission
+    {
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        return Permission::firstOrCreate(['name' => 'users.acp.ban']);
+    }
+
+    public function test_authorized_users_can_ban_and_unban_accounts(): void
+    {
+        $banPermission = $this->createBanPermission();
+
+        $role = Role::firstOrCreate(['name' => 'admin']);
+        $role->givePermissionTo($banPermission);
+
+        $admin = User::factory()->create();
+        $admin->assignRole($role);
+        $this->actingAs($admin);
+
+        $target = User::factory()->create();
+
+        $this->put(route('acp.users.ban', $target))
+            ->assertRedirect(route('acp.users.index'));
+
+        $target->refresh();
+        $this->assertTrue($target->is_banned);
+        $this->assertNotNull($target->banned_at);
+        $this->assertSame($admin->id, $target->banned_by_id);
+
+        $this->put(route('acp.users.unban', $target))
+            ->assertRedirect(route('acp.users.index'));
+
+        $target->refresh();
+        $this->assertFalse($target->is_banned);
+        $this->assertNull($target->banned_at);
+        $this->assertNull($target->banned_by_id);
+    }
+
+    public function test_users_without_permission_cannot_toggle_bans(): void
+    {
+        $this->createBanPermission();
+
+        $editorRole = Role::firstOrCreate(['name' => 'editor']);
+
+        $editor = User::factory()->create();
+        $editor->assignRole($editorRole);
+        $this->actingAs($editor);
+
+        $target = User::factory()->create();
+
+        $this->put(route('acp.users.ban', $target))
+            ->assertForbidden();
+
+        $this->assertFalse($target->fresh()->is_banned);
+    }
+
+    public function test_banned_users_are_flagged_in_admin_index(): void
+    {
+        $banPermission = $this->createBanPermission();
+
+        $role = Role::firstOrCreate(['name' => 'admin']);
+        $role->givePermissionTo($banPermission);
+
+        $admin = User::factory()->create();
+        $admin->assignRole($role);
+        $this->actingAs($admin);
+
+        User::factory()->create();
+        $bannedUser = User::factory()->create();
+        $bannedUser->forceFill([
+            'is_banned' => true,
+            'banned_at' => now(),
+            'banned_by_id' => $admin->id,
+        ])->save();
+
+        $response = $this->get(route('acp.users.index'));
+
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('acp/Users')
+            ->where('users.data', function ($users) use ($bannedUser) {
+                return collect($users)->contains(function ($user) use ($bannedUser) {
+                    return $user['id'] === $bannedUser->id
+                        && $user['is_banned'] === true;
+                });
+            })
+        );
+    }
+}

--- a/tests/Feature/Auth/BannedUserAccessTest.php
+++ b/tests/Feature/Auth/BannedUserAccessTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BannedUserAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_banned_users_cannot_login(): void
+    {
+        $user = User::factory()->create([
+            'is_banned' => true,
+            'banned_at' => now(),
+        ]);
+
+        $response = $this->post(route('login'), [
+            'email' => $user->email,
+            'password' => 'password',
+        ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHasErrors('email');
+        $this->assertGuest();
+    }
+
+    public function test_authenticated_banned_users_are_logged_out(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        $user->forceFill([
+            'is_banned' => true,
+            'banned_at' => now(),
+        ])->save();
+
+        $response = $this->get(route('dashboard'));
+
+        $response->assertRedirect(route('login'));
+        $response->assertSessionHasErrors('email');
+        $this->assertGuest();
+    }
+}


### PR DESCRIPTION
## Summary
- add ban and unban endpoints for ACP user management that record ban metadata
- expose ban status and ban/unban controls in the admin users table UI
- track ban metadata on users and cover the workflow with feature tests

## Testing
- not run (composer install requires GitHub token in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dded0758bc832cb99329118dde0338