### PR TITLE
Add admin user filters and coverage

### DIFF
--- a/tests/Feature/Admin/UsersIndexTest.php
+++ b/tests/Feature/Admin/UsersIndexTest.php
@@ -227,11 +227,17 @@ class UsersIndexTest extends TestCase
         $response->assertInertia(fn (Assert $page) => $page
             ->component('acp/Users')
             ->where('filters.activity_window', 5)
-            ->where('users.meta.total', 1)
-            ->where('users.data', function ($users) use ($recentUser, $staleUser) {
-                return count($users) === 1
-                    && $users[0]['id'] === $recentUser->id
-                    && $users[0]['id'] !== $staleUser->id;
+            ->where('users.meta.total', 2)
+            ->where('users.data', function ($users) use ($admin, $recentUser, $staleUser) {
+                if (count($users) !== 2) {
+                    return false;
+                }
+
+                $ids = collect($users)->pluck('id');
+
+                return $ids->contains($admin->id)
+                    && $ids->contains($recentUser->id)
+                    && ! $ids->contains($staleUser->id);
             })
         );
 

--- a/tests/Feature/Admin/UsersIndexTest.php
+++ b/tests/Feature/Admin/UsersIndexTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Admin;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Inertia\Testing\AssertableInertia as Assert;
 use Spatie\Permission\Models\Role;
 use Tests\TestCase;
@@ -100,5 +101,140 @@ class UsersIndexTest extends TestCase
                 return $ids->values()->all() === $expectedUsers->pluck('id')->values()->all();
             })
         );
+    }
+
+    public function test_role_filter_limits_results_to_selected_role(): void
+    {
+        $adminRole = Role::firstOrCreate(['name' => 'admin']);
+        $moderatorRole = Role::firstOrCreate(['name' => 'moderator']);
+        $memberRole = Role::firstOrCreate(['name' => 'member']);
+
+        $admin = User::factory()->create();
+        $admin->assignRole($adminRole);
+
+        $this->actingAs($admin);
+
+        $moderator = User::factory()->create();
+        $moderator->assignRole($moderatorRole);
+
+        $member = User::factory()->create();
+        $member->assignRole($memberRole);
+
+        $response = $this->get(route('acp.users.index', [
+            'role' => $moderatorRole->name,
+        ]));
+
+        $response->assertOk();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('acp/Users')
+            ->where('filters.role', $moderatorRole->name)
+            ->where('users.meta.total', 1)
+            ->where('users.data', function ($users) use ($moderator, $member) {
+                return count($users) === 1
+                    && $users[0]['id'] === $moderator->id
+                    && $users[0]['id'] !== $member->id;
+            })
+        );
+    }
+
+    public function test_verification_filter_limits_results_to_unverified_users(): void
+    {
+        $adminRole = Role::firstOrCreate(['name' => 'admin']);
+
+        $admin = User::factory()->create();
+        $admin->assignRole($adminRole);
+
+        $this->actingAs($admin);
+
+        $verified = User::factory()->create();
+        $unverified = User::factory()->unverified()->create();
+
+        $response = $this->get(route('acp.users.index', [
+            'verification' => 'unverified',
+        ]));
+
+        $response->assertOk();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('acp/Users')
+            ->where('filters.verification', 'unverified')
+            ->where('users.meta.total', 1)
+            ->where('users.data', function ($users) use ($unverified, $verified) {
+                return count($users) === 1
+                    && $users[0]['id'] === $unverified->id
+                    && $users[0]['id'] !== $verified->id;
+            })
+        );
+    }
+
+    public function test_banned_filter_limits_results_to_banned_users(): void
+    {
+        $adminRole = Role::firstOrCreate(['name' => 'admin']);
+
+        $admin = User::factory()->create();
+        $admin->assignRole($adminRole);
+
+        $this->actingAs($admin);
+
+        $bannedUser = User::factory()->create(['is_banned' => true]);
+        $activeUser = User::factory()->create(['is_banned' => false]);
+
+        $response = $this->get(route('acp.users.index', [
+            'banned' => 'banned',
+        ]));
+
+        $response->assertOk();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('acp/Users')
+            ->where('filters.banned', 'banned')
+            ->where('users.meta.total', 1)
+            ->where('users.data', function ($users) use ($bannedUser, $activeUser) {
+                return count($users) === 1
+                    && $users[0]['id'] === $bannedUser->id
+                    && $users[0]['id'] !== $activeUser->id;
+            })
+        );
+    }
+
+    public function test_activity_window_filter_limits_results_to_recently_active_users(): void
+    {
+        $adminRole = Role::firstOrCreate(['name' => 'admin']);
+
+        $admin = User::factory()->create();
+        $admin->assignRole($adminRole);
+
+        $this->actingAs($admin);
+
+        $now = now()->startOfMinute();
+        Carbon::setTestNow($now);
+
+        $recentUser = User::factory()->create([
+            'last_activity_at' => $now->copy()->subMinutes(3),
+        ]);
+
+        $staleUser = User::factory()->create([
+            'last_activity_at' => $now->copy()->subHours(2),
+        ]);
+
+        $response = $this->get(route('acp.users.index', [
+            'activity_window' => 5,
+        ]));
+
+        $response->assertOk();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('acp/Users')
+            ->where('filters.activity_window', 5)
+            ->where('users.meta.total', 1)
+            ->where('users.data', function ($users) use ($recentUser, $staleUser) {
+                return count($users) === 1
+                    && $users[0]['id'] === $recentUser->id
+                    && $users[0]['id'] !== $staleUser->id;
+            })
+        );
+
+        Carbon::setTestNow();
     }
 }


### PR DESCRIPTION
## Summary
- add role, verification, ban, and activity window filtering to the admin users index endpoint
- surface filter controls in the ACP Users page and keep pagination/query params in sync
- add feature tests that verify each new filter narrows results appropriately

## Testing
- php artisan test --filter=UsersIndexTest *(fails: vendor/autoload.php missing because composer install cannot clone doctrine/inflector due to 403 network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_68de9997b2b0832c8792db7e46093297