### PR TITLE
Allow customers to reopen support tickets

### DIFF
--- a/app/Http/Controllers/SupportCenterController.php
+++ b/app/Http/Controllers/SupportCenterController.php
@@ -354,6 +354,26 @@ class SupportCenterController extends Controller
         return back()->with('success', 'Ticket closed.');
     }
 
+    public function reopen(Request $request, SupportTicket $ticket): RedirectResponse
+    {
+        $user = $request->user();
+
+        abort_unless($user && (int) $ticket->user_id === (int) $user->id, 403);
+
+        if ($ticket->status !== 'closed') {
+            return back()->with('info', 'This ticket is already open.');
+        }
+
+        $ticket->update([
+            'status' => 'open',
+            'resolved_at' => null,
+            'resolved_by' => null,
+            'customer_satisfaction_rating' => null,
+        ]);
+
+        return back()->with('success', 'Ticket reopened. We will take another look.');
+    }
+
     private function escapeForLike(string $value): string
     {
         return str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $value);

--- a/resources/js/pages/SupportTicketView.vue
+++ b/resources/js/pages/SupportTicketView.vue
@@ -114,6 +114,8 @@ const ratingForm = useForm<{ rating: number | null }>({
     rating: null,
 });
 
+const reopenForm = useForm<Record<string, never>>({});
+
 const isClosed = computed(() => props.ticket.status === 'closed');
 const canRateTicket = computed(() => props.canRate);
 
@@ -190,6 +192,24 @@ const submitRating = () => {
         onSuccess: () => {
             ratingForm.reset('rating');
         },
+    });
+};
+
+const confirmReopenTicket = () => {
+    if (!isClosed.value || reopenForm.processing) {
+        return;
+    }
+
+    if (
+        !window.confirm(
+            'Reopen this ticket to let our support team know you still need help? We will notify the team immediately.',
+        )
+    ) {
+        return;
+    }
+
+    reopenForm.patch(route('support.tickets.reopen', { ticket: props.ticket.id }), {
+        preserveScroll: true,
     });
 };
 
