### PR TITLE
Enhance blog comments with profile metadata

### DIFF
--- a/app/Http/Controllers/BlogCommentController.php
+++ b/app/Http/Controllers/BlogCommentController.php
@@ -18,7 +18,7 @@ class BlogCommentController extends Controller
         $perPage = max(1, min($perPage, 50));
 
         $comments = $blog->comments()
-            ->with(['user:id,nickname,avatar_url,profile_bio'])
+            ->with(['user:id,name,nickname,avatar_url,profile_bio'])
             ->orderBy('created_at')
             ->paginate($perPage);
 
@@ -61,7 +61,7 @@ class BlogCommentController extends Controller
             'body' => $body,
         ]);
 
-        $comment->load(['user:id,nickname,avatar_url,profile_bio']);
+        $comment->load(['user:id,name,nickname,avatar_url,profile_bio']);
 
         return response()->json([
             'data' => $this->transformComment($comment),
@@ -86,7 +86,7 @@ class BlogCommentController extends Controller
             'body' => $body,
         ])->save();
 
-        $comment->load(['user:id,nickname,avatar_url,profile_bio']);
+        $comment->load(['user:id,name,nickname,avatar_url,profile_bio']);
 
         return response()->json([
             'data' => $this->transformComment($comment),
@@ -140,7 +140,7 @@ class BlogCommentController extends Controller
 
     private function transformComment(BlogComment $comment): array
     {
-        $comment->loadMissing(['user:id,nickname,avatar_url,profile_bio']);
+        $comment->loadMissing(['user:id,name,nickname,avatar_url,profile_bio']);
 
         $user = $comment->user;
 
@@ -162,6 +162,7 @@ class BlogCommentController extends Controller
             'updated_at' => optional($comment->updated_at)->toIso8601String(),
             'user' => $user ? [
                 'id' => $user->id,
+                'name' => $user->name,
                 'nickname' => $user->nickname,
                 'avatar_url' => $avatarUrl,
                 'profile_bio' => $profileBio,

--- a/app/Http/Controllers/BlogCommentController.php
+++ b/app/Http/Controllers/BlogCommentController.php
@@ -18,7 +18,7 @@ class BlogCommentController extends Controller
         $perPage = max(1, min($perPage, 50));
 
         $comments = $blog->comments()
-            ->with(['user:id,nickname'])
+            ->with(['user:id,nickname,avatar_url,profile_bio'])
             ->orderBy('created_at')
             ->paginate($perPage);
 
@@ -61,7 +61,7 @@ class BlogCommentController extends Controller
             'body' => $body,
         ]);
 
-        $comment->load(['user:id,nickname']);
+        $comment->load(['user:id,nickname,avatar_url,profile_bio']);
 
         return response()->json([
             'data' => $this->transformComment($comment),
@@ -86,7 +86,7 @@ class BlogCommentController extends Controller
             'body' => $body,
         ])->save();
 
-        $comment->load(['user:id,nickname']);
+        $comment->load(['user:id,nickname,avatar_url,profile_bio']);
 
         return response()->json([
             'data' => $this->transformComment($comment),
@@ -140,14 +140,31 @@ class BlogCommentController extends Controller
 
     private function transformComment(BlogComment $comment): array
     {
+        $comment->loadMissing(['user:id,nickname,avatar_url,profile_bio']);
+
+        $user = $comment->user;
+
+        $avatarUrl = null;
+        $profileBio = null;
+
+        if ($user) {
+            $avatarCandidate = is_string($user->avatar_url) ? trim($user->avatar_url) : '';
+            $avatarUrl = $avatarCandidate !== '' ? $avatarCandidate : null;
+
+            $bioCandidate = is_string($user->profile_bio) ? trim($user->profile_bio) : '';
+            $profileBio = $bioCandidate !== '' ? $bioCandidate : null;
+        }
+
         return [
             'id' => $comment->id,
             'body' => $comment->body,
             'created_at' => optional($comment->created_at)->toIso8601String(),
             'updated_at' => optional($comment->updated_at)->toIso8601String(),
-            'user' => $comment->user ? [
-                'id' => $comment->user->id,
-                'nickname' => $comment->user->nickname,
+            'user' => $user ? [
+                'id' => $user->id,
+                'nickname' => $user->nickname,
+                'avatar_url' => $avatarUrl,
+                'profile_bio' => $profileBio,
             ] : null,
         ];
     }

--- a/app/Http/Controllers/BlogCommentController.php
+++ b/app/Http/Controllers/BlogCommentController.php
@@ -18,7 +18,7 @@ class BlogCommentController extends Controller
         $perPage = max(1, min($perPage, 50));
 
         $comments = $blog->comments()
-            ->with(['user:id,name,nickname,avatar_url,profile_bio'])
+            ->with(['user:id,nickname,avatar_url,profile_bio'])
             ->orderBy('created_at')
             ->paginate($perPage);
 
@@ -61,7 +61,7 @@ class BlogCommentController extends Controller
             'body' => $body,
         ]);
 
-        $comment->load(['user:id,name,nickname,avatar_url,profile_bio']);
+        $comment->load(['user:id,nickname,avatar_url,profile_bio']);
 
         return response()->json([
             'data' => $this->transformComment($comment),
@@ -86,7 +86,7 @@ class BlogCommentController extends Controller
             'body' => $body,
         ])->save();
 
-        $comment->load(['user:id,name,nickname,avatar_url,profile_bio']);
+        $comment->load(['user:id,nickname,avatar_url,profile_bio']);
 
         return response()->json([
             'data' => $this->transformComment($comment),
@@ -140,7 +140,7 @@ class BlogCommentController extends Controller
 
     private function transformComment(BlogComment $comment): array
     {
-        $comment->loadMissing(['user:id,name,nickname,avatar_url,profile_bio']);
+        $comment->loadMissing(['user:id,nickname,avatar_url,profile_bio']);
 
         $user = $comment->user;
 
@@ -162,7 +162,6 @@ class BlogCommentController extends Controller
             'updated_at' => optional($comment->updated_at)->toIso8601String(),
             'user' => $user ? [
                 'id' => $user->id,
-                'name' => $user->name,
                 'nickname' => $user->nickname,
                 'avatar_url' => $avatarUrl,
                 'profile_bio' => $profileBio,

--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -253,13 +253,13 @@ class BlogController extends Controller
         }
 
         $comments = $blog->comments()
-            ->with(['user:id,name,nickname,avatar_url,profile_bio'])
+            ->with(['user:id,nickname,avatar_url,profile_bio'])
             ->orderBy('created_at')
             ->paginate(10, ['*'], 'page', 1);
 
         $commentItems = $comments->getCollection()
             ->map(function (BlogComment $comment) {
-                $comment->loadMissing(['user:id,name,nickname,avatar_url,profile_bio']);
+                $comment->loadMissing(['user:id,nickname,avatar_url,profile_bio']);
 
                 $user = $comment->user;
                 $avatarUrl = null;

--- a/app/Http/Requests/Settings/ProfileUpdateRequest.php
+++ b/app/Http/Requests/Settings/ProfileUpdateRequest.php
@@ -13,11 +13,13 @@ class ProfileUpdateRequest extends FormRequest
         $payload = [];
 
         if ($this->exists('avatar_url')) {
-            $payload['avatar_url'] = $this->filled('avatar_url') ? $this->input('avatar_url') : null;
+            $avatar = is_string($this->input('avatar_url')) ? trim($this->input('avatar_url')) : '';
+            $payload['avatar_url'] = $avatar !== '' ? $avatar : null;
         }
 
         if ($this->exists('profile_bio')) {
-            $payload['profile_bio'] = $this->filled('profile_bio') ? $this->input('profile_bio') : null;
+            $bio = is_string($this->input('profile_bio')) ? trim($this->input('profile_bio')) : '';
+            $payload['profile_bio'] = $bio !== '' ? $bio : null;
         }
 
         if ($this->exists('social_links')) {

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -28,6 +28,8 @@ class UserFactory extends Factory
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
+            'avatar_url' => sprintf('https://i.pravatar.cc/150?img=%d', fake()->numberBetween(1, 70)),
+            'profile_bio' => fake()->sentences(2, true),
             'remember_token' => Str::random(10),
             'is_banned' => false,
         ];

--- a/database/seeders/AcpDashboardDemoSeeder.php
+++ b/database/seeders/AcpDashboardDemoSeeder.php
@@ -46,6 +46,8 @@ class AcpDashboardDemoSeeder extends Seeder
                 'password' => $password,
                 'email_verified_at' => $adminCreatedAt,
                 'last_activity_at' => $now->copy()->subDay(),
+                'avatar_url' => 'https://i.pravatar.cc/150?u=acp-dashboard-admin',
+                'profile_bio' => 'Keeps the dashboards humming with fresh insights.',
             ]
         );
         $admin->forceFill([
@@ -69,6 +71,8 @@ class AcpDashboardDemoSeeder extends Seeder
                         'password' => $password,
                         'email_verified_at' => $createdAt,
                         'last_activity_at' => $createdAt->copy()->addDays(10),
+                        'avatar_url' => sprintf('https://i.pravatar.cc/150?u=%s', $email),
+                        'profile_bio' => 'Community member sharing updates throughout the year.',
                     ]
                 );
                 $user->forceFill([
@@ -97,6 +101,8 @@ class AcpDashboardDemoSeeder extends Seeder
                     'password' => $password,
                     'email_verified_at' => $createdAt,
                     'last_activity_at' => $createdAt->copy()->addHours(6),
+                    'avatar_url' => sprintf('https://i.pravatar.cc/150?u=%s', $email),
+                    'profile_bio' => 'Active community voice testing the latest releases.',
                 ]
             );
             $user->forceFill([

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,6 +18,8 @@ class DatabaseSeeder extends Seeder
         User::factory()->create([
             'nickname' => 'Test User',
             'email' => 'test@example.com',
+            'avatar_url' => 'https://i.pravatar.cc/150?img=68',
+            'profile_bio' => 'Curious tester keeping an eye on new features.',
         ]);
 
         $this->call([

--- a/database/seeders/TokenLogDemoSeeder.php
+++ b/database/seeders/TokenLogDemoSeeder.php
@@ -26,6 +26,8 @@ class TokenLogDemoSeeder extends Seeder
                     'password' => $password,
                     'email_verified_at' => $now->copy()->subDays(14),
                     'last_activity_at' => $now->copy()->subDay(),
+                    'avatar_url' => 'https://i.pravatar.cc/150?img=12',
+                    'profile_bio' => 'Oversees security tokens and keeps the system tidy.',
                 ]
             );
 
@@ -41,6 +43,8 @@ class TokenLogDemoSeeder extends Seeder
                     'password' => $password,
                     'email_verified_at' => $now->copy()->subDays(30),
                     'last_activity_at' => $now->copy()->subHours(6),
+                    'avatar_url' => 'https://i.pravatar.cc/150?img=33',
+                    'profile_bio' => 'Automation service powering webhooks and integrations.',
                 ]
             );
 

--- a/resources/js/components/blog/BlogComments.vue
+++ b/resources/js/components/blog/BlogComments.vue
@@ -4,6 +4,7 @@ import { usePage } from '@inertiajs/vue3';
 import { toast } from 'vue-sonner';
 
 import InputError from '@/components/InputError.vue';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useUserTimezone } from '@/composables/useUserTimezone';
@@ -12,6 +13,8 @@ type CommentUser = {
     id: number;
     nickname?: string | null;
     name?: string | null;
+    avatar_url?: string | null;
+    profile_bio?: string | null;
 };
 
 type BlogComment = {
@@ -194,6 +197,31 @@ const { formatDate, fromNow } = useUserTimezone();
 
 const commentAuthor = (comment: BlogComment) => {
     return comment.user?.nickname ?? comment.user?.name ?? 'Unknown user';
+};
+
+const commentInitials = (comment: BlogComment) => {
+    const source = comment.user?.nickname ?? comment.user?.name ?? 'U';
+    const parts = source
+        .split(/\s+/)
+        .filter(Boolean)
+        .map((part) => part[0] ?? '')
+        .join('');
+
+    return parts.slice(0, 2).toUpperCase() || 'U';
+};
+
+const authorBioSnippet = (comment: BlogComment) => {
+    const bio = comment.user?.profile_bio?.trim();
+
+    if (!bio) {
+        return '';
+    }
+
+    if (bio.length <= 160) {
+        return bio;
+    }
+
+    return `${bio.slice(0, 157)}…`;
 };
 
 const formatCommentTimestamp = (comment: BlogComment) => {
@@ -472,60 +500,79 @@ const deleteComment = async (commentId: number) => {
                 :key="comment.id"
                 class="rounded-lg border border-sidebar-border/50 dark:border-sidebar-border/80 p-4"
             >
-                <div class="flex flex-wrap items-center justify-between gap-2">
-                    <div>
-                        <p class="text-sm font-semibold text-foreground">
-                            {{ commentAuthor(comment) }}
-                        </p>
-                        <p v-if="comment.created_at" class="text-xs text-muted-foreground">
-                            {{ formatCommentTimestamp(comment) }}
-                            <span v-if="isEdited(comment)" class="ml-1 italic">(edited)</span>
-                        </p>
-                    </div>
-                    <div v-if="canManageComment(comment)" class="flex flex-wrap items-center gap-2 text-xs">
-                        <Button
-                            v-if="editingCommentId !== comment.id"
-                            variant="ghost"
-                            size="sm"
-                            class="h-8 px-2"
-                            @click="startEditing(comment)"
-                        >
-                            Edit
-                        </Button>
-                        <template v-else>
-                            <Button variant="ghost" size="sm" class="h-8 px-2" @click="cancelEditing">
-                                Cancel
-                            </Button>
-                            <Button
-                                size="sm"
-                                class="h-8 px-3"
-                                :disabled="isUpdating(comment.id)"
-                                @click="updateComment(comment.id)"
-                            >
-                                <span v-if="isUpdating(comment.id)">Saving...</span>
-                                <span v-else>Save</span>
-                            </Button>
-                        </template>
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            class="h-8 px-2 text-destructive hover:text-destructive"
-                            :disabled="isDeleting(comment.id)"
-                            @click="deleteComment(comment.id)"
-                        >
-                            <span v-if="isDeleting(comment.id)">Removing...</span>
-                            <span v-else>Delete</span>
-                        </Button>
-                    </div>
-                </div>
+                <div class="flex gap-4">
+                    <Avatar size="sm" class="mt-1">
+                        <AvatarImage
+                            v-if="comment.user?.avatar_url"
+                            :src="comment.user.avatar_url"
+                            :alt="`${commentAuthor(comment)} avatar`"
+                        />
+                        <AvatarFallback>{{ commentInitials(comment) }}</AvatarFallback>
+                    </Avatar>
 
-                <div v-if="editingCommentId === comment.id" class="mt-4 space-y-3">
-                    <Textarea v-model="editingContent" rows="4" class="w-full" />
-                    <InputError :message="editError" />
+                    <div class="min-w-0 flex-1 space-y-3">
+                        <div class="flex flex-wrap items-start justify-between gap-2">
+                            <div class="min-w-0">
+                                <p class="text-sm font-semibold text-foreground">
+                                    {{ commentAuthor(comment) }}
+                                </p>
+                                <p v-if="comment.created_at" class="text-xs text-muted-foreground">
+                                    {{ formatCommentTimestamp(comment) }}
+                                    <span v-if="isEdited(comment)" class="ml-1 italic">(edited)</span>
+                                </p>
+                                <p
+                                    v-if="authorBioSnippet(comment)"
+                                    class="mt-1 text-xs text-muted-foreground"
+                                >
+                                    {{ authorBioSnippet(comment) }}
+                                </p>
+                            </div>
+                            <div v-if="canManageComment(comment)" class="flex flex-wrap items-center gap-2 text-xs">
+                                <Button
+                                    v-if="editingCommentId !== comment.id"
+                                    variant="ghost"
+                                    size="sm"
+                                    class="h-8 px-2"
+                                    @click="startEditing(comment)"
+                                >
+                                    Edit
+                                </Button>
+                                <template v-else>
+                                    <Button variant="ghost" size="sm" class="h-8 px-2" @click="cancelEditing">
+                                        Cancel
+                                    </Button>
+                                    <Button
+                                        size="sm"
+                                        class="h-8 px-3"
+                                        :disabled="isUpdating(comment.id)"
+                                        @click="updateComment(comment.id)"
+                                    >
+                                        <span v-if="isUpdating(comment.id)">Saving...</span>
+                                        <span v-else>Save</span>
+                                    </Button>
+                                </template>
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    class="h-8 px-2 text-destructive hover:text-destructive"
+                                    :disabled="isDeleting(comment.id)"
+                                    @click="deleteComment(comment.id)"
+                                >
+                                    <span v-if="isDeleting(comment.id)">Removing...</span>
+                                    <span v-else>Delete</span>
+                                </Button>
+                            </div>
+                        </div>
+
+                        <div v-if="editingCommentId === comment.id" class="space-y-3">
+                            <Textarea v-model="editingContent" rows="4" class="w-full" />
+                            <InputError :message="editError" />
+                        </div>
+                        <p v-else class="whitespace-pre-line text-sm text-foreground">
+                            {{ comment.body }}
+                        </p>
+                    </div>
                 </div>
-                <p v-else class="mt-4 whitespace-pre-line text-sm text-foreground">
-                    {{ comment.body }}
-                </p>
             </div>
             <p v-if="loadMoreError" class="text-sm text-destructive">{{ loadMoreError }}</p>
             <div v-if="hasMore" class="pt-2 text-center">

--- a/tests/Feature/Blog/BlogCommentsMetadataTest.php
+++ b/tests/Feature/Blog/BlogCommentsMetadataTest.php
@@ -41,7 +41,7 @@ class BlogCommentsMetadataTest extends TestCase
         $response->assertJsonPath('data.0.user.id', $commenter->id);
         $response->assertJsonPath('data.0.user.avatar_url', 'https://cdn.example.com/commenter.png');
         $response->assertJsonPath('data.0.user.profile_bio', 'Product designer who loves sharing release notes.');
-        $response->assertJsonPath('data.0.user.name', $commenter->name);
+        $response->assertJsonPath('data.0.user.nickname', $commenter->nickname);
     }
 
     public function test_inertia_comment_payload_includes_profile_metadata(): void
@@ -72,6 +72,6 @@ class BlogCommentsMetadataTest extends TestCase
             ->where('comments.data.0.user.id', $commenter->id)
             ->where('comments.data.0.user.avatar_url', 'https://cdn.example.com/commenter.png')
             ->where('comments.data.0.user.profile_bio', 'Product designer who loves sharing release notes.')
-            ->where('comments.data.0.user.name', $commenter->name));
+            ->where('comments.data.0.user.nickname', $commenter->nickname));
     }
 }

--- a/tests/Feature/Blog/BlogCommentsMetadataTest.php
+++ b/tests/Feature/Blog/BlogCommentsMetadataTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Blog;
+
+use App\Models\Blog;
+use App\Models\BlogComment;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BlogCommentsMetadataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_comment_payload_includes_profile_metadata(): void
+    {
+        $author = User::factory()->create();
+        $commenter = User::factory()->create([
+            'avatar_url' => 'https://cdn.example.com/commenter.png',
+            'profile_bio' => 'Product designer who loves sharing release notes.',
+        ]);
+
+        $blog = Blog::factory()
+            ->published()
+            ->create([
+                'user_id' => $author->id,
+                'status' => 'published',
+            ]);
+
+        BlogComment::create([
+            'blog_id' => $blog->id,
+            'user_id' => $commenter->id,
+            'body' => 'Looking forward to trying this update!',
+        ]);
+
+        $response = $this->getJson(route('blogs.comments.index', ['blog' => $blog->slug]));
+
+        $response->assertOk();
+
+        $response->assertJsonPath('data.0.user.id', $commenter->id);
+        $response->assertJsonPath('data.0.user.avatar_url', 'https://cdn.example.com/commenter.png');
+        $response->assertJsonPath('data.0.user.profile_bio', 'Product designer who loves sharing release notes.');
+    }
+}

--- a/tests/Feature/Blog/BlogCommentsMetadataTest.php
+++ b/tests/Feature/Blog/BlogCommentsMetadataTest.php
@@ -6,6 +6,7 @@ use App\Models\Blog;
 use App\Models\BlogComment;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
 use Tests\TestCase;
 
 class BlogCommentsMetadataTest extends TestCase
@@ -40,5 +41,37 @@ class BlogCommentsMetadataTest extends TestCase
         $response->assertJsonPath('data.0.user.id', $commenter->id);
         $response->assertJsonPath('data.0.user.avatar_url', 'https://cdn.example.com/commenter.png');
         $response->assertJsonPath('data.0.user.profile_bio', 'Product designer who loves sharing release notes.');
+        $response->assertJsonPath('data.0.user.name', $commenter->name);
+    }
+
+    public function test_inertia_comment_payload_includes_profile_metadata(): void
+    {
+        $author = User::factory()->create();
+        $commenter = User::factory()->create([
+            'avatar_url' => 'https://cdn.example.com/commenter.png',
+            'profile_bio' => 'Product designer who loves sharing release notes.',
+        ]);
+
+        $blog = Blog::factory()
+            ->published()
+            ->create([
+                'user_id' => $author->id,
+                'status' => 'published',
+            ]);
+
+        BlogComment::create([
+            'blog_id' => $blog->id,
+            'user_id' => $commenter->id,
+            'body' => 'Looking forward to trying this update!',
+        ]);
+
+        $response = $this->get(route('blogs.view', ['slug' => $blog->slug]));
+
+        $response->assertOk()->assertInertia(fn (Assert $page) => $page
+            ->component('BlogView')
+            ->where('comments.data.0.user.id', $commenter->id)
+            ->where('comments.data.0.user.avatar_url', 'https://cdn.example.com/commenter.png')
+            ->where('comments.data.0.user.profile_bio', 'Product designer who loves sharing release notes.')
+            ->where('comments.data.0.user.name', $commenter->name));
     }
 }

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -30,6 +30,8 @@ class ProfileUpdateTest extends TestCase
             ->patch('/settings/profile', [
                 'nickname' => 'Test User',
                 'email' => 'test@example.com',
+                'avatar_url' => ' https://cdn.example.com/avatar.png ',
+                'profile_bio' => ' Passionate about testing. ',
             ]);
 
         $response
@@ -41,6 +43,8 @@ class ProfileUpdateTest extends TestCase
         $this->assertSame('Test User', $user->nickname);
         $this->assertSame('test@example.com', $user->email);
         $this->assertNull($user->email_verified_at);
+        $this->assertSame('https://cdn.example.com/avatar.png', $user->avatar_url);
+        $this->assertSame('Passionate about testing.', $user->profile_bio);
     }
 
     public function test_email_verification_status_is_unchanged_when_the_email_address_is_unchanged()


### PR DESCRIPTION
## Summary
- load commenter avatars and bios when serializing blog comments and surface sanitized metadata through the API
- render comment avatars and optional bio snippets in the blog comments component for a richer discussion experience
- trim profile settings inputs, seed realistic profile assets, and extend feature tests to cover avatar/bio handling

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de9985eab4832ca640179f913f62bc