### PR TITLE
Add searchable pagination to admin users list

### DIFF
--- a/tests/Feature/Admin/UsersIndexTest.php
+++ b/tests/Feature/Admin/UsersIndexTest.php
@@ -41,4 +41,64 @@ class UsersIndexTest extends TestCase
             })
         );
     }
+
+    public function test_search_results_are_paginated_on_server(): void
+    {
+        $adminRole = Role::firstOrCreate(['name' => 'admin']);
+
+        $admin = User::factory()->create();
+        $admin->assignRole($adminRole);
+
+        $this->actingAs($admin);
+
+        $matchingUsers = User::factory()
+            ->count(5)
+            ->sequence(fn ($sequence) => [
+                'nickname' => "Searchable {$sequence->index}",
+                'email' => "searchable-{$sequence->index}@example.com",
+            ])
+            ->create();
+
+        User::factory()
+            ->count(3)
+            ->sequence(fn ($sequence) => [
+                'nickname' => "Other {$sequence->index}",
+                'email' => "other-{$sequence->index}@example.com",
+            ])
+            ->create();
+
+        $perPage = 2;
+        $search = 'Searchable';
+
+        $response = $this->get(route('acp.users.index', [
+            'search' => $search,
+            'page' => 2,
+            'per_page' => $perPage,
+        ]));
+
+        $response->assertOk();
+
+        $expectedUsers = $matchingUsers
+            ->sortByDesc('created_at')
+            ->values()
+            ->slice($perPage, $perPage)
+            ->values();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('acp/Users')
+            ->where('filters.search', $search)
+            ->where('users.meta.current_page', 2)
+            ->where('users.meta.per_page', $perPage)
+            ->where('users.meta.total', $matchingUsers->count())
+            ->where('users.data', function ($users) use ($expectedUsers) {
+                if (count($users) !== $expectedUsers->count()) {
+                    return false;
+                }
+
+                $ids = collect($users)->pluck('id');
+
+                return $ids->values()->all() === $expectedUsers->pluck('id')->values()->all();
+            })
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add backend filtering for the admin users index and keep stats untouched
- debounce the search box, send the query through Inertia, and persist it across pagination
- cover the search pagination behaviour with a new feature test

## Testing
- php artisan test --filter=UsersIndexTest *(fails: missing Composer dependencies; composer install requires GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68de4140f28c832c922d680027968815