### PR TITLE
Add customer ticket closure endpoint and UI feedback

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -88,6 +88,9 @@ Route::middleware('auth')->group(function () {
 
     Route::post('support/tickets/{ticket}/rating', [SupportCenterController::class, 'storeRating'])
         ->name('support.tickets.rating.store');
+
+    Route::patch('support/tickets/{ticket}/status', [SupportCenterController::class, 'updateStatus'])
+        ->name('support.tickets.status.update');
 });
 
 //AUTH REQUIRED PAGES


### PR DESCRIPTION
## Summary
- add an authenticated PATCH route that maps to a new SupportCenterController method for closing tickets
- update the Support page dropdown to call the new endpoint, prevent duplicate closes, and refresh the list
- surface flash success/info/error messages as toasts so users get feedback after closing tickets

## Testing
- php artisan test --filter=SupportTicket *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68ddfa09aaf0832c88e68b3dabb1eb1d