### PR TITLE
Add filters and pagination to token logs

### DIFF
--- a/resources/js/pages/acp/Tokens.vue
+++ b/resources/js/pages/acp/Tokens.vue
@@ -309,7 +309,7 @@ const {
 
 function cleanQuery(query: Record<string, unknown>) {
     return Object.fromEntries(
-        Object.entries(query).filter(([_, value]) => {
+        Object.entries(query).filter(([, value]) => {
             if (value === null || value === undefined) {
                 return false;
             }

--- a/resources/js/pages/acp/Tokens.vue
+++ b/resources/js/pages/acp/Tokens.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import dayjs from 'dayjs';
-import { ref, computed, watch, onBeforeUnmount } from 'vue';
+import { ref, computed, watch, onBeforeUnmount, reactive } from 'vue';
 import AppLayout from '@/layouts/AppLayout.vue';
 import AdminLayout from '@/layouts/acp/AdminLayout.vue';
 import { Head, Link, router, useForm, usePage } from '@inertiajs/vue3';
@@ -89,16 +89,26 @@ interface TokenLog {
     timestamp: string | null;
 }
 
+interface PaginationLinks {
+    first: string | null;
+    last: string | null;
+    prev: string | null;
+    next: string | null;
+}
+
+interface TokenLogFilters {
+    token?: string | null;
+    status?: string | null;
+    date_from?: string | null;
+    date_to?: string | null;
+    per_page?: number | null;
+}
+
 const props = defineProps<{
     tokens: {
         data: Token[];
         meta?: PaginationMeta | null;
-        links?: {
-            first: string | null;
-            last: string | null;
-            prev: string | null;
-            next: string | null;
-        } | null;
+        links?: PaginationLinks | null;
     };
     tokenStats: {
         total: number;
@@ -111,7 +121,12 @@ const props = defineProps<{
         nickname: string;
         email: string;
     }>;
-    tokenLogs: TokenLog[];
+    tokenLogs: {
+        data: TokenLog[];
+        meta?: PaginationMeta | null;
+        links?: PaginationLinks | null;
+    };
+    logFilters?: TokenLogFilters | null;
 }>();
 
 const page = usePage<SharedData & { flash?: { plain_text_token?: string | null; success?: string | null; error?: string | null } }>();
@@ -184,7 +199,65 @@ onBeforeUnmount(() => {
 
 const tokensMetaSource = computed(() => props.tokens.meta ?? null);
 const tokenItems = computed(() => props.tokens.data ?? []);
-const tokenLogsItems = computed(() => props.tokenLogs ?? []);
+
+const LOGS_PER_PAGE_DEFAULT = 25;
+const LOGS_PER_PAGE_OPTIONS = [10, 25, 50, 100];
+
+const logFiltersState = reactive({
+    token: props.logFilters?.token ?? '',
+    status: props.logFilters?.status ?? '',
+    date_from: props.logFilters?.date_from ?? '',
+    date_to: props.logFilters?.date_to ?? '',
+});
+
+const initialLogsPerPage = props.logFilters?.per_page
+    ?? props.tokenLogs.meta?.per_page
+    ?? LOGS_PER_PAGE_DEFAULT;
+
+const logsPerPage = ref(Number.isFinite(initialLogsPerPage) && initialLogsPerPage ? initialLogsPerPage : LOGS_PER_PAGE_DEFAULT);
+
+const tokenLogsMetaSource = computed(() => props.tokenLogs.meta ?? null);
+const tokenLogsItems = computed(() => props.tokenLogs.data ?? []);
+
+watch(
+    () => props.logFilters,
+    (filters) => {
+        logFiltersState.token = filters?.token ?? '';
+        logFiltersState.status = filters?.status ?? '';
+        logFiltersState.date_from = filters?.date_from ?? '';
+        logFiltersState.date_to = filters?.date_to ?? '';
+
+        if (typeof filters?.per_page === 'number' && filters.per_page > 0) {
+            logsPerPage.value = filters.per_page;
+        }
+    },
+    { deep: true },
+);
+
+watch(
+    () => props.tokenLogs.meta?.per_page,
+    (perPage) => {
+        if (typeof perPage === 'number' && perPage > 0) {
+            logsPerPage.value = perPage;
+        }
+    },
+);
+
+const availableLogStatuses = computed(() => {
+    const statuses = new Set<string>(['success', 'failed']);
+
+    if (logFiltersState.status) {
+        statuses.add(logFiltersState.status);
+    }
+
+    tokenLogsItems.value.forEach((log) => {
+        if (log.status) {
+            statuses.add(log.status);
+        }
+    });
+
+    return Array.from(statuses).sort((a, b) => a.localeCompare(b));
+});
 
 const {
     meta: tokensMeta,
@@ -200,7 +273,7 @@ const {
     onNavigate: (page) => {
         router.get(
             route('acp.tokens.index'),
-            { page },
+            buildQueryParams({ page }),
             {
                 preserveScroll: true,
                 preserveState: true,
@@ -209,6 +282,93 @@ const {
         );
     },
 });
+
+const {
+    meta: tokenLogsMeta,
+    page: tokenLogsPage,
+    setPage: setTokenLogsPage,
+    rangeLabel: tokenLogsRangeLabel,
+} = useInertiaPagination({
+    meta: tokenLogsMetaSource,
+    itemsLength: computed(() => tokenLogsItems.value.length),
+    defaultPerPage: logsPerPage.value || LOGS_PER_PAGE_DEFAULT,
+    itemLabel: 'log entry',
+    itemLabelPlural: 'log entries',
+    onNavigate: (page) => {
+        router.get(
+            route('acp.tokens.index'),
+            buildQueryParams({ logs_page: page }),
+            {
+                preserveScroll: true,
+                preserveState: true,
+                replace: true,
+            },
+        );
+    },
+});
+
+function cleanQuery(query: Record<string, unknown>) {
+    return Object.fromEntries(
+        Object.entries(query).filter(([_, value]) => {
+            if (value === null || value === undefined) {
+                return false;
+            }
+
+            if (typeof value === 'string') {
+                return value.trim() !== '';
+            }
+
+            return true;
+        }),
+    );
+}
+
+function buildQueryParams(overrides: Record<string, unknown> = {}) {
+    return cleanQuery({
+        page: tokensPage.value,
+        logs_page: tokenLogsPage.value,
+        logs_per_page: logsPerPage.value,
+        token: logFiltersState.token,
+        status: logFiltersState.status,
+        date_from: logFiltersState.date_from,
+        date_to: logFiltersState.date_to,
+        ...overrides,
+    });
+}
+
+const applyLogFilters = (overrides: Record<string, unknown> = {}) => {
+    setTokenLogsPage(1, { emitNavigate: false });
+
+    router.get(
+        route('acp.tokens.index'),
+        buildQueryParams({ logs_page: 1, ...overrides }),
+        {
+            preserveScroll: true,
+            preserveState: true,
+            replace: true,
+        },
+    );
+};
+
+const resetLogFilters = () => {
+    logFiltersState.token = '';
+    logFiltersState.status = '';
+    logFiltersState.date_from = '';
+    logFiltersState.date_to = '';
+    logsPerPage.value = LOGS_PER_PAGE_DEFAULT;
+
+    applyLogFilters({ logs_per_page: LOGS_PER_PAGE_DEFAULT });
+};
+
+const onLogsPerPageChange = (value: number) => {
+    const nextValue = Number.isFinite(value) && value > 0 ? value : LOGS_PER_PAGE_DEFAULT;
+    logsPerPage.value = nextValue;
+    applyLogFilters({ logs_per_page: nextValue });
+};
+
+const showTokenLogsPagination = computed(
+    () => tokenLogsMeta.value.total > tokenLogsMeta.value.per_page,
+);
 
 const totalTokens = computed(() => props.tokenStats.total);
 const activeTokens = computed(() => props.tokenStats.active);
@@ -379,25 +539,6 @@ const lastUsedDisplay = (value?: string | null) => {
 
     return fromNow(value);
 };
-
-const logSearchQuery = ref('');
-const filteredLogs = computed(() => {
-    const logs = tokenLogsItems.value;
-
-    if (!logSearchQuery.value) {
-        return logs;
-    }
-    const q = logSearchQuery.value.toLowerCase();
-    return logs.filter((log) => {
-        const tokenName = log.token_name?.toLowerCase() ?? '';
-        return (
-            tokenName.includes(q) ||
-            log.api_route.toLowerCase().includes(q) ||
-            log.status.toLowerCase().includes(q) ||
-            log.method.toLowerCase().includes(q)
-        );
-    });
-});
 </script>
 
 <template>
@@ -814,15 +955,71 @@ const filteredLogs = computed(() => {
                     <!-- Token Logs Tab -->
                     <TabsContent value="logs" class="space-y-6">
                         <div class="rounded-xl border border-sidebar-border/70 dark:border-sidebar-border p-4">
-                            <div class="flex flex-col md:flex-row md:items-center md:justify-between mb-4">
-                                <h2 class="text-lg font-semibold mb-2 md:mb-0">Token Activity Logs</h2>
-                                <div class="flex space-x-2">
-                                    <!-- Search Bar for Logs -->
-                                    <Input
-                                        v-model="logSearchQuery"
-                                        placeholder="Search logs..."
-                                        class="w-full rounded-md"
-                                    />
+                            <div class="flex flex-col gap-4 mb-4">
+                                <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
+                                    <div>
+                                        <h2 class="text-lg font-semibold">Token Activity Logs</h2>
+                                        <p class="text-sm text-muted-foreground mt-1">
+                                            Filter logs by token name, status, or a specific date range.
+                                        </p>
+                                    </div>
+                                    <form
+                                        class="grid w-full gap-3 md:w-auto md:grid-cols-2 lg:grid-cols-4"
+                                        @submit.prevent="applyLogFilters()"
+                                    >
+                                        <div class="flex flex-col gap-1">
+                                            <Label for="log-token-filter">Token</Label>
+                                            <Input
+                                                id="log-token-filter"
+                                                v-model="logFiltersState.token"
+                                                placeholder="Token name"
+                                                class="w-full rounded-md"
+                                            />
+                                        </div>
+                                        <div class="flex flex-col gap-1">
+                                            <Label for="log-status-filter">Status</Label>
+                                            <select
+                                                id="log-status-filter"
+                                                v-model="logFiltersState.status"
+                                                class="flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                                            >
+                                                <option value="">All statuses</option>
+                                                <option
+                                                    v-for="statusOption in availableLogStatuses"
+                                                    :key="statusOption"
+                                                    :value="statusOption"
+                                                >
+                                                    {{ statusOption }}
+                                                </option>
+                                            </select>
+                                        </div>
+                                        <div class="flex flex-col gap-1">
+                                            <Label for="log-date-from">From</Label>
+                                            <Input
+                                                id="log-date-from"
+                                                v-model="logFiltersState.date_from"
+                                                type="datetime-local"
+                                                class="w-full rounded-md"
+                                            />
+                                        </div>
+                                        <div class="flex flex-col gap-1">
+                                            <Label for="log-date-to">To</Label>
+                                            <Input
+                                                id="log-date-to"
+                                                v-model="logFiltersState.date_to"
+                                                type="datetime-local"
+                                                class="w-full rounded-md"
+                                            />
+                                        </div>
+                                        <div class="flex items-center justify-end gap-2 md:col-span-2 lg:col-span-4">
+                                            <Button type="button" variant="outline" @click="resetLogFilters">
+                                                Reset
+                                            </Button>
+                                            <Button type="submit">
+                                                Apply
+                                            </Button>
+                                        </div>
+                                    </form>
                                 </div>
                             </div>
                             <!-- Logs Table -->
@@ -840,7 +1037,7 @@ const filteredLogs = computed(() => {
                                     </TableHeader>
                                     <TableBody>
                                         <TableRow
-                                            v-for="log in filteredLogs"
+                                            v-for="log in tokenLogsItems"
                                             :key="log.id"
                                             class="hover:bg-gray-50 dark:hover:bg-gray-900"
                                         >
@@ -862,13 +1059,72 @@ const filteredLogs = computed(() => {
                                                 </Link>
                                             </TableCell>
                                         </TableRow>
-                                        <TableRow v-if="filteredLogs.length === 0">
+                                        <TableRow v-if="tokenLogsItems.length === 0">
                                             <TableCell colspan="6" class="text-center text-sm text-gray-600 dark:text-gray-300">
                                                 No token activity found.
                                             </TableCell>
                                         </TableRow>
                                     </TableBody>
                                 </Table>
+                            </div>
+                            <div class="flex flex-col items-center justify-between gap-4 md:flex-row">
+                                <div class="text-sm text-muted-foreground text-center md:text-left">
+                                    {{ tokenLogsRangeLabel }}
+                                </div>
+                                <div class="flex flex-col items-center gap-3 md:flex-row md:items-center">
+                                    <label class="flex items-center gap-2 text-sm text-muted-foreground">
+                                        <span>Per page</span>
+                                        <select
+                                            class="h-9 rounded-md border border-input bg-transparent px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                            :value="logsPerPage"
+                                            @change="onLogsPerPageChange(Number(($event.target as HTMLSelectElement).value))"
+                                        >
+                                            <option
+                                                v-for="option in LOGS_PER_PAGE_OPTIONS"
+                                                :key="option"
+                                                :value="option"
+                                            >
+                                                {{ option }}
+                                            </option>
+                                        </select>
+                                    </label>
+                                    <Pagination
+                                        v-if="showTokenLogsPagination"
+                                        v-slot="{ page, pageCount }"
+                                        v-model:page="tokenLogsPage"
+                                        :items-per-page="Math.max(tokenLogsMeta.per_page, 1)"
+                                        :total="tokenLogsMeta.total"
+                                        :sibling-count="1"
+                                        show-edges
+                                    >
+                                        <div class="flex flex-col items-center gap-2 md:flex-row md:items-center md:gap-3">
+                                            <span class="text-sm text-muted-foreground">Page {{ page }} of {{ pageCount }}</span>
+                                            <PaginationList v-slot="{ items }" class="flex items-center gap-1">
+                                                <PaginationFirst />
+                                                <PaginationPrev />
+
+                                                <template v-for="(item, index) in items" :key="index">
+                                                    <PaginationListItem
+                                                        v-if="item.type === 'page'"
+                                                        :value="item.value"
+                                                        as-child
+                                                    >
+                                                        <Button class="w-9 h-9 p-0" :variant="item.value === page ? 'default' : 'outline'">
+                                                            {{ item.value }}
+                                                        </Button>
+                                                    </PaginationListItem>
+                                                    <PaginationEllipsis
+                                                        v-else
+                                                        :index="index"
+                                                    />
+                                                </template>
+
+                                                <PaginationNext />
+                                                <PaginationLast />
+                                            </PaginationList>
+                                        </div>
+                                    </Pagination>
+                                </div>
                             </div>
                         </div>
                     </TabsContent>

--- a/tests/Feature/Admin/TokenLogPaginationTest.php
+++ b/tests/Feature/Admin/TokenLogPaginationTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\PersonalAccessToken;
+use App\Models\TokenLog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Inertia\Testing\AssertableInertia as Assert;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class TokenLogPaginationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function signInAdmin(): User
+    {
+        $role = Role::firstOrCreate(['name' => 'admin']);
+        $admin = User::factory()->create();
+        $admin->assignRole($role);
+
+        $this->actingAs($admin);
+
+        return $admin;
+    }
+
+    private function createToken(User $user, string $name): PersonalAccessToken
+    {
+        return $user->createToken($name)->accessToken;
+    }
+
+    private function createTokenLog(PersonalAccessToken $token, array $overrides = []): TokenLog
+    {
+        $log = new TokenLog([
+            'personal_access_token_id' => $overrides['personal_access_token_id'] ?? $token->id,
+            'token_name' => $overrides['token_name'] ?? $token->name,
+            'route' => $overrides['route'] ?? '/api/example',
+            'method' => $overrides['method'] ?? 'GET',
+            'status' => $overrides['status'] ?? 'success',
+            'http_status' => $overrides['http_status'] ?? 200,
+        ]);
+
+        $createdAt = $overrides['created_at'] ?? Carbon::now();
+        $updatedAt = $overrides['updated_at'] ?? $createdAt;
+
+        $log->created_at = $createdAt;
+        $log->updated_at = $updatedAt;
+
+        $log->save();
+
+        return $log;
+    }
+
+    public function test_token_logs_are_paginated(): void
+    {
+        $this->signInAdmin();
+
+        $tokenOwner = User::factory()->create();
+        $token = $this->createToken($tokenOwner, 'Primary token');
+
+        foreach (range(1, 60) as $index) {
+            $this->createTokenLog($token, [
+                'route' => "/api/example/{$index}",
+                'status' => $index % 2 === 0 ? 'success' : 'failed',
+                'created_at' => Carbon::now()->subMinutes($index),
+            ]);
+        }
+
+        $response = $this->get(route('acp.tokens.index', [
+            'logs_per_page' => 25,
+        ]));
+
+        $response->assertOk();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('acp/Tokens')
+            ->where('logFilters.per_page', 25)
+            ->where('tokenLogs.meta.total', 60)
+            ->where('tokenLogs.meta.per_page', 25)
+            ->where('tokenLogs.meta.current_page', 1)
+            ->where('tokenLogs.data', fn ($logs) => count($logs) === 25)
+        );
+
+        $secondPage = $this->get(route('acp.tokens.index', [
+            'logs_page' => 2,
+            'logs_per_page' => 25,
+        ]));
+
+        $secondPage->assertOk();
+
+        $secondPage->assertInertia(fn (Assert $page) => $page
+            ->component('acp/Tokens')
+            ->where('tokenLogs.meta.current_page', 2)
+            ->where('tokenLogs.meta.per_page', 25)
+            ->where('logFilters.per_page', 25)
+            ->where('tokenLogs.data', fn ($logs) => count($logs) === 25)
+        );
+    }
+
+    public function test_token_log_filters_are_applied_and_persisted(): void
+    {
+        $this->signInAdmin();
+
+        $user = User::factory()->create();
+        $alphaToken = $this->createToken($user, 'Alpha Token');
+        $betaToken = $this->createToken($user, 'Beta Token');
+
+        $inRange = Carbon::now()->subDay();
+        $outOfRange = Carbon::now()->subWeeks(2);
+
+        $matchingLog = $this->createTokenLog($alphaToken, [
+            'route' => '/api/alpha/success',
+            'status' => 'success',
+            'created_at' => $inRange,
+        ]);
+
+        $this->createTokenLog($alphaToken, [
+            'route' => '/api/alpha/failed',
+            'status' => 'failed',
+            'created_at' => $inRange,
+        ]);
+
+        $this->createTokenLog($betaToken, [
+            'route' => '/api/beta/success',
+            'status' => 'success',
+            'created_at' => $inRange,
+        ]);
+
+        $this->createTokenLog($alphaToken, [
+            'route' => '/api/alpha/old',
+            'status' => 'success',
+            'created_at' => $outOfRange,
+        ]);
+
+        $dateFrom = $inRange->copy()->startOfDay()->format('Y-m-d\TH:i');
+        $dateTo = $inRange->copy()->endOfDay()->format('Y-m-d\TH:i');
+
+        $response = $this->get(route('acp.tokens.index', [
+            'token' => 'Alpha',
+            'status' => 'success',
+            'date_from' => $dateFrom,
+            'date_to' => $dateTo,
+            'logs_per_page' => 10,
+        ]));
+
+        $response->assertOk();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('acp/Tokens')
+            ->where('logFilters.token', 'Alpha')
+            ->where('logFilters.status', 'success')
+            ->where('logFilters.date_from', $dateFrom)
+            ->where('logFilters.date_to', $dateTo)
+            ->where('logFilters.per_page', 10)
+            ->where('tokenLogs.meta.total', 1)
+            ->where('tokenLogs.data', fn ($logs) => count($logs) === 1 && $logs[0]['id'] === $matchingLog->id)
+        );
+
+        $secondResponse = $this->get(route('acp.tokens.index', [
+            'token' => 'Alpha',
+            'status' => 'success',
+            'date_from' => $dateFrom,
+            'date_to' => $dateTo,
+            'logs_page' => 2,
+            'logs_per_page' => 10,
+        ]));
+
+        $secondResponse->assertOk();
+
+        $secondResponse->assertInertia(fn (Assert $page) => $page
+            ->component('acp/Tokens')
+            ->where('logFilters.token', 'Alpha')
+            ->where('logFilters.status', 'success')
+            ->where('tokenLogs.meta.current_page', 2)
+            ->where('tokenLogs.data', fn ($logs) => count($logs) === 0)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- replace the admin token log query with a paginated builder that supports token, status, and date filters while returning filter state to Inertia
- enhance the Tokens.vue page with filter inputs, preserved query params, and paginated activity log controls tied to the server
- add feature coverage that exercises the new pagination and filtering behaviour across multiple pages of token activity

## Testing
- `php artisan test --filter TokenLogPaginationTest` *(fails: vendor dependencies unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de03cef1c0832c97757cc80d177471