### PR TITLE
Refine forum mention suggestions

### DIFF
--- a/app/Http/Resources/MentionSuggestionResource.php
+++ b/app/Http/Resources/MentionSuggestionResource.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Route;
+
+/**
+ * @mixin \App\Models\User
+ */
+class MentionSuggestionResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $nickname = trim((string) $this->nickname);
+
+        $profileUrl = null;
+
+        if ($nickname !== '' && Route::has('members.show')) {
+            $profileUrl = route('members.show', ['user' => $this->getRouteKey()]);
+        }
+
+        return [
+            'id' => $this->getKey(),
+            'nickname' => $nickname,
+            'avatar_url' => $this->avatar_url,
+            'profile_url' => $profileUrl,
+        ];
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace the manual forum mention suggestion mapping with a dedicated JSON resource
- filter out blank nicknames before building the collection and keep the response shape consistent

## Testing
- not run (composer install requires GitHub access in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e0a8e7f894832c80ba4f2515c28c9b