### PR TITLE
Fix mention suggestions JSON structure

### DIFF
--- a/app/Http/Controllers/ForumController.php
+++ b/app/Http/Controllers/ForumController.php
@@ -156,13 +156,11 @@ class ForumController extends Controller
             ->limit(8)
             ->get();
 
-        $results = [];
-
-        foreach ($users as $mentioned) {
+        $results = $users->map(function (User $mentioned) {
             $nickname = is_string($mentioned->nickname) ? trim($mentioned->nickname) : '';
 
             if ($nickname === '') {
-                continue;
+                return null;
             }
 
             $profileUrl = null;
@@ -171,13 +169,13 @@ class ForumController extends Controller
                 $profileUrl = route('members.show', ['user' => $mentioned->getRouteKey()]);
             }
 
-            $results[] = [
+            return [
                 'id' => $mentioned->getKey(),
                 'nickname' => $nickname,
                 'avatar_url' => $mentioned->avatar_url,
                 'profile_url' => $profileUrl,
             ];
-        }
+        })->filter()->values()->all();
 
         return response()->json([
             'data' => $results,


### PR DESCRIPTION
## Summary
- build forum mention suggestion results using a collection pipeline that filters empty nicknames
- ensure the API returns a plain array of mention entries for the JSON response

## Testing
- not run (composer install requires network access that is blocked in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0a33be678832c84b748f5c4186fae