### PR TITLE
Add FAQ categories and redesign support FAQ experience

### DIFF
--- a/app/Http/Controllers/Admin/FaqCategoryController.php
+++ b/app/Http/Controllers/Admin/FaqCategoryController.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\FaqCategoryRequest;
+use App\Models\FaqCategory;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Inertia\Response;
+
+class FaqCategoryController extends Controller
+{
+    public function index(Request $request): Response|JsonResponse
+    {
+        $categories = FaqCategory::query()
+            ->withCount('faqs')
+            ->orderBy('order')
+            ->orderBy('name')
+            ->get()
+            ->map(fn (FaqCategory $category) => [
+                'id' => $category->id,
+                'name' => $category->name,
+                'slug' => $category->slug,
+                'description' => $category->description,
+                'order' => $category->order,
+                'faqs_count' => $category->faqs_count ?? 0,
+                'created_at' => optional($category->created_at)->toIso8601String(),
+                'updated_at' => optional($category->updated_at)->toIso8601String(),
+            ])
+            ->values()
+            ->all();
+
+        if ($request->wantsJson()) {
+            return response()->json(['categories' => $categories]);
+        }
+
+        return inertia('acp/SupportFaqCategories', [
+            'categories' => $categories,
+        ]);
+    }
+
+    public function create(): Response
+    {
+        return inertia('acp/SupportFaqCategoryCreate');
+    }
+
+    public function store(FaqCategoryRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        FaqCategory::create([
+            'name' => $validated['name'],
+            'slug' => $this->resolveSlug($validated['slug'] ?? null, $validated['name']),
+            'description' => $validated['description'] ?? null,
+            'order' => $validated['order'],
+        ]);
+
+        return redirect()
+            ->route('acp.support.faq-categories.index')
+            ->with('success', 'FAQ category created successfully.');
+    }
+
+    public function edit(FaqCategory $category): Response
+    {
+        $category->loadCount('faqs');
+
+        return inertia('acp/SupportFaqCategoryEdit', [
+            'category' => [
+                'id' => $category->id,
+                'name' => $category->name,
+                'slug' => $category->slug,
+                'description' => $category->description,
+                'order' => $category->order,
+                'faqs_count' => $category->faqs_count ?? 0,
+                'created_at' => optional($category->created_at)->toIso8601String(),
+                'updated_at' => optional($category->updated_at)->toIso8601String(),
+            ],
+        ]);
+    }
+
+    public function update(FaqCategoryRequest $request, FaqCategory $category): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        $category->forceFill([
+            'name' => $validated['name'],
+            'slug' => $this->resolveSlug($validated['slug'] ?? null, $validated['name'], $category->id),
+            'description' => $validated['description'] ?? null,
+            'order' => $validated['order'],
+        ])->save();
+
+        return redirect()
+            ->route('acp.support.faq-categories.index')
+            ->with('success', 'FAQ category updated successfully.');
+    }
+
+    public function destroy(FaqCategory $category): RedirectResponse
+    {
+        $category->delete();
+
+        return redirect()
+            ->route('acp.support.faq-categories.index')
+            ->with('success', 'FAQ category deleted successfully.');
+    }
+
+    protected function resolveSlug(?string $slug, string $name, ?int $ignoreId = null): string
+    {
+        $candidate = Str::slug($slug ?: $name);
+
+        if ($candidate === '') {
+            $candidate = Str::random(8);
+        }
+
+        $original = $candidate;
+        $suffix = 1;
+
+        $query = FaqCategory::query()->where('slug', $candidate);
+
+        if ($ignoreId) {
+            $query->where('id', '!=', $ignoreId);
+        }
+
+        while ($query->exists()) {
+            $candidate = $original.'-'.$suffix++;
+
+            $query = FaqCategory::query()->where('slug', $candidate);
+
+            if ($ignoreId) {
+                $query->where('id', '!=', $ignoreId);
+            }
+        }
+
+        return $candidate;
+    }
+}

