### PR TITLE
Add board-level mark as read support

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -53,6 +53,8 @@ Route::middleware('auth')->group(function () {
         ->name('forum.threads.report');
     Route::post('forum/{board:slug}/{thread:slug}/mark-read', [ForumThreadActionController::class, 'markAsRead'])
         ->name('forum.threads.mark-read');
+    Route::post('forum/{board:slug}/mark-read', [ForumThreadActionController::class, 'markBoardAsRead'])
+        ->name('forum.boards.mark-read');
     Route::post('forum/{board:slug}/{thread:slug}/subscribe', [ForumThreadActionController::class, 'subscribe'])
         ->name('forum.threads.subscribe');
     Route::delete('forum/{board:slug}/{thread:slug}/unsubscribe', [ForumThreadActionController::class, 'unsubscribe'])


### PR DESCRIPTION
## Summary
- add an authenticated route for marking an entire forum board as read
- batch upsert forum thread read timestamps for all accessible threads in a board
- expose a "Mark board read" control in the board view that calls the new endpoint and reloads unread badges

## Testing
- `php artisan test` *(fails: vendor autoload not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de6916d070832c8d57bbba36fc7d63