### PR TITLE
Use shared confirm dialog across ACP management pages

### DIFF
--- a/resources/js/components/ConfirmDialog.vue
+++ b/resources/js/components/ConfirmDialog.vue
@@ -77,6 +77,7 @@ const handleConfirm = () => {
                     {{ description }}
                 </DialogDescription>
             </DialogHeader>
+            <slot />
             <DialogFooter class="sm:space-x-2">
                 <Button ref="cancelButtonRef" variant="outline" @click="handleCancel">
                     {{ cancelLabel }}

--- a/resources/js/components/ConfirmDialog.vue
+++ b/resources/js/components/ConfirmDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, ref, watch, type ComponentPublicInstance } from 'vue';
 import { useId } from 'radix-vue';
 
 import { Button, type ButtonVariants } from '@/components/ui/button';
@@ -44,15 +44,42 @@ const dialogOpen = computed({
 const dialogId = useId();
 const descriptionId = computed(() => (props.description ? `${dialogId}-description` : undefined));
 
-const cancelButtonRef = ref<HTMLButtonElement | null>(null);
-const confirmButtonRef = ref<HTMLButtonElement | null>(null);
+type FocusCandidate = HTMLElement | ComponentPublicInstance | null;
+
+const cancelButtonRef = ref<FocusCandidate>(null);
+const confirmButtonRef = ref<FocusCandidate>(null);
+
+const focusCandidate = (candidate: FocusCandidate) => {
+    if (!candidate) {
+        return;
+    }
+
+    if (candidate instanceof HTMLElement) {
+        candidate.focus();
+        return;
+    }
+
+    const focusMethod = (candidate as { focus?: () => void }).focus;
+    if (typeof focusMethod === 'function') {
+        focusMethod.call(candidate);
+        return;
+    }
+
+    const instance = candidate as ComponentPublicInstance & {
+        $el?: unknown;
+        el?: unknown;
+    };
+
+    const possibleElement = (instance.$el ?? instance.el) as HTMLElement | undefined;
+    possibleElement?.focus?.();
+};
 
 watch(
     () => dialogOpen.value,
     (isOpen) => {
         if (isOpen) {
             requestAnimationFrame(() => {
-                (cancelButtonRef.value ?? confirmButtonRef.value)?.focus();
+                focusCandidate(cancelButtonRef.value ?? confirmButtonRef.value);
             });
         }
     },

--- a/resources/js/composables/useConfirmDialog.ts
+++ b/resources/js/composables/useConfirmDialog.ts
@@ -1,0 +1,76 @@
+import { computed, reactive } from 'vue';
+import type { ButtonVariants } from '@/components/ui/button';
+
+type ConfirmDialogOptions = {
+    title: string;
+    description?: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    confirmVariant?: ButtonVariants['variant'];
+    confirmDisabled?: boolean;
+    onConfirm: () => void;
+    onCancel?: () => void;
+};
+
+const createInitialState = () => ({
+    open: false,
+    title: '',
+    description: null as string | null,
+    confirmLabel: 'Confirm',
+    cancelLabel: 'Cancel',
+    confirmVariant: 'destructive' as ButtonVariants['variant'],
+    confirmDisabled: false,
+    onConfirm: null as null | (() => void),
+    onCancel: null as null | (() => void),
+});
+
+export const useConfirmDialog = () => {
+    const state = reactive(createInitialState());
+
+    const description = computed(() => state.description ?? undefined);
+
+    const openConfirmDialog = (options: ConfirmDialogOptions) => {
+        state.title = options.title;
+        state.description = options.description ?? null;
+        state.confirmLabel = options.confirmLabel ?? 'Confirm';
+        state.cancelLabel = options.cancelLabel ?? 'Cancel';
+        state.confirmVariant = options.confirmVariant ?? 'destructive';
+        state.confirmDisabled = options.confirmDisabled ?? false;
+        state.onConfirm = options.onConfirm;
+        state.onCancel = options.onCancel ?? null;
+        state.open = true;
+    };
+
+    const closeConfirmDialog = () => {
+        state.open = false;
+        state.onConfirm = null;
+        state.onCancel = null;
+        state.confirmDisabled = false;
+    };
+
+    const handleConfirmDialogConfirm = () => {
+        state.onConfirm?.();
+        closeConfirmDialog();
+    };
+
+    const handleConfirmDialogCancel = () => {
+        state.onCancel?.();
+        closeConfirmDialog();
+    };
+
+    const setConfirmDialogConfirmDisabled = (value: boolean) => {
+        state.confirmDisabled = value;
+    };
+
+    return {
+        confirmDialogState: state,
+        confirmDialogDescription: description,
+        openConfirmDialog,
+        closeConfirmDialog,
+        handleConfirmDialogConfirm,
+        handleConfirmDialogCancel,
+        setConfirmDialogConfirmDisabled,
+    };
+};
+
+export type { ConfirmDialogOptions };

--- a/resources/js/pages/acp/Blogs.vue
+++ b/resources/js/pages/acp/Blogs.vue
@@ -29,14 +29,6 @@ import {
     PaginationPrev,
 } from '@/components/ui/pagination';
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-} from '@/components/ui/dialog';
-import {
     FileText,
     Edit3,
     CheckCircle,
@@ -52,6 +44,8 @@ import {
 import { usePermissions } from '@/composables/usePermissions';
 import { useUserTimezone } from '@/composables/useUserTimezone';
 import { useInertiaPagination, type PaginationMeta } from '@/composables/useInertiaPagination';
+import ConfirmDialog from '@/components/ConfirmDialog.vue';
+import { useConfirmDialog } from '@/composables/useConfirmDialog';
 
 // dayjs composable for human readable dates
 const { fromNow } = useUserTimezone();
@@ -218,36 +212,27 @@ const unpublishPost = (postId: number) => {
     });
 };
 
-const archiveDialogOpen = ref(false);
-const archiveTarget = ref<BlogRow | null>(null);
+const {
+    confirmDialogState,
+    confirmDialogDescription,
+    openConfirmDialog,
+    handleConfirmDialogConfirm,
+    handleConfirmDialogCancel,
+} = useConfirmDialog();
 
-const openArchiveDialog = (post: BlogRow) => {
-    archiveTarget.value = post;
-    archiveDialogOpen.value = true;
-};
-
-const closeArchiveDialog = () => {
-    archiveDialogOpen.value = false;
-};
-
-const confirmArchivePost = () => {
-    if (!archiveTarget.value) {
-        return;
-    }
-
-    router.put(route('acp.blogs.archive', { blog: archiveTarget.value.id }), {}, {
-        preserveScroll: true,
-        onSuccess: () => {
-            archiveDialogOpen.value = false;
+const confirmArchivePost = (post: BlogRow) => {
+    openConfirmDialog({
+        title: `Archive “${post.title}”?`,
+        description:
+            'Archiving this post will hide it from the public blog listing. You can restore it from the admin panel at any time.',
+        confirmLabel: 'Archive post',
+        onConfirm: () => {
+            router.put(route('acp.blogs.archive', { blog: post.id }), {}, {
+                preserveScroll: true,
+            });
         },
     });
 };
-
-watch(archiveDialogOpen, (open) => {
-    if (!open) {
-        archiveTarget.value = null;
-    }
-});
 
 const unarchivePost = (postId: number) => {
     router.put(route('acp.blogs.unarchive', { blog: postId }), {}, {
@@ -258,6 +243,15 @@ const unarchivePost = (postId: number) => {
 const deletePost = (postId: number) => {
     router.delete(route('acp.blogs.destroy', { blog: postId }), {
         preserveScroll: true,
+    });
+};
+
+const confirmDeletePost = (post: BlogRow) => {
+    openConfirmDialog({
+        title: `Delete “${post.title}”?`,
+        description: 'Deleting this post will permanently remove it and its content from the site.',
+        confirmLabel: 'Delete post',
+        onConfirm: () => deletePost(post.id),
     });
 };
 </script>
@@ -381,7 +375,7 @@ const deletePost = (postId: number) => {
                                                     </DropdownMenuItem>
                                                     <DropdownMenuItem
                                                         v-if="post.status !== 'archived'"
-                                                        @click="openArchiveDialog(post)"
+                                                        @click="confirmArchivePost(post)"
                                                     >
                                                         <Archive class="mr-2" />
                                                         <span>Archive</span>
@@ -400,7 +394,7 @@ const deletePost = (postId: number) => {
                                                 <DropdownMenuItem
                                                     v-if="deleteBlogs"
                                                     class="text-red-500"
-                                                    @click="deletePost(post.id)"
+                                                    @click="confirmDeletePost(post)"
                                                 >
                                                     <Trash2 class="mr-2" />
                                                     <span>Delete</span>
@@ -464,21 +458,15 @@ const deletePost = (postId: number) => {
             </div>
         </AdminLayout>
     </AppLayout>
-    <Dialog v-model:open="archiveDialogOpen">
-        <DialogContent class="sm:max-w-md">
-            <DialogHeader>
-                <DialogTitle>Archive blog post</DialogTitle>
-                <DialogDescription>
-                    Archiving
-                    <span class="font-semibold">{{ archiveTarget?.title ?? 'this blog post' }}</span>
-                    will hide it from the public blog listing. You can unarchive it from the admin panel at any
-                    time.
-                </DialogDescription>
-            </DialogHeader>
-            <DialogFooter class="gap-2 sm:gap-3">
-                <Button variant="outline" @click="closeArchiveDialog">Cancel</Button>
-                <Button variant="destructive" @click="confirmArchivePost">Archive</Button>
-            </DialogFooter>
-        </DialogContent>
-    </Dialog>
+    <ConfirmDialog
+        v-model:open="confirmDialogState.open"
+        :title="confirmDialogState.title"
+        :description="confirmDialogDescription"
+        :confirm-label="confirmDialogState.confirmLabel"
+        :cancel-label="confirmDialogState.cancelLabel"
+        :confirm-variant="confirmDialogState.confirmVariant"
+        :confirm-disabled="confirmDialogState.confirmDisabled"
+        @confirm="handleConfirmDialogConfirm"
+        @cancel="handleConfirmDialogCancel"
+    />
 </template>


### PR DESCRIPTION
## Summary
- add a reusable `useConfirmDialog` composable and allow the `ConfirmDialog` component to render custom content
- apply the shared confirm dialog to destructive actions on the access control, blogs, forums, forum reports, support, and token ACP list pages
- ensure confirmation dialogs cover deletion, revocation, and status/priority changes with consistent messaging across the ACP

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e040996e58832c8550cf8eb479cbc8