### PR TITLE
Add Atom feed for blog posts

### DIFF
--- a/database/migrations/2025_05_06_010000_update_blog_status_enum_for_scheduling.php
+++ b/database/migrations/2025_05_06_010000_update_blog_status_enum_for_scheduling.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
@@ -11,8 +12,34 @@ return new class extends Migration
      */
     public function up(): void
     {
-        if (Schema::getConnection()->getDriverName() === 'mysql') {
+        $driver = Schema::getConnection()->getDriverName();
+
+        if ($driver === 'mysql') {
             DB::statement("ALTER TABLE blogs MODIFY status ENUM('draft','scheduled','published','archived') DEFAULT 'draft'");
+
+            return;
+        }
+
+        if ($driver === 'sqlite') {
+            Schema::table('blogs', function (Blueprint $table) {
+                $table->string('status_temp')->default('draft');
+            });
+
+            DB::statement("UPDATE blogs SET status_temp = status");
+
+            Schema::table('blogs', function (Blueprint $table) {
+                $table->dropColumn('status');
+            });
+
+            Schema::table('blogs', function (Blueprint $table) {
+                $table->enum('status', ['draft', 'scheduled', 'published', 'archived'])->default('draft');
+            });
+
+            DB::statement("UPDATE blogs SET status = status_temp");
+
+            Schema::table('blogs', function (Blueprint $table) {
+                $table->dropColumn('status_temp');
+            });
         }
     }
 
@@ -21,8 +48,34 @@ return new class extends Migration
      */
     public function down(): void
     {
-        if (Schema::getConnection()->getDriverName() === 'mysql') {
+        $driver = Schema::getConnection()->getDriverName();
+
+        if ($driver === 'mysql') {
             DB::statement("ALTER TABLE blogs MODIFY status ENUM('draft','published','archived') DEFAULT 'draft'");
+
+            return;
+        }
+
+        if ($driver === 'sqlite') {
+            Schema::table('blogs', function (Blueprint $table) {
+                $table->string('status_temp')->default('draft');
+            });
+
+            DB::statement("UPDATE blogs SET status_temp = status");
+
+            Schema::table('blogs', function (Blueprint $table) {
+                $table->dropColumn('status');
+            });
+
+            Schema::table('blogs', function (Blueprint $table) {
+                $table->enum('status', ['draft', 'published', 'archived'])->default('draft');
+            });
+
+            DB::statement("UPDATE blogs SET status = status_temp");
+
+            Schema::table('blogs', function (Blueprint $table) {
+                $table->dropColumn('status_temp');
+            });
         }
     }
 };

--- a/resources/js/pages/Blog.vue
+++ b/resources/js/pages/Blog.vue
@@ -260,14 +260,25 @@ const {
                         <h2 class="text-base font-semibold">Browse the library</h2>
                         <p class="text-sm text-muted-foreground">Focus on categories and tags to surface relevant posts.</p>
                     </div>
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        :disabled="!hasActiveFilters"
-                        @click="clearFilters"
-                    >
-                        Clear filters
-                    </Button>
+                    <div class="flex items-center gap-3">
+                        <a
+                            :href="route('blogs.feed')"
+                            rel="alternate"
+                            type="application/atom+xml"
+                            target="_blank"
+                            class="text-sm font-medium text-primary transition hover:text-primary/80"
+                        >
+                            Subscribe via RSS
+                        </a>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            :disabled="!hasActiveFilters"
+                            @click="clearFilters"
+                        >
+                            Clear filters
+                        </Button>
+                    </div>
                 </div>
 
                 <div class="space-y-3">

--- a/resources/views/feeds/blog.blade.php
+++ b/resources/views/feeds/blog.blade.php
@@ -1,0 +1,20 @@
+@php echo '<?xml version="1.0" encoding="UTF-8"?>'; @endphp
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title>{{ $title }}</title>
+    <id>{{ $selfUrl }}</id>
+    <link href="{{ $selfUrl }}" rel="self" />
+    <link href="{{ $homeUrl }}" />
+    <updated>{{ $updatedAt }}</updated>
+    @foreach ($entries as $entry)
+        <entry>
+            <title>{{ $entry['title'] }}</title>
+            <id>{{ $entry['link'] }}</id>
+            <link href="{{ $entry['link'] }}" />
+            @if (!empty($entry['excerpt']))
+                <summary type="html">{{ $entry['excerpt'] }}</summary>
+            @endif
+            <published>{{ $entry['published_at'] }}</published>
+            <updated>{{ $entry['updated_at'] }}</updated>
+        </entry>
+    @endforeach
+</feed>

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ Route::get('/', function () {
 
 // Public Blog Routes
 Route::get('/blogs', [BlogController::class, 'index'])->name('blogs.index');
+Route::get('/blogs/feed', [BlogController::class, 'feed'])->name('blogs.feed');
 Route::get('/blogs/preview/{blog}/{token}', [BlogController::class, 'preview'])->name('blogs.preview');
 Route::get('/blogs/{slug}', [BlogController::class, 'show'])->name('blogs.view');
 

--- a/tests/Feature/Blog/BlogFeedTest.php
+++ b/tests/Feature/Blog/BlogFeedTest.php
@@ -3,11 +3,14 @@
 namespace Tests\Feature\Blog;
 
 use App\Models\Blog;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
 class BlogFeedTest extends TestCase
 {
+    use RefreshDatabase;
+
     public function test_feed_returns_atom_xml_with_latest_published_posts(): void
     {
         $olderPost = Blog::factory()->published()->create([

--- a/tests/Feature/Blog/BlogFeedTest.php
+++ b/tests/Feature/Blog/BlogFeedTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\Blog;
+
+use App\Models\Blog;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class BlogFeedTest extends TestCase
+{
+    public function test_feed_returns_atom_xml_with_latest_published_posts(): void
+    {
+        $olderPost = Blog::factory()->published()->create([
+            'published_at' => Carbon::now()->subDays(5),
+        ]);
+
+        $newerPost = Blog::factory()->published()->create([
+            'published_at' => Carbon::now()->subMinutes(5),
+        ]);
+
+        $scheduledPost = Blog::factory()->scheduled()->create([
+            'scheduled_for' => Carbon::now()->subMinutes(30),
+        ]);
+        $expectedScheduledPublishedAt = $scheduledPost->scheduled_for->copy();
+
+        $response = $this->get(route('blogs.feed'));
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'application/atom+xml; charset=UTF-8');
+
+        $this->assertDatabaseHas('blogs', [
+            'id' => $scheduledPost->id,
+            'status' => 'published',
+            'published_at' => $expectedScheduledPublishedAt,
+        ]);
+
+        $xml = simplexml_load_string($response->getContent());
+
+        $this->assertNotFalse($xml, 'Feed response should be valid XML.');
+        $this->assertSame('feed', $xml->getName());
+        $this->assertSame(route('blogs.feed'), (string) $xml->id);
+        $this->assertCount(3, $xml->entry);
+
+        $firstEntry = $xml->entry[0];
+        $this->assertSame($newerPost->title, (string) $firstEntry->title);
+        $this->assertSame(route('blogs.view', ['slug' => $newerPost->slug]), (string) $firstEntry->link['href']);
+        $this->assertSame($newerPost->excerpt, trim((string) $firstEntry->summary));
+        $this->assertSame($newerPost->published_at->toAtomString(), (string) $firstEntry->published);
+
+        $secondEntry = $xml->entry[1];
+        $this->assertSame(route('blogs.view', ['slug' => $scheduledPost->slug]), (string) $secondEntry->link['href']);
+        $this->assertSame(
+            $expectedScheduledPublishedAt->toAtomString(),
+            (string) $secondEntry->published,
+        );
+
+        $thirdEntry = $xml->entry[2];
+        $this->assertSame(route('blogs.view', ['slug' => $olderPost->slug]), (string) $thirdEntry->link['href']);
+    }
+}


### PR DESCRIPTION
## Summary
- add an Atom feed endpoint on the blog controller and route it under /blogs/feed
- render the Atom XML through a dedicated Blade view and link it from the blog index page
- cover the feed output and scheduled post publishing with a new feature test

## Testing
- php artisan test --filter=BlogFeedTest *(fails: composer dependencies could not be installed because external downloads are blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de03817930832cbc9e3f3f26c2fe27