### PR TITLE
Expose comments metadata on BlogView payload

### DIFF
--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -289,6 +289,10 @@ class BlogController extends Controller
             ->values()
             ->all();
 
+        $paginatedComments = array_merge([
+            'data' => $commentItems,
+        ], $this->inertiaPagination($comments));
+
         $coverImageUrl = $blog->cover_image
             ? Storage::disk('public')->url($blog->cover_image)
             : null;
@@ -440,10 +444,9 @@ class BlogController extends Controller
                     ];
                 })->values()->all(),
                 'recommendations' => $recommendations,
-                'comments' => array_merge([
-                    'data' => $commentItems,
-                ], $this->inertiaPagination($comments)),
+                'comments' => $paginatedComments,
             ],
+            'comments' => $paginatedComments,
         ])->withViewData([
             'metaTags' => $metaTags,
             'linkTags' => $linkTags,


### PR DESCRIPTION
## Summary
- reuse the prepared paginated comments payload when building the BlogView response
- expose the comments listing at the page root so Inertia assertions can reach comment user metadata

## Testing
- ⚠️ `composer install && ./vendor/bin/phpunit` *(blocked by GitHub authentication while installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e020e83d4c832c833741e145321fc3