--- a/app/Http/Requests/Admin/FaqCategoryRequest.php
+++ b/app/Http/Requests/Admin/FaqCategoryRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class FaqCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('slug') && $this->input('slug') === '') {
+            $this->merge(['slug' => null]);
+        }
+
+        if ($this->has('description') && $this->input('description') === '') {
+            $this->merge(['description' => null]);
+        }
+
+        if ($this->has('order')) {
+            $order = $this->input('order');
+
+            if (is_numeric($order)) {
+                $this->merge(['order' => (int) $order]);
+            }
+        }
+    }
+
+    public function rules(): array
+    {
+        $category = $this->route('category');
+
+        $categoryId = $category instanceof Model
+            ? $category->getKey()
+            : (is_numeric($category) ? (int) $category : null);
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'nullable',
+                'string',
+                'max:255',
+                Rule::unique('faq_categories', 'slug')->ignore($categoryId),
+            ],
+            'description' => ['nullable', 'string', 'max:255'],
+            'order' => ['required', 'integer'],
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/StoreFaqRequest.php
+++ b/app/Http/Requests/Admin/StoreFaqRequest.php
@@ -14,6 +14,7 @@ class StoreFaqRequest extends FormRequest
     public function rules()
     {
         return [
+            'faq_category_id' => 'required|integer|exists:faq_categories,id',
             'question'  => 'required|string|max:255',
             'answer'    => 'required|string',
             'order'     => 'integer',

--- a/app/Http/Requests/Admin/UpdateFaqRequest.php
+++ b/app/Http/Requests/Admin/UpdateFaqRequest.php
@@ -14,6 +14,7 @@ class UpdateFaqRequest extends FormRequest
     public function rules()
     {
         return [
+            'faq_category_id' => 'sometimes|required|integer|exists:faq_categories,id',
             'question'  => 'sometimes|required|string|max:255',
             'answer'    => 'sometimes|required|string',
             'order'     => 'integer',

--- a/app/Models/Faq.php
+++ b/app/Models/Faq.php
@@ -3,13 +3,23 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Faq extends Model
 {
     protected $fillable = [
+        'faq_category_id',
         'question',
         'answer',
         'order',
         'published',
     ];
+
+    /**
+     * @return BelongsTo<FaqCategory, self>
+     */
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(FaqCategory::class, 'faq_category_id');
+    }
 }

--- a/app/Models/Faq.php
+++ b/app/Models/Faq.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Faq extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'faq_category_id',
         'question',

--- a/app/Models/FaqCategory.php
+++ b/app/Models/FaqCategory.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class FaqCategory extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'name',
         'slug',

--- a/app/Models/FaqCategory.php
+++ b/app/Models/FaqCategory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class FaqCategory extends Model
+{
+    protected $fillable = [
+        'name',
+        'slug',
+        'description',
+        'order',
+    ];
+
+    /**
+     * @return HasMany<Faq>
+     */
+    public function faqs(): HasMany
+    {
+        return $this->hasMany(Faq::class);
+    }
+}

--- a/database/factories/FaqCategoryFactory.php
+++ b/database/factories/FaqCategoryFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\FaqCategory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<FaqCategory>
+ */
+class FaqCategoryFactory extends Factory
+{
+    protected $model = FaqCategory::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(2, true);
+
+        return [
+            'name' => Str::title($name),
+            'slug' => Str::slug($name),
+            'description' => $this->faker->optional()->sentence(),
+            'order' => $this->faker->numberBetween(0, 20),
+        ];
+    }
+}

--- a/database/factories/FaqFactory.php
+++ b/database/factories/FaqFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Faq;
+use App\Models\FaqCategory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Faq>
+ */
+class FaqFactory extends Factory
+{
+    protected $model = Faq::class;
+
+    public function definition(): array
+    {
+        $question = rtrim($this->faker->sentence(6, true), '.');
+
+        return [
+            'faq_category_id' => FaqCategory::factory(),
+            'question' => $question.'?',
+            'answer' => $this->faker->paragraph(),
+            'order' => $this->faker->numberBetween(0, 20),
+            'published' => $this->faker->boolean(),
+        ];
+    }
+}

--- a/database/migrations/2025_05_10_130000_create_faq_categories_table.php
+++ b/database/migrations/2025_05_10_130000_create_faq_categories_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('faq_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->string('description')->nullable();
+            $table->integer('order')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::table('faqs', function (Blueprint $table) {
+            $table->foreignId('faq_category_id')
+                ->nullable()
+                ->after('id')
+                ->constrained('faq_categories')
+                ->cascadeOnDelete();
+        });
+
+        $now = now();
+        $defaultCategoryId = DB::table('faq_categories')->insertGetId([
+            'name' => 'General',
+            'slug' => Str::slug('General'),
+            'description' => 'General support questions and answers.',
+            'order' => 0,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        DB::table('faqs')->update(['faq_category_id' => $defaultCategoryId]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('faqs', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('faq_category_id');
+        });
+
+        Schema::dropIfExists('faq_categories');
+    }
+};

--- a/resources/js/pages/acp/Support.vue
+++ b/resources/js/pages/acp/Support.vue
@@ -109,6 +109,11 @@ const props = defineProps<{
             answer: string;
             order: number;
             published: boolean;
+            category: {
+                id: number;
+                name: string;
+                slug: string;
+            } | null;
         }>;
         meta?: PaginationMeta | null;
         links?: PaginationLinks | null;
@@ -790,6 +795,7 @@ const unpublishFaq = (faq: FaqItem) => {
                                             <TableHead>ID</TableHead>
                                             <TableHead>Question</TableHead>
                                             <TableHead>Answer</TableHead>
+                                            <TableHead>Category</TableHead>
                                             <TableHead>Order</TableHead>
                                             <TableHead>Published</TableHead>
                                             <TableHead>Actions</TableHead>
@@ -804,6 +810,7 @@ const unpublishFaq = (faq: FaqItem) => {
                                             <TableCell>{{ f.id }}</TableCell>
                                             <TableCell>{{ f.question }}</TableCell>
                                             <TableCell>{{ f.answer }}</TableCell>
+                                            <TableCell>{{ f.category?.name ?? '—' }}</TableCell>
                                             <TableCell>{{ f.order }}</TableCell>
                                             <TableCell>{{ f.published ? 'Yes' : 'No' }}</TableCell>
                                             <TableCell class="text-center">
@@ -864,9 +871,9 @@ const unpublishFaq = (faq: FaqItem) => {
                                             </TableCell>
                                         </TableRow>
                                         <TableRow v-if="!faqItems.length">
-                                            <TableCell colspan="6" class="text-center text-gray-500">
-                                                No FAQs found.
-                                            </TableCell>
+                                        <TableCell colspan="7" class="text-center text-gray-500">
+                                            No FAQs found.
+                                        </TableCell>
                                         </TableRow>
                                     </TableBody>
                                 </Table>

--- a/resources/js/pages/acp/Support.vue
+++ b/resources/js/pages/acp/Support.vue
@@ -770,20 +770,30 @@ const unpublishFaq = (faq: FaqItem) => {
                             <!-- Header: Search & Create -->
                             <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
                                 <h2 class="text-lg font-semibold">FAQ Management</h2>
-                                <div class="flex space-x-2 w-full md:w-auto">
+                                <div class="flex w-full flex-col gap-2 md:w-auto md:flex-row md:items-center md:gap-2">
                                     <Input
                                         v-model="faqSearchQuery"
                                         placeholder="Search FAQs..."
-                                        class="flex-1"
+                                        class="w-full md:w-64"
                                     />
-                                    <Link
-                                        v-if="createSupport"
-                                        :href="route('acp.support.faqs.create')"
-                                    >
-                                        <Button variant="secondary" class="text-sm text-white bg-green-500 hover:bg-green-600">
-                                            Create FAQ
-                                        </Button>
-                                    </Link>
+                                    <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-end md:gap-2">
+                                        <Link
+                                            v-if="editSupport || createSupport"
+                                            :href="route('acp.support.faq-categories.index')"
+                                        >
+                                            <Button variant="outline" class="w-full md:w-auto">
+                                                Manage categories
+                                            </Button>
+                                        </Link>
+                                        <Link
+                                            v-if="createSupport"
+                                            :href="route('acp.support.faqs.create')"
+                                        >
+                                            <Button variant="secondary" class="w-full text-sm text-white md:w-auto bg-green-500 hover:bg-green-600">
+                                                Create FAQ
+                                            </Button>
+                                        </Link>
+                                    </div>
                                 </div>
                             </div>
 

--- a/resources/js/pages/acp/SupportFaqCategories.vue
+++ b/resources/js/pages/acp/SupportFaqCategories.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { useUserTimezone } from '@/composables/useUserTimezone';
+import { LifeBuoy, Pencil, PlusCircle, Trash2 } from 'lucide-vue-next';
+
+const props = defineProps<{
+    categories: Array<{
+        id: number;
+        name: string;
+        slug: string;
+        description: string | null;
+        order: number;
+        faqs_count: number;
+        created_at: string | null;
+        updated_at: string | null;
+    }>;
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Support ACP', href: route('acp.support.index') },
+    { title: 'FAQ categories', href: route('acp.support.faq-categories.index') },
+];
+
+const hasCategories = computed(() => props.categories.length > 0);
+const { formatDate } = useUserTimezone();
+
+const deleteCategory = (categoryId: number) => {
+    if (!confirm('Deleting this category will remove it for any associated FAQs. Continue?')) {
+        return;
+    }
+
+    router.delete(route('acp.support.faq-categories.destroy', { category: categoryId }), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Manage FAQ categories" />
+
+        <AdminLayout>
+            <Card class="flex-1">
+                <CardHeader class="relative overflow-hidden">
+                    <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                    <div class="relative flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <CardTitle class="flex items-center gap-2">
+                                <LifeBuoy class="h-5 w-5" />
+                                FAQ categories
+                            </CardTitle>
+                            <CardDescription>
+                                Group related questions together so visitors can skim support topics more easily.
+                            </CardDescription>
+                        </div>
+                        <Button variant="secondary" as-child>
+                            <Link :href="route('acp.support.faq-categories.create')">
+                                <PlusCircle class="h-4 w-4" />
+                                Create category
+                            </Link>
+                        </Button>
+                    </div>
+                </CardHeader>
+                <CardContent>
+                    <div
+                        v-if="!hasCategories"
+                        class="rounded-lg border border-dashed border-muted-foreground/40 p-6 text-center text-sm text-muted-foreground"
+                    >
+                        No FAQ categories yet. Create one to start organizing your knowledge base content.
+                    </div>
+
+                    <div v-else class="overflow-x-auto">
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead class="w-1/4">Name</TableHead>
+                                    <TableHead class="w-1/4">Slug</TableHead>
+                                    <TableHead class="w-1/6 text-center">Display order</TableHead>
+                                    <TableHead>Description</TableHead>
+                                    <TableHead class="text-center">FAQ count</TableHead>
+                                    <TableHead class="text-center">Updated</TableHead>
+                                    <TableHead class="text-right">Actions</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                <TableRow v-for="category in props.categories" :key="category.id">
+                                    <TableCell class="font-medium">{{ category.name }}</TableCell>
+                                    <TableCell>
+                                        <span class="rounded bg-muted px-2 py-1 text-xs font-mono">{{ category.slug }}</span>
+                                    </TableCell>
+                                    <TableCell class="text-center">{{ category.order }}</TableCell>
+                                    <TableCell class="max-w-sm text-sm text-muted-foreground">
+                                        {{ category.description ?? '—' }}
+                                    </TableCell>
+                                    <TableCell class="text-center">
+                                        <span class="font-semibold">{{ category.faqs_count }}</span>
+                                        <span class="ml-1 text-xs text-muted-foreground">
+                                            item{{ category.faqs_count === 1 ? '' : 's' }}
+                                        </span>
+                                    </TableCell>
+                                    <TableCell class="text-center">
+                                        {{ category.updated_at ? formatDate(category.updated_at, 'MMM D, YYYY h:mm A') : '—' }}
+                                    </TableCell>
+                                    <TableCell class="flex justify-end gap-2">
+                                        <Button variant="outline" size="sm" as-child>
+                                            <Link :href="route('acp.support.faq-categories.edit', { category: category.id })">
+                                                <Pencil class="h-4 w-4" />
+                                                Edit
+                                            </Link>
+                                        </Button>
+                                        <Button variant="destructive" size="sm" @click="deleteCategory(category.id)">
+                                            <Trash2 class="h-4 w-4" />
+                                            Delete
+                                        </Button>
+                                    </TableCell>
+                                </TableRow>
+                            </TableBody>
+                        </Table>
+                    </div>
+                </CardContent>
+            </Card>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/SupportFaqCategoryCreate.vue
+++ b/resources/js/pages/acp/SupportFaqCategoryCreate.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { Head, Link, useForm } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import InputError from '@/components/InputError.vue';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Support ACP', href: route('acp.support.index') },
+    { title: 'FAQ categories', href: route('acp.support.faq-categories.index') },
+    { title: 'Create category', href: route('acp.support.faq-categories.create') },
+];
+
+const form = useForm({
+    name: '',
+    slug: '',
+    description: '',
+    order: 0,
+});
+
+const handleSubmit = () => {
+    form.post(route('acp.support.faq-categories.store'), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Create FAQ category" />
+
+        <AdminLayout>
+            <form class="flex flex-1 flex-col gap-6" @submit.prevent="handleSubmit">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">Create FAQ category</h1>
+                        <p class="text-sm text-muted-foreground">
+                            Create a grouping for related help articles so you can filter FAQs by topic.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2">
+                        <Button variant="outline" as-child>
+                            <Link :href="route('acp.support.faq-categories.index')">Cancel</Link>
+                        </Button>
+                        <Button type="submit" :disabled="form.processing">Save category</Button>
+                    </div>
+                </div>
+
+                <Card>
+                    <CardHeader class="relative overflow-hidden">
+                        <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                        <div class="relative space-y-1">
+                            <CardTitle>Category details</CardTitle>
+                            <CardDescription>
+                                Provide a clear name, optional slug, and description to help agents choose the right grouping.
+                            </CardDescription>
+                        </div>
+                    </CardHeader>
+                    <CardContent class="space-y-6">
+                        <div class="grid gap-2">
+                            <Label for="name">Name</Label>
+                            <Input id="name" v-model="form.name" type="text" autocomplete="off" required />
+                            <InputError :message="form.errors.name" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="slug">Slug</Label>
+                            <Input
+                                id="slug"
+                                v-model="form.slug"
+                                type="text"
+                                autocomplete="off"
+                                placeholder="Leave blank to auto-generate from the name"
+                            />
+                            <InputError :message="form.errors.slug" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="description">Description</Label>
+                            <Textarea
+                                id="description"
+                                v-model="form.description"
+                                placeholder="Optional short summary shown to users when filtering by this category"
+                                class="min-h-24"
+                            />
+                            <InputError :message="form.errors.description" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="order">Display order</Label>
+                            <Input id="order" v-model.number="form.order" type="number" />
+                            <InputError :message="form.errors.order" />
+                        </div>
+                    </CardContent>
+                    <CardFooter class="justify-end gap-2">
+                        <Button type="submit" :disabled="form.processing">Save category</Button>
+                    </CardFooter>
+                </Card>
+            </form>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/SupportFaqCategoryEdit.vue
+++ b/resources/js/pages/acp/SupportFaqCategoryEdit.vue
@@ -1,0 +1,140 @@
+<script setup lang="ts">
+import { Head, Link, useForm } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import InputError from '@/components/InputError.vue';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { useUserTimezone } from '@/composables/useUserTimezone';
+
+const props = defineProps<{
+    category: {
+        id: number;
+        name: string;
+        slug: string;
+        description: string | null;
+        order: number;
+        faqs_count: number;
+        created_at: string | null;
+        updated_at: string | null;
+    };
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Support ACP', href: route('acp.support.index') },
+    { title: 'FAQ categories', href: route('acp.support.faq-categories.index') },
+    { title: `Category #${props.category.id}`, href: route('acp.support.faq-categories.edit', { category: props.category.id }) },
+];
+
+const form = useForm({
+    name: props.category.name,
+    slug: props.category.slug,
+    description: props.category.description ?? '',
+    order: props.category.order,
+});
+
+const { formatDate } = useUserTimezone();
+
+const handleSubmit = () => {
+    form.put(route('acp.support.faq-categories.update', { category: props.category.id }), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head :title="`Edit FAQ category #${props.category.id}`" />
+
+        <AdminLayout>
+            <form class="flex flex-1 flex-col gap-6" @submit.prevent="handleSubmit">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">Edit FAQ category</h1>
+                        <p class="text-sm text-muted-foreground">
+                            Update the name, order, or description for this group of help articles.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2">
+                        <Button variant="outline" as-child>
+                            <Link :href="route('acp.support.faq-categories.index')">Back to categories</Link>
+                        </Button>
+                        <Button type="submit" :disabled="form.processing">Save changes</Button>
+                    </div>
+                </div>
+
+                <Card>
+                    <CardHeader class="relative overflow-hidden">
+                        <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                        <div class="relative space-y-1">
+                            <CardTitle>Category details</CardTitle>
+                            <CardDescription>
+                                Provide a clear label and optional description to help readers understand what belongs here.
+                            </CardDescription>
+                        </div>
+                    </CardHeader>
+                    <CardContent class="space-y-6">
+                        <div class="grid gap-2">
+                            <Label for="name">Name</Label>
+                            <Input id="name" v-model="form.name" type="text" autocomplete="off" required />
+                            <InputError :message="form.errors.name" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="slug">Slug</Label>
+                            <Input
+                                id="slug"
+                                v-model="form.slug"
+                                type="text"
+                                autocomplete="off"
+                                placeholder="Leave blank to auto-generate from the name"
+                            />
+                            <InputError :message="form.errors.slug" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="description">Description</Label>
+                            <Textarea
+                                id="description"
+                                v-model="form.description"
+                                placeholder="Optional short summary shown to users when filtering by this category"
+                                class="min-h-24"
+                            />
+                            <InputError :message="form.errors.description" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="order">Display order</Label>
+                            <Input id="order" v-model.number="form.order" type="number" />
+                            <InputError :message="form.errors.order" />
+                        </div>
+                    </CardContent>
+                    <CardFooter class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                        <div class="text-sm text-muted-foreground">
+                            <div v-if="props.category.created_at">
+                                Created {{ formatDate(props.category.created_at, 'MMM D, YYYY h:mm A') }}
+                            </div>
+                            <div v-if="props.category.updated_at">
+                                Updated {{ formatDate(props.category.updated_at, 'MMM D, YYYY h:mm A') }}
+                            </div>
+                            <div>Linked FAQs: {{ props.category.faqs_count }}</div>
+                        </div>
+                        <div class="flex gap-2">
+                            <Button variant="outline" as-child>
+                                <Link :href="route('acp.support.faq-categories.index')">Cancel</Link>
+                            </Button>
+                            <Button type="submit" :disabled="form.processing">Save changes</Button>
+                        </div>
+                    </CardFooter>
+                </Card>
+            </form>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/SupportFaqCreate.vue
+++ b/resources/js/pages/acp/SupportFaqCreate.vue
@@ -13,12 +13,22 @@ import { Checkbox } from '@/components/ui/checkbox';
 import InputError from '@/components/InputError.vue';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 
+const props = defineProps<{
+    categories: Array<{
+        id: number;
+        name: string;
+        slug: string;
+        description: string | null;
+    }>;
+}>();
+
 const breadcrumbs: BreadcrumbItem[] = [
     { title: 'Support ACP', href: route('acp.support.index') },
     { title: 'Create FAQ', href: route('acp.support.faqs.create') },
 ];
 
 const form = useForm({
+    faq_category_id: props.categories[0]?.id ?? null,
     question: '',
     answer: '',
     order: 0,
@@ -92,6 +102,29 @@ const handleSubmit = () => {
                             <CardDescription>Set the display order and choose whether the FAQ is visible.</CardDescription>
                         </CardHeader>
                         <CardContent class="space-y-4">
+                            <div class="grid gap-2">
+                                <Label for="faq_category_id">Category</Label>
+                                <select
+                                    id="faq_category_id"
+                                    v-model.number="form.faq_category_id"
+                                    class="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                    :disabled="!props.categories.length"
+                                    required
+                                >
+                                    <option
+                                        v-for="category in props.categories"
+                                        :key="category.id"
+                                        :value="category.id"
+                                    >
+                                        {{ category.name }}
+                                    </option>
+                                </select>
+                                <p v-if="!props.categories.length" class="text-sm text-muted-foreground">
+                                    Create a category before adding FAQs.
+                                </p>
+                                <InputError :message="form.errors.faq_category_id" />
+                            </div>
+
                             <div class="grid gap-2">
                                 <Label for="order">Display order</Label>
                                 <Input id="order" v-model.number="form.order" type="number" min="0" />

--- a/resources/js/pages/acp/SupportFaqEdit.vue
+++ b/resources/js/pages/acp/SupportFaqEdit.vue
@@ -22,9 +22,16 @@ const props = defineProps<{
         answer: string;
         order: number;
         published: boolean;
+        faq_category_id: number;
         created_at: string;
         updated_at: string;
     };
+    categories: Array<{
+        id: number;
+        name: string;
+        slug: string;
+        description: string | null;
+    }>;
 }>();
 
 const breadcrumbs: BreadcrumbItem[] = [
@@ -33,6 +40,7 @@ const breadcrumbs: BreadcrumbItem[] = [
 ];
 
 const form = useForm({
+    faq_category_id: props.faq.faq_category_id,
     question: props.faq.question,
     answer: props.faq.answer,
     order: props.faq.order,
@@ -106,6 +114,26 @@ const handleSubmit = () => {
                                 <CardDescription>Control ordering and publish state for this entry.</CardDescription>
                             </CardHeader>
                             <CardContent class="space-y-4">
+                                <div class="grid gap-2">
+                                    <Label for="faq_category_id">Category</Label>
+                                    <select
+                                        id="faq_category_id"
+                                        v-model.number="form.faq_category_id"
+                                        class="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                        :disabled="!props.categories.length"
+                                        required
+                                    >
+                                        <option
+                                            v-for="category in props.categories"
+                                            :key="category.id"
+                                            :value="category.id"
+                                        >
+                                            {{ category.name }}
+                                        </option>
+                                    </select>
+                                    <InputError :message="form.errors.faq_category_id" />
+                                </div>
+
                                 <div class="grid gap-2">
                                     <Label for="order">Display order</Label>
                                     <Input id="order" v-model.number="form.order" type="number" min="0" />

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Admin\UsersController as AdminUserController;
 use App\Http\Controllers\Admin\ForumBoardController;
 use App\Http\Controllers\Admin\ForumCategoryController;
 use App\Http\Controllers\Admin\ForumReportController;
+use App\Http\Controllers\Admin\FaqCategoryController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -111,6 +112,14 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
     Route::patch('acp/support/faqs/{faq}/reorder', [SupportController::class,'reorderFaq'])->name('acp.support.faqs.reorder');
     Route::patch('acp/support/faqs/{faq}/publish', [SupportController::class,'publishFaq'])->name('acp.support.faqs.publish');
     Route::patch('acp/support/faqs/{faq}/unpublish', [SupportController::class,'unpublishFaq'])->name('acp.support.faqs.unpublish');
+
+    // FAQ Categories
+    Route::get('acp/support/faq-categories', [FaqCategoryController::class, 'index'])->name('acp.support.faq-categories.index');
+    Route::get('acp/support/faq-categories/create', [FaqCategoryController::class, 'create'])->name('acp.support.faq-categories.create');
+    Route::post('acp/support/faq-categories', [FaqCategoryController::class, 'store'])->name('acp.support.faq-categories.store');
+    Route::get('acp/support/faq-categories/{category}/edit', [FaqCategoryController::class, 'edit'])->name('acp.support.faq-categories.edit');
+    Route::put('acp/support/faq-categories/{category}', [FaqCategoryController::class, 'update'])->name('acp.support.faq-categories.update');
+    Route::delete('acp/support/faq-categories/{category}', [FaqCategoryController::class, 'destroy'])->name('acp.support.faq-categories.destroy');
 
     Route::get('acp/system', [SystemSettingsController::class, 'index'])->name('acp.system');
     Route::put('acp/system', [SystemSettingsController::class, 'update'])->name('acp.system.update');

--- a/tests/Feature/Admin/FaqCategoryManagementTest.php
+++ b/tests/Feature/Admin/FaqCategoryManagementTest.php
@@ -56,7 +56,7 @@ class FaqCategoryManagementTest extends TestCase
 
         $response->assertOk()
             ->assertJson(fn (AssertableJson $json) => $json
-                ->where('categories', fn (array $categories) => collect($categories)
+                ->where('categories', fn ($categories) => collect($categories)
                     ->contains(fn (array $category) => $category['name'] === 'Getting Started'
                         && $category['faqs_count'] === 1)
                 )

--- a/tests/Feature/Admin/FaqCategoryManagementTest.php
+++ b/tests/Feature/Admin/FaqCategoryManagementTest.php
@@ -56,12 +56,9 @@ class FaqCategoryManagementTest extends TestCase
 
         $response->assertOk()
             ->assertJson(fn (AssertableJson $json) => $json
-                ->has('categories', fn (AssertableJson $categories) => $categories
-                    ->first(fn (AssertableJson $category) => $category
-                        ->where('name', 'Getting Started')
-                        ->where('faqs_count', 1)
-                        ->etc()
-                    )
+                ->where('categories', fn (array $categories) => collect($categories)
+                    ->contains(fn (array $category) => $category['name'] === 'Getting Started'
+                        && $category['faqs_count'] === 1)
                 )
             );
     }

--- a/tests/Feature/Admin/FaqCategoryManagementTest.php
+++ b/tests/Feature/Admin/FaqCategoryManagementTest.php
@@ -6,6 +6,7 @@ use App\Models\Faq;
 use App\Models\FaqCategory;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Testing\Fluent\AssertableJson;
 use Inertia\Testing\AssertableInertia as Assert;
 use Spatie\Permission\Models\Role;
 use Tests\TestCase;
@@ -37,9 +38,10 @@ class FaqCategoryManagementTest extends TestCase
         $response->assertOk();
         $response->assertInertia(fn (Assert $page) => $page
             ->component('acp/SupportFaqCategories')
-            ->has('categories', 2)
+            ->has('categories', 3)
             ->where('categories.0.name', 'Billing')
-            ->where('categories.1.name', 'Account')
+            ->where('categories.1.name', 'General')
+            ->where('categories.2.name', 'Account')
         );
     }
 
@@ -53,8 +55,15 @@ class FaqCategoryManagementTest extends TestCase
         $response = $this->getJson(route('acp.support.faq-categories.index'));
 
         $response->assertOk()
-            ->assertJsonPath('categories.0.name', 'Getting Started')
-            ->assertJsonPath('categories.0.faqs_count', 1);
+            ->assertJson(fn (AssertableJson $json) => $json
+                ->has('categories', fn (AssertableJson $categories) => $categories
+                    ->first(fn (AssertableJson $category) => $category
+                        ->where('name', 'Getting Started')
+                        ->where('faqs_count', 1)
+                        ->etc()
+                    )
+                )
+            );
     }
 
     public function test_admin_can_create_faq_category(): void

--- a/tests/Feature/Admin/FaqCategoryManagementTest.php
+++ b/tests/Feature/Admin/FaqCategoryManagementTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Faq;
+use App\Models\FaqCategory;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class FaqCategoryManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingAsAdmin(): User
+    {
+        $user = User::factory()->create();
+        $role = Role::firstOrCreate(['name' => 'admin']);
+        $user->assignRole($role);
+
+        $this->actingAs($user);
+
+        return $user;
+    }
+
+    public function test_admin_can_view_faq_category_index_page(): void
+    {
+        $this->actingAsAdmin();
+
+        FaqCategory::factory()->create(['name' => 'Billing', 'slug' => 'billing', 'order' => 0]);
+        FaqCategory::factory()->create(['name' => 'Account', 'slug' => 'account', 'order' => 1]);
+
+        $response = $this->get(route('acp.support.faq-categories.index'));
+
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('acp/SupportFaqCategories')
+            ->has('categories', 2)
+            ->where('categories.0.name', 'Billing')
+            ->where('categories.1.name', 'Account')
+        );
+    }
+
+    public function test_faq_category_index_returns_json_payload(): void
+    {
+        $this->actingAsAdmin();
+
+        $category = FaqCategory::factory()->create(['name' => 'Getting Started', 'slug' => 'getting-started']);
+        Faq::factory()->for($category, 'category')->create();
+
+        $response = $this->getJson(route('acp.support.faq-categories.index'));
+
+        $response->assertOk()
+            ->assertJsonPath('categories.0.name', 'Getting Started')
+            ->assertJsonPath('categories.0.faqs_count', 1);
+    }
+
+    public function test_admin_can_create_faq_category(): void
+    {
+        $this->actingAsAdmin();
+
+        $response = $this->post(route('acp.support.faq-categories.store'), [
+            'name' => 'Troubleshooting',
+            'slug' => '',
+            'description' => 'Steps for solving common issues.',
+            'order' => 1,
+        ]);
+
+        $response->assertRedirect(route('acp.support.faq-categories.index'));
+
+        $this->assertDatabaseHas('faq_categories', [
+            'name' => 'Troubleshooting',
+            'slug' => 'troubleshooting',
+            'description' => 'Steps for solving common issues.',
+            'order' => 1,
+        ]);
+    }
+
+    public function test_faq_category_slug_must_be_unique(): void
+    {
+        $this->actingAsAdmin();
+
+        FaqCategory::factory()->create(['slug' => 'duplicate']);
+
+        $response = $this->from(route('acp.support.faq-categories.create'))
+            ->post(route('acp.support.faq-categories.store'), [
+                'name' => 'Another Category',
+                'slug' => 'duplicate',
+                'description' => 'Should not save',
+                'order' => 0,
+            ]);
+
+        $response->assertRedirect(route('acp.support.faq-categories.create'));
+        $response->assertSessionHasErrors('slug');
+    }
+
+    public function test_admin_can_update_faq_category(): void
+    {
+        $this->actingAsAdmin();
+
+        $category = FaqCategory::factory()->create([
+            'name' => 'Original Category',
+            'slug' => 'original-category',
+            'description' => 'Original description',
+            'order' => 5,
+        ]);
+
+        $response = $this->put(route('acp.support.faq-categories.update', $category), [
+            'name' => 'Updated Category',
+            'slug' => '',
+            'description' => 'Updated description',
+            'order' => 7,
+        ]);
+
+        $response->assertRedirect(route('acp.support.faq-categories.index'));
+
+        $category->refresh();
+
+        $this->assertSame('Updated Category', $category->name);
+        $this->assertSame('updated-category', $category->slug);
+        $this->assertSame('Updated description', $category->description);
+        $this->assertSame(7, $category->order);
+    }
+
+    public function test_admin_can_reuse_slug_on_same_faq_category(): void
+    {
+        $this->actingAsAdmin();
+
+        $category = FaqCategory::factory()->create([
+            'name' => 'Announcements',
+            'slug' => 'announcements',
+        ]);
+
+        $response = $this->put(route('acp.support.faq-categories.update', $category), [
+            'name' => 'Announcements',
+            'slug' => 'announcements',
+            'description' => null,
+            'order' => $category->order,
+        ]);
+
+        $response->assertRedirect(route('acp.support.faq-categories.index'));
+
+        $this->assertDatabaseHas('faq_categories', [
+            'id' => $category->id,
+            'slug' => 'announcements',
+        ]);
+    }
+
+    public function test_admin_can_delete_faq_category(): void
+    {
+        $this->actingAsAdmin();
+
+        $category = FaqCategory::factory()->create();
+        Faq::factory()->count(2)->for($category, 'category')->create();
+
+        $response = $this->from(route('acp.support.faq-categories.index'))
+            ->delete(route('acp.support.faq-categories.destroy', $category));
+
+        $response->assertRedirect(route('acp.support.faq-categories.index'));
+
+        $this->assertDatabaseMissing('faq_categories', ['id' => $category->id]);
+        $this->assertDatabaseMissing('faqs', ['faq_category_id' => $category->id]);
+    }
+}

--- a/tests/Feature/Support/SupportCenterSearchTest.php
+++ b/tests/Feature/Support/SupportCenterSearchTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Support;
 
 use App\Models\Faq;
+use App\Models\FaqCategory;
 use App\Models\SupportTicket;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -47,7 +48,22 @@ class SupportCenterSearchTest extends TestCase
 
         Carbon::setTestNow();
 
+        $billingCategory = FaqCategory::create([
+            'name' => 'Billing',
+            'slug' => 'billing',
+            'description' => 'Answers about billing and invoices.',
+            'order' => 1,
+        ]);
+
+        $accountCategory = FaqCategory::create([
+            'name' => 'Account',
+            'slug' => 'account',
+            'description' => 'Profile and account management help.',
+            'order' => 2,
+        ]);
+
         $firstFaq = Faq::create([
+            'faq_category_id' => $billingCategory->id,
             'question' => 'Billing FAQ one',
             'answer' => 'Details about billing.',
             'order' => 1,
@@ -55,6 +71,7 @@ class SupportCenterSearchTest extends TestCase
         ]);
 
         $secondFaq = Faq::create([
+            'faq_category_id' => $billingCategory->id,
             'question' => 'Billing FAQ two',
             'answer' => 'More billing information.',
             'order' => 2,
@@ -62,6 +79,7 @@ class SupportCenterSearchTest extends TestCase
         ]);
 
         Faq::create([
+            'faq_category_id' => $accountCategory->id,
             'question' => 'Account FAQ',
             'answer' => 'Information about accounts.',
             'order' => 3,
@@ -69,6 +87,7 @@ class SupportCenterSearchTest extends TestCase
         ]);
 
         Faq::create([
+            'faq_category_id' => $billingCategory->id,
             'question' => 'Hidden billing FAQ',
             'answer' => 'Should not be visible.',
             'order' => 4,
@@ -82,8 +101,7 @@ class SupportCenterSearchTest extends TestCase
                 'tickets_per_page' => 1,
                 'tickets_page' => 2,
                 'faqs_search' => 'billing',
-                'faqs_per_page' => 1,
-                'faqs_page' => 2,
+                'faq_category_id' => $billingCategory->id,
             ]));
 
         $response->assertOk()->assertInertia(fn (Assert $page) => $page
@@ -96,33 +114,39 @@ class SupportCenterSearchTest extends TestCase
                 return $ids->contains($olderInvoiceTicket->id)
                     && !$ids->contains($newerInvoiceTicket->id);
             })
-            ->where('tickets.links.prev', function ($url) {
+            ->where('tickets.links.prev', function ($url) use ($billingCategory) {
                 return is_string($url)
                     && str_contains($url, 'tickets_search=invoice')
-                    && str_contains($url, 'faqs_search=billing');
+                    && str_contains($url, 'faqs_search=billing')
+                    && str_contains($url, 'faq_category_id=' . $billingCategory->id);
             })
             ->where('tickets.links.first', function ($url) {
                 return is_string($url)
                     && str_contains($url, 'tickets_search=invoice')
-                    && str_contains($url, 'faqs_search=billing');
+                    && str_contains($url, 'faqs_search=billing')
+                    && str_contains($url, 'faq_category_id=' . $billingCategory->id);
             })
-            ->where('faqs.meta.current_page', 2)
-            ->where('faqs.meta.total', 2)
-            ->where('faqs.data', function ($data) use ($secondFaq, $firstFaq) {
-                $ids = collect($data)->pluck('id');
+            ->where('faqs.filters.selectedCategoryId', $billingCategory->id)
+            ->where('faqs.filters.search', 'billing')
+            ->where('faqs.matchingCount', 2)
+            ->where('faqs.groups', function ($groups) use ($billingCategory, $firstFaq, $secondFaq) {
+                $collection = collect($groups);
 
-                return $ids->contains($secondFaq->id)
-                    && !$ids->contains($firstFaq->id);
-            })
-            ->where('faqs.links.prev', function ($url) {
-                return is_string($url)
-                    && str_contains($url, 'tickets_search=invoice')
-                    && str_contains($url, 'faqs_search=billing');
-            })
-            ->where('faqs.links.first', function ($url) {
-                return is_string($url)
-                    && str_contains($url, 'tickets_search=invoice')
-                    && str_contains($url, 'faqs_search=billing');
+                if ($collection->count() !== 1) {
+                    return false;
+                }
+
+                $group = $collection->first();
+                $categoryId = $group['category']['id'] ?? null;
+
+                if ($categoryId !== $billingCategory->id) {
+                    return false;
+                }
+
+                $ids = collect($group['faqs'])->pluck('id');
+
+                return $ids->contains($firstFaq->id)
+                    && $ids->contains($secondFaq->id);
             }));
     }
 }

--- a/tests/Feature/Support/SupportCenterSearchTest.php
+++ b/tests/Feature/Support/SupportCenterSearchTest.php
@@ -120,7 +120,7 @@ class SupportCenterSearchTest extends TestCase
                     && str_contains($url, 'faqs_search=billing')
                     && str_contains($url, 'faq_category_id=' . $billingCategory->id);
             })
-            ->where('tickets.links.first', function ($url) {
+            ->where('tickets.links.first', function ($url) use ($billingCategory) {
                 return is_string($url)
                     && str_contains($url, 'tickets_search=invoice')
                     && str_contains($url, 'faqs_search=billing')


### PR DESCRIPTION
## Summary
- add FAQ categories with a dedicated table, model, and validation updates
- group FAQs by category in the public support center and surface filter metadata for the frontend
- refresh the public FAQ tab and admin FAQ tools to use category-aware accordions and update coverage

## Testing
- ⚠️ `composer install --no-interaction --prefer-dist` *(failed: blocked from cloning GitHub repositories in this environment)*
- ⚠️ `php artisan test` *(fails before running because vendor/autoload.php is missing after the install failure)*

------
https://chatgpt.com/codex/tasks/task_e_68de03b610d8832c93da019fb49944e6