### PR TITLE
Add aggregated search endpoint with command palette

### DIFF
--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Blog;
+use App\Models\Faq;
+use App\Models\ForumThread;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class SearchController extends Controller
+{
+    /**
+     * Handle the aggregated search across blogs, forum threads, and FAQs.
+     */
+    public function __invoke(Request $request): JsonResponse
+    {
+        $query = $request->string('q')->trim();
+        $limit = (int) $request->integer('limit', 5);
+        $limit = max(1, min($limit, 10));
+
+        if ($query->isEmpty()) {
+            return response()->json([
+                'query' => '',
+                'results' => $this->emptyResults(),
+            ]);
+        }
+
+        $term = $query->toString();
+        $likeTerm = '%' . $term . '%';
+
+        $blogsCollection = Blog::query()
+            ->where(function ($query) {
+                $query->where('status', 'published')
+                    ->orWhere(function ($query) {
+                        $query->where('status', 'scheduled')
+                            ->whereNotNull('scheduled_for')
+                            ->where('scheduled_for', '<=', now());
+                    });
+            })
+            ->where(function ($query) use ($likeTerm) {
+                $query->where('title', 'like', $likeTerm)
+                    ->orWhere('excerpt', 'like', $likeTerm);
+            })
+            ->orderByDesc('published_at')
+            ->orderByDesc('created_at')
+            ->limit($limit + 1)
+            ->get(['id', 'title', 'slug', 'excerpt', 'published_at', 'created_at']);
+
+        $blogItems = $blogsCollection
+            ->take($limit)
+            ->map(function (Blog $blog) {
+                $excerpt = is_string($blog->excerpt) ? trim($blog->excerpt) : '';
+
+                return [
+                    'id' => $blog->id,
+                    'title' => $blog->title,
+                    'description' => $excerpt !== '' ? Str::limit($excerpt, 120) : null,
+                    'url' => route('blogs.view', ['slug' => $blog->slug]),
+                ];
+            })
+            ->values()
+            ->all();
+
+        $threadsCollection = ForumThread::query()
+            ->where('is_published', true)
+            ->where(function ($query) use ($likeTerm) {
+                $query->where('title', 'like', $likeTerm)
+                    ->orWhere('excerpt', 'like', $likeTerm);
+            })
+            ->with(['board:id,slug,title'])
+            ->orderByDesc('last_posted_at')
+            ->orderByDesc('created_at')
+            ->limit($limit + 1)
+            ->get(['id', 'forum_board_id', 'title', 'slug', 'excerpt', 'last_posted_at', 'created_at']);
+
+        $threadItems = $threadsCollection
+            ->take($limit)
+            ->map(function (ForumThread $thread) {
+                $board = $thread->board;
+
+                if ($board === null) {
+                    return null;
+                }
+
+                $excerpt = is_string($thread->excerpt) ? trim($thread->excerpt) : '';
+
+                return [
+                    'id' => $thread->id,
+                    'title' => $thread->title,
+                    'description' => $excerpt !== '' ? Str::limit($excerpt, 120) : null,
+                    'url' => route('forum.threads.show', ['board' => $board->slug, 'thread' => $thread->slug]),
+                ];
+            })
+            ->filter()
+            ->values()
+            ->all();
+
+        $faqCollection = Faq::query()
+            ->where('published', true)
+            ->where(function ($query) use ($likeTerm) {
+                $query->where('question', 'like', $likeTerm)
+                    ->orWhere('answer', 'like', $likeTerm);
+            })
+            ->orderBy('order')
+            ->orderBy('question')
+            ->limit($limit + 1)
+            ->get(['id', 'faq_category_id', 'question', 'answer']);
+
+        $faqItems = $faqCollection
+            ->take($limit)
+            ->map(function (Faq $faq) use ($term) {
+                $answer = is_string($faq->answer) ? trim(strip_tags($faq->answer)) : '';
+
+                $params = ['faqs_search' => $term];
+
+                if ($faq->faq_category_id) {
+                    $params['faq_category_id'] = $faq->faq_category_id;
+                }
+
+                return [
+                    'id' => $faq->id,
+                    'title' => $faq->question,
+                    'description' => $answer !== '' ? Str::limit($answer, 120) : null,
+                    'url' => route('support', $params),
+                ];
+            })
+            ->values()
+            ->all();
+
+        return response()->json([
+            'query' => $term,
+            'results' => [
+                'blogs' => [
+                    'items' => $blogItems,
+                    'has_more' => $blogsCollection->count() > $limit,
+                ],
+                'forum_threads' => [
+                    'items' => $threadItems,
+                    'has_more' => $threadsCollection->count() > $limit,
+                ],
+                'faqs' => [
+                    'items' => $faqItems,
+                    'has_more' => $faqCollection->count() > $limit,
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, array{items: array<int, array<string, mixed>>, has_more: bool}>
+     */
+    private function emptyResults(): array
+    {
+        return [
+            'blogs' => [
+                'items' => [],
+                'has_more' => false,
+            ],
+            'forum_threads' => [
+                'items' => [],
+                'has_more' => false,
+            ],
+            'faqs' => [
+                'items' => [],
+                'has_more' => false,
+            ],
+        ];
+    }
+}

--- a/resources/js/components/AppHeader.vue
+++ b/resources/js/components/AppHeader.vue
@@ -2,6 +2,7 @@
 import AppLogo from '@/components/AppLogo.vue';
 import AppLogoIcon from '@/components/AppLogoIcon.vue';
 import Breadcrumbs from '@/components/Breadcrumbs.vue';
+import CommandPalette from '@/components/CommandPalette.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
@@ -19,7 +20,7 @@ import { getInitials } from '@/composables/useInitials';
 import type { BreadcrumbItem, NavItem, NotificationItem, SharedData, User } from '@/types';
 import { Link, router, usePage } from '@inertiajs/vue3';
 import { BookOpen, Folder, LayoutGrid, Menu, Search, Megaphone, Shield, LifeBuoy, Bell, Check, Trash2 } from 'lucide-vue-next';
-import { computed, ref } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 
 interface Props {
     breadcrumbs?: BreadcrumbItem[];
@@ -44,6 +45,35 @@ const isCurrentRoute = computed(() => (url: string) => page.url === url);
 const activeItemStyles = computed(
     () => (url: string) => (isCurrentRoute.value(url) ? 'text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100' : ''),
 );
+
+const isCommandPaletteOpen = ref(false);
+
+const openCommandPalette = () => {
+    isCommandPaletteOpen.value = true;
+};
+
+const closeCommandPalette = () => {
+    isCommandPaletteOpen.value = false;
+};
+
+const handleSearchShortcut = (event: KeyboardEvent) => {
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        openCommandPalette();
+    }
+
+    if (event.key === 'Escape' && isCommandPaletteOpen.value) {
+        closeCommandPalette();
+    }
+};
+
+onMounted(() => {
+    window.addEventListener('keydown', handleSearchShortcut);
+});
+
+onBeforeUnmount(() => {
+    window.removeEventListener('keydown', handleSearchShortcut);
+});
 
 const mainNavItems: NavItem[] = [
     { title: 'Dashboard', href: '/dashboard', icon: LayoutGrid },
@@ -181,6 +211,8 @@ const viewNotification = (notification: NotificationItem) => {
 
 <template>
     <div>
+        <CommandPalette v-model:open="isCommandPaletteOpen" />
+
         <!-- Fixed header -->
         <div class="fixed inset-x-0 top-0 z-50 border-b border-sidebar-border/80 bg-white dark:bg-neutral-900">
             <div class="mx-auto flex h-16 items-center px-4 md:max-w-7xl">
@@ -262,7 +294,15 @@ const viewNotification = (notification: NotificationItem) => {
                 <!-- Right side -->
                 <div class="ml-auto flex items-center space-x-2">
                     <div class="relative flex items-center space-x-1">
-                        <Button variant="ghost" size="icon" class="group h-9 w-9 cursor-pointer">
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            class="group h-9 w-9 cursor-pointer"
+                            :title="'Search (Ctrl+K)'"
+                            @click="openCommandPalette"
+                        >
+                            <span class="sr-only">Open search (Ctrl+K)</span>
                             <Search class="size-5 opacity-80 group-hover:opacity-100" />
                         </Button>
 

--- a/resources/js/components/CommandPalette.vue
+++ b/resources/js/components/CommandPalette.vue
@@ -1,0 +1,284 @@
+<script setup lang="ts">
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Link } from '@inertiajs/vue3';
+import { useDebounceFn, useVModel } from '@vueuse/core';
+import { Loader2, Search as SearchIcon } from 'lucide-vue-next';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+
+type SearchResultItem = {
+    id: number | string;
+    title: string;
+    description: string | null;
+    url: string;
+};
+
+type SearchResultGroup = {
+    items: SearchResultItem[];
+    has_more: boolean;
+};
+
+type SearchResultsPayload = {
+    query: string;
+    results: {
+        blogs: SearchResultGroup;
+        forum_threads: SearchResultGroup;
+        faqs: SearchResultGroup;
+    };
+};
+
+const props = defineProps<{ open: boolean }>();
+const emit = defineEmits<{ (e: 'update:open', value: boolean): void }>();
+
+const open = useVModel(props, 'open', emit, { passive: true });
+
+const query = ref('');
+const isLoading = ref(false);
+const fetchError = ref<string | null>(null);
+const inputRef = ref<HTMLInputElement | { $el?: HTMLInputElement } | null>(null);
+
+const createEmptyResults = (): SearchResultsPayload['results'] => ({
+    blogs: { items: [], has_more: false },
+    forum_threads: { items: [], has_more: false },
+    faqs: { items: [], has_more: false },
+});
+
+const results = ref<SearchResultsPayload['results']>(createEmptyResults());
+
+const MIN_QUERY_LENGTH = 2;
+let activeController: AbortController | null = null;
+
+const trimmedQuery = computed(() => query.value.trim());
+
+const hasAnyResults = computed(() =>
+    results.value.blogs.items.length > 0 ||
+    results.value.forum_threads.items.length > 0 ||
+    results.value.faqs.items.length > 0,
+);
+
+const groups = computed(() =>
+    [
+        {
+            key: 'blogs',
+            title: 'Blog posts',
+            items: results.value.blogs.items,
+            hasMore: results.value.blogs.has_more,
+        },
+        {
+            key: 'forum_threads',
+            title: 'Forum threads',
+            items: results.value.forum_threads.items,
+            hasMore: results.value.forum_threads.has_more,
+        },
+        {
+            key: 'faqs',
+            title: 'FAQs',
+            items: results.value.faqs.items,
+            hasMore: results.value.faqs.has_more,
+        },
+    ].filter((group) => group.items.length > 0),
+);
+
+const isMac = ref(false);
+
+const resolveInputElement = () => {
+    if (inputRef.value instanceof HTMLInputElement) {
+        return inputRef.value;
+    }
+
+    if (inputRef.value && '$el' in inputRef.value && inputRef.value.$el instanceof HTMLInputElement) {
+        return inputRef.value.$el;
+    }
+
+    return null;
+};
+
+const focusInput = () => {
+    void nextTick(() => {
+        resolveInputElement()?.focus();
+    });
+};
+
+const clearActiveRequest = () => {
+    if (activeController) {
+        activeController.abort();
+        activeController = null;
+    }
+};
+
+const resetResults = () => {
+    results.value = createEmptyResults();
+};
+
+const performSearch = async (term: string) => {
+    clearActiveRequest();
+
+    const controller = new AbortController();
+    activeController = controller;
+    isLoading.value = true;
+    fetchError.value = null;
+
+    try {
+        const response = await fetch(route('search', { q: term, limit: 5 }), {
+            headers: { Accept: 'application/json' },
+            signal: controller.signal,
+        });
+
+        if (!response.ok) {
+            throw new Error(`Search request failed with status ${response.status}`);
+        }
+
+        const payload = (await response.json()) as SearchResultsPayload;
+
+        results.value = payload?.results ?? createEmptyResults();
+    } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+            return;
+        }
+
+        fetchError.value = 'Unable to load search results. Please try again.';
+        resetResults();
+    } finally {
+        if (activeController === controller) {
+            isLoading.value = false;
+            activeController = null;
+        }
+    }
+};
+
+const debouncedSearch = useDebounceFn((term: string) => {
+    void performSearch(term);
+}, 250);
+
+watch(
+    () => trimmedQuery.value,
+    (value) => {
+        if (!open.value) {
+            return;
+        }
+
+        if (value.length < MIN_QUERY_LENGTH) {
+            clearActiveRequest();
+            debouncedSearch.cancel?.();
+            isLoading.value = false;
+            fetchError.value = null;
+            resetResults();
+            return;
+        }
+
+        debouncedSearch(value);
+    },
+);
+
+watch(
+    () => open.value,
+    (isOpen) => {
+        if (isOpen) {
+            focusInput();
+            return;
+        }
+
+        clearActiveRequest();
+        debouncedSearch.cancel?.();
+        query.value = '';
+        fetchError.value = null;
+        isLoading.value = false;
+        resetResults();
+    },
+);
+
+const closePalette = () => {
+    open.value = false;
+};
+
+const handleGlobalKeydown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && open.value) {
+        event.preventDefault();
+        closePalette();
+    }
+};
+
+onMounted(() => {
+    isMac.value = /Mac|iPod|iPhone|iPad/.test(window.navigator.platform);
+    window.addEventListener('keydown', handleGlobalKeydown);
+});
+
+onBeforeUnmount(() => {
+    window.removeEventListener('keydown', handleGlobalKeydown);
+    clearActiveRequest();
+});
+</script>
+
+<template>
+    <Dialog v-model:open="open">
+        <DialogContent class="max-w-2xl gap-0 overflow-hidden p-0">
+            <div class="border-b border-border/70 bg-muted/40 px-4 py-3">
+                <label class="sr-only" for="global-command-palette">Search</label>
+                <div class="flex items-center gap-3">
+                    <SearchIcon class="h-4 w-4 text-muted-foreground" />
+                    <Input
+                        id="global-command-palette"
+                        ref="inputRef"
+                        v-model="query"
+                        type="search"
+                        placeholder="Search blogs, forum threads, and FAQs"
+                        class="h-9 border-0 bg-transparent p-0 text-base shadow-none focus-visible:ring-0"
+                        autocomplete="off"
+                        @keydown.esc.prevent="closePalette"
+                    />
+                    <kbd
+                        class="ml-auto hidden items-center gap-1 rounded border border-border bg-background px-2 py-0.5 text-[11px] font-medium text-muted-foreground md:inline-flex"
+                    >
+                        <span>{{ isMac ? '⌘' : 'Ctrl' }}</span>
+                        <span>K</span>
+                    </kbd>
+                </div>
+            </div>
+
+            <div class="max-h-[60vh] min-h-[140px] overflow-y-auto">
+                <div v-if="fetchError" class="px-4 py-6 text-sm text-destructive">
+                    {{ fetchError }}
+                </div>
+                <div
+                    v-else-if="trimmedQuery.length < MIN_QUERY_LENGTH"
+                    class="px-4 py-6 text-sm text-muted-foreground"
+                >
+                    Type at least {{ MIN_QUERY_LENGTH }} characters to search.
+                </div>
+                <div v-else-if="isLoading" class="flex items-center gap-2 px-4 py-6 text-sm text-muted-foreground">
+                    <Loader2 class="h-4 w-4 animate-spin" />
+                    Searching…
+                </div>
+                <template v-else>
+                    <div v-if="hasAnyResults" class="divide-y divide-border/60">
+                        <section v-for="group in groups" :key="group.key" class="bg-background">
+                            <div class="px-4 pt-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                {{ group.title }}
+                            </div>
+                            <ul>
+                                <li v-for="item in group.items" :key="`${group.key}-${item.id}`">
+                                    <Link
+                                        :href="item.url"
+                                        class="flex flex-col gap-1 px-4 py-3 text-left transition hover:bg-muted focus:bg-muted focus:outline-none"
+                                        @click="closePalette"
+                                    >
+                                        <span class="text-sm font-medium text-foreground">{{ item.title }}</span>
+                                        <span v-if="item.description" class="text-sm text-muted-foreground">
+                                            {{ item.description }}
+                                        </span>
+                                    </Link>
+                                </li>
+                            </ul>
+                            <div v-if="group.hasMore" class="px-4 pb-3 text-xs text-muted-foreground">
+                                Showing top {{ group.items.length }} results.
+                            </div>
+                        </section>
+                    </div>
+                    <div v-else class="px-4 py-6 text-sm text-muted-foreground">
+                        No results for “{{ trimmedQuery }}”.
+                    </div>
+                </template>
+            </div>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\ForumController;
 use App\Http\Controllers\ForumPostController;
 use App\Http\Controllers\ForumThreadActionController;
 use App\Http\Controllers\ForumThreadModerationController;
+use App\Http\Controllers\SearchController;
 use App\Http\Controllers\SupportCenterController;
 use App\Http\Controllers\UserNotificationController;
 use Illuminate\Support\Facades\Route;
@@ -17,6 +18,8 @@ use Inertia\Inertia;
 Route::get('/', function () {
     return Inertia::render('Welcome');
 })->name('home');
+
+Route::get('/search', SearchController::class)->name('search');
 
 // Public Blog Routes
 Route::get('/blogs', [BlogController::class, 'index'])->name('blogs.index');


### PR DESCRIPTION
## Summary
- add an aggregated `SearchController` endpoint that returns blogs, forum threads, and FAQs in a single JSON payload
- register the `/search` route and introduce a headless `CommandPalette` Vue component that debounces calls to the endpoint and groups results
- wire the header search button and global shortcut to open the command palette with Inertia-powered navigation

## Testing
- npm run lint
- php artisan test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68e06bd5e238832c941a13aced97df38