### PR TITLE
Fix mention suggestions response for forum posts

### DIFF
--- a/app/Http/Controllers/ForumController.php
+++ b/app/Http/Controllers/ForumController.php
@@ -156,20 +156,28 @@ class ForumController extends Controller
             ->limit(8)
             ->get();
 
-        $results = $users->map(function (User $mentioned) {
+        $results = [];
+
+        foreach ($users as $mentioned) {
+            $nickname = is_string($mentioned->nickname) ? trim($mentioned->nickname) : '';
+
+            if ($nickname === '') {
+                continue;
+            }
+
             $profileUrl = null;
 
             if (Route::has('members.show')) {
                 $profileUrl = route('members.show', ['user' => $mentioned->getRouteKey()]);
             }
 
-            return [
-                'id' => (int) $mentioned->id,
-                'nickname' => $mentioned->nickname,
+            $results[] = [
+                'id' => $mentioned->getKey(),
+                'nickname' => $nickname,
                 'avatar_url' => $mentioned->avatar_url,
                 'profile_url' => $profileUrl,
             ];
-        })->values()->all();
+        }
 
         return response()->json([
             'data' => $results,


### PR DESCRIPTION
## Summary
- ensure forum mention suggestion results always include id, nickname, avatar, and profile URL fields
- trim empty nicknames and skip blank entries to avoid malformed payloads

## Testing
- not run (composer install requires GitHub access in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e09e9d3248832c865fb51f16c8641a