### PR TITLE
Show last activity in ACP users list

### DIFF
--- a/app/Http/Controllers/Admin/UsersController.php
+++ b/app/Http/Controllers/Admin/UsersController.php
@@ -40,6 +40,7 @@ class UsersController extends Controller
                     'nickname' => $user->nickname,
                     'email' => $user->email,
                     'email_verified_at' => optional($user->email_verified_at)->toIso8601String(),
+                    'last_activity_at' => optional($user->last_activity_at)->toIso8601String(),
                     'is_banned' => $user->is_banned,
                     'banned_at' => optional($user->banned_at)->toIso8601String(),
                     'banned_by' => $user->bannedBy?->only(['id', 'nickname']),

--- a/resources/js/pages/acp/Users.vue
+++ b/resources/js/pages/acp/Users.vue
@@ -67,6 +67,7 @@ const props = defineProps<{
             nickname: string;
             email: string;
             email_verified_at: string | null;
+            last_activity_at: string | null;
             roles: Array<{ name: string }>;
             created_at: string | null;
             is_banned: boolean;
@@ -202,6 +203,7 @@ const stats = [
                                     <TableHead>Name</TableHead>
                                     <TableHead>Email</TableHead>
                                     <TableHead class="text-center">Roles</TableHead>
+                                    <TableHead class="text-center">Last Active</TableHead>
                                     <TableHead class="text-center">Created</TableHead>
                                     <TableHead class="text-center">Status</TableHead>
                                     <TableHead class="text-center">Actions</TableHead>
@@ -232,6 +234,12 @@ const stats = [
                       >
                         {{ role.name }}
                       </span>
+                                    </TableCell>
+                                    <TableCell class="text-center">
+                                        <span v-if="user.last_activity_at" :title="user.last_activity_at">
+                                            {{ fromNow(user.last_activity_at) }}
+                                        </span>
+                                        <span v-else class="text-muted-foreground">Never</span>
                                     </TableCell>
                                     <TableCell class="text-center">{{ fromNow(user.created_at) }}</TableCell>
                                     <TableCell class="text-center">
@@ -295,7 +303,7 @@ const stats = [
                                     </TableCell>
                                 </TableRow>
                                 <TableRow v-if="filteredUsers.length === 0">
-                                    <TableCell colspan="7" class="text-center text-gray-600 dark:text-gray-300">
+                                    <TableCell colspan="8" class="text-center text-gray-600 dark:text-gray-300">
                                         No users found.
                                     </TableCell>
                                 </TableRow>

--- a/tests/Feature/Admin/UsersIndexTest.php
+++ b/tests/Feature/Admin/UsersIndexTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class UsersIndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_recent_activity_timestamp_is_exposed(): void
+    {
+        $adminRole = Role::firstOrCreate(['name' => 'admin']);
+
+        $admin = User::factory()->create();
+        $admin->assignRole($adminRole);
+
+        $this->actingAs($admin);
+
+        $lastActiveAt = now()->subMinutes(2)->startOfSecond();
+
+        $recentUser = User::factory()->create([
+            'last_activity_at' => $lastActiveAt,
+        ]);
+
+        $response = $this->get(route('acp.users.index'));
+
+        $response->assertOk();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('acp/Users')
+            ->where('users.data', function ($users) use ($recentUser, $lastActiveAt) {
+                return collect($users)->contains(function ($user) use ($recentUser, $lastActiveAt) {
+                    return $user['id'] === $recentUser->id
+                        && $user['last_activity_at'] === $lastActiveAt->toIso8601String();
+                });
+            })
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- expose each user's `last_activity_at` timestamp in the ACP users index payload
- surface the relative "last active" time in the admin users table UI
- cover the new payload field with an inertia feature test for recently active accounts

## Testing
- php artisan test --filter=UsersIndexTest *(fails: missing vendor autoload because composer install cannot complete without GitHub access)*

------
https://chatgpt.com/codex/tasks/task_e_68de156924b8832cac5c8f5a7061c02e