### PR TITLE
Ensure mention suggestions and support notifications meet expectations

### DIFF
--- a/app/Http/Controllers/ForumController.php
+++ b/app/Http/Controllers/ForumController.php
@@ -164,12 +164,12 @@ class ForumController extends Controller
             }
 
             return [
-                'id' => $mentioned->id,
+                'id' => (int) $mentioned->id,
                 'nickname' => $mentioned->nickname,
                 'avatar_url' => $mentioned->avatar_url,
                 'profile_url' => $profileUrl,
             ];
-        })->values();
+        })->values()->all();
 
         return response()->json([
             'data' => $results,

--- a/app/Support/SupportTicketNotificationDispatcher.php
+++ b/app/Support/SupportTicketNotificationDispatcher.php
@@ -4,12 +4,13 @@ namespace App\Support;
 
 use App\Models\SupportTicket;
 use App\Models\User;
-use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Notification as BaseNotification;
+use Illuminate\Support\Facades\Notification;
 
 class SupportTicketNotificationDispatcher
 {
     /**
-     * @param  callable(string, array<int, string>): Notification  $notificationFactory
+     * @param  callable(string, array<int, string>): BaseNotification  $notificationFactory
      */
     public function dispatch(SupportTicket $ticket, callable $notificationFactory): void
     {
@@ -26,11 +27,11 @@ class SupportTicketNotificationDispatcher
                 $queuedChannels = array_values(array_diff($channels, $synchronousChannels));
 
                 if ($synchronousChannels !== []) {
-                    $recipient->notifyNow($notificationFactory($audience, $synchronousChannels));
+                    Notification::sendNow($recipient, $notificationFactory($audience, $synchronousChannels));
                 }
 
                 if ($queuedChannels !== []) {
-                    $recipient->notify($notificationFactory($audience, $queuedChannels));
+                    Notification::send($recipient, $notificationFactory($audience, $queuedChannels));
                 }
             });
     }


### PR DESCRIPTION
## Summary
- ensure forum mention suggestion payloads return plain arrays with numeric IDs for JSON assertions
- send support ticket reply notifications via the Notification facade so both mail and database channels are captured

## Testing
- not run (composer install blocked by GitHub API 403 during dependency download)


------
https://chatgpt.com/codex/tasks/task_e_68e09c30732c832c9043fbfae3a09733