@@ -476,6 +496,28 @@ const formatFileSize = (bytes: number) => {
                             <p v-else class="text-muted-foreground">
                                 We'll invite you to rate your experience once our team resolves this ticket.
                             </p>
+                        </CardContent>
+                    </Card>
+
+                    <Card v-if="isClosed">
+                        <CardHeader>
+                            <CardTitle>Need more help?</CardTitle>
+                            <CardDescription>
+                                Reopen this ticket to continue the conversation with our support team.
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent class="space-y-4 text-sm">
+                            <p class="text-muted-foreground">
+                                If the issue resurfaces or you have new information, let us know and we'll jump back in.
+                            </p>
+                            <Button
+                                type="button"
+                                :disabled="reopenForm.processing"
+                                @click="confirmReopenTicket"
+                            >
+                                <span v-if="reopenForm.processing">Reopening…</span>
+                                <span v-else>Reopen ticket</span>
+                            </Button>
                         </CardContent>
                     </Card>
 

--- a/resources/js/pages/SupportTicketView.vue
+++ b/resources/js/pages/SupportTicketView.vue
@@ -11,6 +11,14 @@ import InputError from '@/components/InputError.vue';
 import { useUserTimezone } from '@/composables/useUserTimezone';
 import Input from '@/components/ui/input/Input.vue';
 import { Paperclip } from 'lucide-vue-next';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
 
 interface TicketAssignee {
     id: number;
@@ -119,6 +127,8 @@ const reopenForm = useForm<Record<string, never>>({});
 const isClosed = computed(() => props.ticket.status === 'closed');
 const canRateTicket = computed(() => props.canRate);
 
+const reopenDialogOpen = ref(false);
+
 const handleAttachmentsChange = (event: Event) => {
     const target = event.target as HTMLInputElement;
 
@@ -195,21 +205,34 @@ const submitRating = () => {
     });
 };
 
-const confirmReopenTicket = () => {
+const handleReopenDialogChange = (open: boolean) => {
+    if (!open && reopenForm.processing) {
+        return;
+    }
+
+    reopenDialogOpen.value = open;
+
+    if (!open) {
+        reopenForm.clearErrors();
+    }
+};
+
+const openReopenDialog = () => {
     if (!isClosed.value || reopenForm.processing) {
         return;
     }
 
-    if (
-        !window.confirm(
-            'Reopen this ticket to let our support team know you still need help? We will notify the team immediately.',
-        )
-    ) {
+    handleReopenDialogChange(true);
+};
+
+const submitReopenTicket = () => {
+    if (!isClosed.value || reopenForm.processing) {
         return;
     }
 
     reopenForm.patch(route('support.tickets.reopen', { ticket: props.ticket.id }), {
         preserveScroll: true,
+        onSuccess: () => handleReopenDialogChange(false),
     });
 };
 
@@ -510,11 +533,7 @@ const formatFileSize = (bytes: number) => {
                             <p class="text-muted-foreground">
                                 If the issue resurfaces or you have new information, let us know and we'll jump back in.
                             </p>
-                            <Button
-                                type="button"
-                                :disabled="reopenForm.processing"
-                                @click="confirmReopenTicket"
-                            >
+                            <Button type="button" :disabled="reopenForm.processing" @click="openReopenDialog">
                                 <span v-if="reopenForm.processing">Reopening…</span>
                                 <span v-else>Reopen ticket</span>
                             </Button>
@@ -535,5 +554,35 @@ const formatFileSize = (bytes: number) => {
                 </div>
             </div>
         </div>
+
+        <Dialog :open="reopenDialogOpen" @update:open="handleReopenDialogChange">
+            <DialogContent class="sm:max-w-[28rem]">
+                <DialogHeader>
+                    <DialogTitle>Reopen this ticket?</DialogTitle>
+                    <DialogDescription>
+                        Let our support team know you still need assistance. We will notify them right away so they can
+                        follow up.
+                    </DialogDescription>
+                </DialogHeader>
+                <p class="text-sm text-muted-foreground">
+                    Reopening the ticket clears the previous resolution details and puts it back in the support queue.
+                    You can always close it again once everything is resolved.
+                </p>
+                <DialogFooter class="flex flex-col gap-2 sm:flex-row sm:justify-end">
+                    <Button
+                        type="button"
+                        variant="outline"
+                        :disabled="reopenForm.processing"
+                        @click="handleReopenDialogChange(false)"
+                    >
+                        Cancel
+                    </Button>
+                    <Button type="button" :disabled="reopenForm.processing" @click="submitReopenTicket">
+                        <span v-if="reopenForm.processing">Reopening…</span>
+                        <span v-else>Reopen ticket</span>
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
     </AppLayout>
 </template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -91,6 +91,9 @@ Route::middleware('auth')->group(function () {
 
     Route::patch('support/tickets/{ticket}/status', [SupportCenterController::class, 'updateStatus'])
         ->name('support.tickets.status.update');
+
+    Route::patch('support/tickets/{ticket}/reopen', [SupportCenterController::class, 'reopen'])
+        ->name('support.tickets.reopen');
 });
 
 //AUTH REQUIRED PAGES

--- a/tests/Feature/Support/SupportTicketReopenTest.php
+++ b/tests/Feature/Support/SupportTicketReopenTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature\Support;
+
+use App\Models\SupportTicket;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class SupportTicketReopenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ticket_owner_can_reopen_closed_ticket(): void
+    {
+        Carbon::setTestNow('2025-02-15 15:00:00');
+
+        $user = User::factory()->create();
+        $agent = User::factory()->create();
+
+        $ticket = SupportTicket::create([
+            'user_id' => $user->id,
+            'subject' => 'Need more help',
+            'body' => 'The problem came back.',
+            'status' => 'closed',
+            'priority' => 'medium',
+            'resolved_at' => Carbon::now()->subDay(),
+            'resolved_by' => $agent->id,
+            'customer_satisfaction_rating' => 2,
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->from(route('support.tickets.show', $ticket))
+            ->patch(route('support.tickets.reopen', $ticket));
+
+        $response->assertRedirect(route('support.tickets.show', $ticket));
+        $response->assertSessionHas('success', 'Ticket reopened. We will take another look.');
+
+        $freshTicket = $ticket->fresh();
+
+        $this->assertSame('open', $freshTicket->status);
+        $this->assertNull($freshTicket->resolved_at);
+        $this->assertNull($freshTicket->resolved_by);
+        $this->assertNull($freshTicket->customer_satisfaction_rating);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_ticket_owner_cannot_reopen_active_ticket(): void
+    {
+        $user = User::factory()->create();
+
+        $ticket = SupportTicket::create([
+            'user_id' => $user->id,
+            'subject' => 'Still in progress',
+            'body' => 'Waiting for an update.',
+            'status' => 'open',
+            'priority' => 'high',
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->from(route('support.tickets.show', $ticket))
+            ->patch(route('support.tickets.reopen', $ticket));
+
+        $response->assertRedirect(route('support.tickets.show', $ticket));
+        $response->assertSessionHas('info', 'This ticket is already open.');
+    }
+
+    public function test_non_owner_cannot_reopen_ticket(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $ticket = SupportTicket::create([
+            'user_id' => $otherUser->id,
+            'subject' => 'Closed elsewhere',
+            'body' => 'Should remain closed.',
+            'status' => 'closed',
+            'priority' => 'low',
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->patch(route('support.tickets.reopen', $ticket));
+
+        $response->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary
- add an authenticated route for reopening support tickets and guard it to ticket owners
- reset resolution metadata when a user reopens their ticket
- expose a reopen action in the ticket view with a confirmation prompt and cover it with feature tests

## Testing
- php artisan test tests/Feature/Support/SupportTicketReopenTest.php *(fails: vendor autoload missing because Composer install is blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de03a27bbc832cac5dde7a93d9709a