### PR TITLE
Add forum thread subscription workflow and notifications

### DIFF
--- a/app/Http/Controllers/ForumController.php
+++ b/app/Http/Controllers/ForumController.php
@@ -268,7 +268,7 @@ class ForumController extends Controller
             'latestPost' => function ($query) {
                 $query->select('forum_posts.id', 'forum_posts.forum_thread_id', 'forum_posts.created_at');
             },
-        ]);
+        ])->loadCount('subscriptions');
 
         $posts = $thread->posts()
             ->with(['author' => function ($query) {
@@ -344,6 +344,8 @@ class ForumController extends Controller
             })
             ->values();
 
+        $isSubscribed = $thread->isSubscribedBy($user);
+
         $canModerateThread = (bool) $isModerator;
         $canEditThread = $user !== null && (
             $canModerateThread || (
@@ -372,6 +374,8 @@ class ForumController extends Controller
                 'views' => $thread->views,
                 'author' => $thread->author?->nickname,
                 'last_posted_at' => optional($thread->last_posted_at)->toDayDateTimeString(),
+                'is_subscribed' => $isSubscribed,
+                'subscribers_count' => $thread->subscriptions_count,
                 'permissions' => [
                     'canModerate' => $canModerateThread,
                     'canEdit' => $canEditThread,

--- a/app/Http/Controllers/ForumPostController.php
+++ b/app/Http/Controllers/ForumPostController.php
@@ -69,7 +69,8 @@ class ForumPostController extends Controller
             ->get();
 
         if ($subscribers->isNotEmpty()) {
-            Notification::send($subscribers, new ForumThreadUpdated($thread, $post));
+            Notification::sendNow($subscribers, (new ForumThreadUpdated($thread, $post))->withChannels(['database']));
+            Notification::send($subscribers, (new ForumThreadUpdated($thread, $post))->withChannels(['mail']));
         }
 
         $postCount = $thread->posts()->count();

--- a/app/Http/Controllers/ForumPostController.php
+++ b/app/Http/Controllers/ForumPostController.php
@@ -7,9 +7,11 @@ use App\Models\ForumPost;
 use App\Models\ForumPostReport;
 use App\Models\ForumThread;
 use App\Models\ForumThreadRead;
+use App\Notifications\ForumThreadUpdated;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 
@@ -59,6 +61,16 @@ class ForumPostController extends Controller
                 'last_read_at' => $post->created_at ?? now(),
             ],
         );
+
+        $thread->loadMissing('board');
+
+        $subscribers = $thread->subscribers()
+            ->where('users.id', '!=', $user->id)
+            ->get();
+
+        if ($subscribers->isNotEmpty()) {
+            Notification::send($subscribers, new ForumThreadUpdated($thread, $post));
+        }
 
         $postCount = $thread->posts()->count();
         $perPage = 10;

--- a/app/Http/Controllers/UserNotificationController.php
+++ b/app/Http/Controllers/UserNotificationController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Notifications\DatabaseNotification;
+
+class UserNotificationController extends Controller
+{
+    public function markAsRead(Request $request, DatabaseNotification $notification): RedirectResponse
+    {
+        $user = $request->user();
+
+        abort_if($user === null, 403);
+        abort_if(
+            $notification->notifiable_id !== $user->id ||
+            $notification->notifiable_type !== $user::class,
+            404,
+        );
+
+        if ($notification->read_at === null) {
+            $notification->markAsRead();
+        }
+
+        return back(status: 303);
+    }
+
+    public function markAllAsRead(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        abort_if($user === null, 403);
+
+        $user->unreadNotifications()->update(['read_at' => now()]);
+
+        return back(status: 303);
+    }
+
+    public function destroy(Request $request, DatabaseNotification $notification): RedirectResponse
+    {
+        $user = $request->user();
+
+        abort_if($user === null, 403);
+        abort_if(
+            $notification->notifiable_id !== $user->id ||
+            $notification->notifiable_type !== $user::class,
+            404,
+        );
+
+        $notification->delete();
+
+        return back(status: 303);
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -57,6 +57,17 @@ class HandleInertiaRequests extends Middleware
                     ? $request->user()->getAllPermissions()->pluck('name')
                     : [],
             ],
+            'notifications' => $request->user()
+                ? $request->user()->unreadNotifications()->limit(10)->get()->map(static function ($notification) {
+                    return [
+                        'id' => $notification->id,
+                        'type' => $notification->type,
+                        'data' => $notification->data,
+                        'created_at' => optional($notification->created_at)->toDayDateTimeString(),
+                        'read_at' => optional($notification->read_at)?->toDayDateTimeString(),
+                    ];
+                })->values()->all()
+                : [],
             'ziggy' => [
                 ...(new Ziggy)->toArray(),
                 'location' => $request->url(),

--- a/app/Models/ForumThread.php
+++ b/app/Models/ForumThread.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
@@ -67,5 +68,24 @@ class ForumThread extends Model
     public function reads(): HasMany
     {
         return $this->hasMany(ForumThreadRead::class);
+    }
+
+    public function subscriptions(): HasMany
+    {
+        return $this->hasMany(ForumThreadSubscription::class);
+    }
+
+    public function subscribers(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'forum_thread_subscriptions')->withTimestamps();
+    }
+
+    public function isSubscribedBy(?User $user): bool
+    {
+        if ($user === null) {
+            return false;
+        }
+
+        return $this->subscriptions()->where('user_id', $user->id)->exists();
     }
 }

--- a/app/Models/ForumThreadSubscription.php
+++ b/app/Models/ForumThreadSubscription.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ForumThreadSubscription extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'forum_thread_id',
+        'user_id',
+    ];
+
+    public function thread(): BelongsTo
+    {
+        return $this->belongsTo(ForumThread::class, 'forum_thread_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ use Illuminate\Auth\MustVerifyEmail as MustVerifyEmailTrait;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -72,6 +73,16 @@ class User extends Authenticatable implements MustVerifyEmail
     public function forumThreadReads(): HasMany
     {
         return $this->hasMany(ForumThreadRead::class);
+    }
+
+    public function forumThreadSubscriptions(): HasMany
+    {
+        return $this->hasMany(ForumThreadSubscription::class);
+    }
+
+    public function subscribedForumThreads(): BelongsToMany
+    {
+        return $this->belongsToMany(ForumThread::class, 'forum_thread_subscriptions')->withTimestamps();
     }
 
     public function blogComments(): HasMany

--- a/app/Notifications/ForumThreadUpdated.php
+++ b/app/Notifications/ForumThreadUpdated.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\ForumPost;
+use App\Models\ForumThread;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Str;
+
+class ForumThreadUpdated extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        protected ForumThread $thread,
+        protected ForumPost $post,
+    ) {
+        $this->thread->setRelation('latestPost', $this->post);
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $url = route('forum.threads.show', [
+            'board' => $this->thread->board?->slug ?? $this->thread->board->slug,
+            'thread' => $this->thread->slug,
+            'page' => null,
+        ]);
+
+        return (new MailMessage())
+            ->subject('New reply in "' . $this->thread->title . '"')
+            ->greeting('Hi ' . ($notifiable->nickname ?? $notifiable->name ?? 'there') . '!')
+            ->line('There is a new reply in a thread you follow: "' . $this->thread->title . '".')
+            ->line(Str::limit(strip_tags($this->post->body), 200))
+            ->action('View reply', $url)
+            ->line('You are receiving this email because you opted to follow this thread.');
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        $excerpt = Str::limit(trim(preg_replace('/\s+/', ' ', strip_tags($this->post->body)) ?? ''), 140);
+
+        return [
+            'thread_id' => $this->thread->id,
+            'thread_title' => $this->thread->title,
+            'post_id' => $this->post->id,
+            'excerpt' => $excerpt,
+            'url' => route('forum.threads.show', [
+                'board' => $this->thread->board?->slug ?? $this->thread->board->slug,
+                'thread' => $this->thread->slug,
+            ]) . '#post-' . $this->post->id,
+        ];
+    }
+}

--- a/database/migrations/2025_05_15_000000_create_forum_thread_subscriptions_table.php
+++ b/database/migrations/2025_05_15_000000_create_forum_thread_subscriptions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('forum_thread_subscriptions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('forum_thread_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['forum_thread_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('forum_thread_subscriptions');
+    }
+};

--- a/database/migrations/2025_05_15_000100_create_notifications_table.php
+++ b/database/migrations/2025_05_15_000100_create_notifications_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->morphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -24,6 +24,7 @@ export interface SharedData extends PageProps {
     name: string;
     quote: { message: string; author: string };
     auth: Auth;
+    notifications: NotificationItem[];
     ziggy: Config & { location: string };
 }
 
@@ -39,3 +40,11 @@ export interface User {
 }
 
 export type BreadcrumbItemType = BreadcrumbItem;
+
+export interface NotificationItem {
+    id: string;
+    type: string;
+    data: Record<string, unknown>;
+    created_at: string | null;
+    read_at: string | null;
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -20,14 +20,6 @@ export interface NavItem {
     isActive?: boolean;
 }
 
-export interface SharedData extends PageProps {
-    name: string;
-    quote: { message: string; author: string };
-    auth: Auth;
-    notifications: NotificationItem[];
-    ziggy: Config & { location: string };
-}
-
 export interface User {
     id: number;
     nickname: string;
@@ -44,7 +36,25 @@ export type BreadcrumbItemType = BreadcrumbItem;
 export interface NotificationItem {
     id: string;
     type: string;
+    title: string;
+    excerpt: string | null;
+    url: string | null;
     data: Record<string, unknown>;
     created_at: string | null;
+    created_at_for_humans: string | null;
     read_at: string | null;
+}
+
+export interface NotificationBag {
+    items: NotificationItem[];
+    unread_count: number;
+    has_more: boolean;
+}
+
+export interface SharedData extends PageProps {
+    name: string;
+    quote: { message: string; author: string };
+    auth: Auth;
+    notifications: NotificationBag;
+    ziggy: Config & { location: string };
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\ForumPostController;
 use App\Http\Controllers\ForumThreadActionController;
 use App\Http\Controllers\ForumThreadModerationController;
 use App\Http\Controllers\SupportCenterController;
+use App\Http\Controllers\UserNotificationController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -37,6 +38,13 @@ Route::get('forum/{board:slug}', [ForumController::class, 'showBoard'])->name('f
 Route::get('forum/{board:slug}/{thread:slug}', [ForumController::class, 'showThread'])->name('forum.threads.show');
 
 Route::middleware('auth')->group(function () {
+    Route::post('notifications/read-all', [UserNotificationController::class, 'markAllAsRead'])
+        ->name('notifications.read-all');
+    Route::post('notifications/{notification}/read', [UserNotificationController::class, 'markAsRead'])
+        ->name('notifications.read');
+    Route::delete('notifications/{notification}', [UserNotificationController::class, 'destroy'])
+        ->name('notifications.destroy');
+
     Route::get('forum/{board:slug}/threads/create', [ForumController::class, 'createThread'])
         ->name('forum.threads.create');
     Route::post('forum/{board:slug}/threads', [ForumController::class, 'storeThread'])

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,6 +45,10 @@ Route::middleware('auth')->group(function () {
         ->name('forum.threads.report');
     Route::post('forum/{board:slug}/{thread:slug}/mark-read', [ForumThreadActionController::class, 'markAsRead'])
         ->name('forum.threads.mark-read');
+    Route::post('forum/{board:slug}/{thread:slug}/subscribe', [ForumThreadActionController::class, 'subscribe'])
+        ->name('forum.threads.subscribe');
+    Route::delete('forum/{board:slug}/{thread:slug}/unsubscribe', [ForumThreadActionController::class, 'unsubscribe'])
+        ->name('forum.threads.unsubscribe');
     Route::put('forum/{board:slug}/{thread:slug}', [ForumThreadModerationController::class, 'update'])
         ->name('forum.threads.update');
 


### PR DESCRIPTION
## Summary
- add forum thread subscription and notifications migrations plus the related Eloquent model
- wire up subscribe/unsubscribe endpoints with queueable notifications on new replies and share unread notifications via Inertia
- update the forum thread view to surface follow controls and follower counts

## Testing
- php artisan test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68de15899530832c99ec08809bc9f0e2