### PR TITLE
Add blog revision history management to ACP

### DIFF
--- a/app/Models/Blog.php
+++ b/app/Models/Blog.php
@@ -75,4 +75,9 @@ class Blog extends Model
         return $this->belongsToMany(BlogTag::class, 'blog_blog_tag')
             ->withTimestamps();
     }
+
+    public function revisions(): HasMany
+    {
+        return $this->hasMany(BlogRevision::class);
+    }
 }

--- a/app/Models/Blog.php
+++ b/app/Models/Blog.php
@@ -12,6 +12,11 @@ class Blog extends Model
 {
     use HasFactory;
 
+    /**
+     * Ensure date attributes maintain microsecond precision when stored.
+     */
+    protected $dateFormat = 'Y-m-d H:i:s.u';
+
     protected $fillable = [
         'title',
         'slug',

--- a/app/Models/BlogRevision.php
+++ b/app/Models/BlogRevision.php
@@ -10,6 +10,11 @@ class BlogRevision extends Model
 {
     use HasFactory;
 
+    /**
+     * Ensure revision timestamps retain microsecond precision.
+     */
+    protected $dateFormat = 'Y-m-d H:i:s.u';
+
     protected $fillable = [
         'blog_id',
         'editor_id',

--- a/app/Models/BlogRevision.php
+++ b/app/Models/BlogRevision.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BlogRevision extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'blog_id',
+        'editor_id',
+        'title',
+        'excerpt',
+        'body',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'metadata' => 'array',
+    ];
+
+    public function blog(): BelongsTo
+    {
+        return $this->belongsTo(Blog::class);
+    }
+
+    public function editor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'editor_id');
+    }
+}

--- a/app/Policies/BlogRevisionPolicy.php
+++ b/app/Policies/BlogRevisionPolicy.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\BlogRevision;
+use App\Models\User;
+
+class BlogRevisionPolicy
+{
+    public function restore(?User $user, BlogRevision $revision): bool
+    {
+        if (! $user) {
+            return false;
+        }
+
+        if (! $user->hasAnyRole(['admin', 'editor'])) {
+            return false;
+        }
+
+        return $revision->blog_id !== null;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\BlogRevision;
+use App\Policies\BlogRevisionPolicy;
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    protected $policies = [
+        BlogRevision::class => BlogRevisionPolicy::class,
+    ];
+
+    public function boot(): void
+    {
+        $this->registerPolicies();
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,5 +2,6 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\AuthServiceProvider::class,
     Spatie\Permission\PermissionServiceProvider::class,
 ];

--- a/database/factories/BlogRevisionFactory.php
+++ b/database/factories/BlogRevisionFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Blog;
+use App\Models\BlogRevision;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<BlogRevision>
+ */
+class BlogRevisionFactory extends Factory
+{
+    protected $model = BlogRevision::class;
+
+    public function definition(): array
+    {
+        $title = $this->faker->sentence(6);
+
+        return [
+            'blog_id' => Blog::factory(),
+            'editor_id' => User::factory(),
+            'title' => $title,
+            'excerpt' => $this->faker->paragraph(),
+            'body' => $this->faker->paragraphs(3, true),
+            'metadata' => [
+                'slug' => Str::slug($title) . '-' . Str::random(5),
+                'status' => 'draft',
+                'cover_image' => null,
+                'published_at' => null,
+                'scheduled_for' => null,
+                'category_ids' => [],
+                'tag_ids' => [],
+            ],
+        ];
+    }
+}

--- a/database/migrations/2025_04_16_080943_create_blogs_table.php
+++ b/database/migrations/2025_04_16_080943_create_blogs_table.php
@@ -16,7 +16,7 @@ class CreateBlogsTable extends Migration
             $table->longText('body');
             $table->unsignedBigInteger('user_id');  // Foreign key to users table
             $table->enum('status', ['draft', 'published', 'archived'])->default('draft');
-            $table->timestamp('published_at')->nullable();
+            $table->timestamp('published_at', 6)->nullable();
             $table->timestamps();
 
             // Optional: add a foreign key constraint if desired

--- a/database/migrations/2025_05_06_000000_add_scheduling_and_preview_fields_to_blogs_table.php
+++ b/database/migrations/2025_05_06_000000_add_scheduling_and_preview_fields_to_blogs_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('blogs', function (Blueprint $table) {
-            $table->timestamp('scheduled_for')->nullable()->after('published_at');
+            $table->timestamp('scheduled_for', 6)->nullable()->after('published_at');
             $table->string('preview_token', 64)->nullable()->after('scheduled_for');
         });
     }

--- a/database/migrations/2025_05_10_000000_create_blog_revisions_table.php
+++ b/database/migrations/2025_05_10_000000_create_blog_revisions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('blog_revisions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('blog_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('editor_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('title');
+            $table->text('excerpt')->nullable();
+            $table->longText('body');
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('blog_revisions');
+    }
+};

--- a/database/migrations/2025_05_10_000000_create_blog_revisions_table.php
+++ b/database/migrations/2025_05_10_000000_create_blog_revisions_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->text('excerpt')->nullable();
             $table->longText('body');
             $table->json('metadata')->nullable();
-            $table->timestamps();
+            $table->timestamps(6);
         });
     }
 

--- a/database/migrations/2025_05_10_010000_update_blog_datetime_precision.php
+++ b/database/migrations/2025_05_10_010000_update_blog_datetime_precision.php
@@ -1,0 +1,81 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('blogs')) {
+            return;
+        }
+
+        $driver = Schema::getConnection()->getDriverName();
+
+        if (! Schema::hasColumn('blogs', 'published_at')) {
+            return;
+        }
+
+        switch ($driver) {
+            case 'mysql':
+                DB::statement('ALTER TABLE blogs MODIFY published_at TIMESTAMP(6) NULL');
+                if (Schema::hasColumn('blogs', 'scheduled_for')) {
+                    DB::statement('ALTER TABLE blogs MODIFY scheduled_for TIMESTAMP(6) NULL');
+                }
+                break;
+            case 'pgsql':
+                DB::statement('ALTER TABLE blogs ALTER COLUMN published_at TYPE TIMESTAMP(6) WITHOUT TIME ZONE');
+                if (Schema::hasColumn('blogs', 'scheduled_for')) {
+                    DB::statement('ALTER TABLE blogs ALTER COLUMN scheduled_for TYPE TIMESTAMP(6) WITHOUT TIME ZONE');
+                }
+                break;
+            case 'sqlsrv':
+                DB::statement('ALTER TABLE blogs ALTER COLUMN published_at DATETIME2(6) NULL');
+                if (Schema::hasColumn('blogs', 'scheduled_for')) {
+                    DB::statement('ALTER TABLE blogs ALTER COLUMN scheduled_for DATETIME2(6) NULL');
+                }
+                break;
+            default:
+                // SQLite stores timestamps as text and already preserves precision.
+                break;
+        }
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('blogs')) {
+            return;
+        }
+
+        $driver = Schema::getConnection()->getDriverName();
+
+        if (! Schema::hasColumn('blogs', 'published_at')) {
+            return;
+        }
+
+        switch ($driver) {
+            case 'mysql':
+                DB::statement('ALTER TABLE blogs MODIFY published_at TIMESTAMP NULL');
+                if (Schema::hasColumn('blogs', 'scheduled_for')) {
+                    DB::statement('ALTER TABLE blogs MODIFY scheduled_for TIMESTAMP NULL');
+                }
+                break;
+            case 'pgsql':
+                DB::statement('ALTER TABLE blogs ALTER COLUMN published_at TYPE TIMESTAMP(0) WITHOUT TIME ZONE');
+                if (Schema::hasColumn('blogs', 'scheduled_for')) {
+                    DB::statement('ALTER TABLE blogs ALTER COLUMN scheduled_for TYPE TIMESTAMP(0) WITHOUT TIME ZONE');
+                }
+                break;
+            case 'sqlsrv':
+                DB::statement('ALTER TABLE blogs ALTER COLUMN published_at DATETIME2(0) NULL');
+                if (Schema::hasColumn('blogs', 'scheduled_for')) {
+                    DB::statement('ALTER TABLE blogs ALTER COLUMN scheduled_for DATETIME2(0) NULL');
+                }
+                break;
+            default:
+                break;
+        }
+    }
+};

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -48,6 +48,8 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
     Route::post('acp/blogs', [AdminBlogController::class, 'store'])->name('acp.blogs.store');
     Route::get('acp/blogs/{blog}/edit', [AdminBlogController::class, 'edit'])->name('acp.blogs.edit');
     Route::put('acp/blogs/{blog}', [AdminBlogController::class, 'update'])->name('acp.blogs.update');
+    Route::post('acp/blogs/{blog}/revisions/{revision}/restore', [AdminBlogController::class, 'restoreRevision'])
+        ->name('acp.blogs.revisions.restore');
     Route::delete('acp/blogs/{blog}', [AdminBlogController::class, 'destroy'])->name('acp.blogs.destroy');
     Route::put('acp/blogs/{blog}/publish', [AdminBlogController::class, 'publish'])->name('acp.blogs.publish');
     Route::put('acp/blogs/{blog}/unpublish', [AdminBlogController::class, 'unpublish'])->name('acp.blogs.unpublish');

--- a/tests/Feature/Admin/BlogRevisionRestoreTest.php
+++ b/tests/Feature/Admin/BlogRevisionRestoreTest.php
@@ -61,7 +61,7 @@ class BlogRevisionRestoreTest extends TestCase
                     'slug' => 'archived-title',
                     'status' => 'published',
                     'cover_image' => 'covers/example.jpg',
-                    'published_at' => $publishedAt->toIso8601String(),
+                    'published_at' => $publishedAt->format('Y-m-d\TH:i:s.uP'),
                     'scheduled_for' => null,
                     'category_ids' => [$targetCategory->id],
                     'tag_ids' => [$targetTag->id],

--- a/tests/Feature/Admin/BlogRevisionRestoreTest.php
+++ b/tests/Feature/Admin/BlogRevisionRestoreTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Blog;
+use App\Models\BlogCategory;
+use App\Models\BlogRevision;
+use App\Models\BlogTag;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class BlogRevisionRestoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Role::firstOrCreate(['name' => 'admin']);
+        Role::firstOrCreate(['name' => 'editor']);
+        Role::firstOrCreate(['name' => 'moderator']);
+    }
+
+    public function test_editor_can_restore_revision_and_updates_blog(): void
+    {
+        $editor = User::factory()->create();
+        $editor->assignRole('editor');
+        $this->actingAs($editor);
+
+        $blog = Blog::factory()->create([
+            'title' => 'Current Title',
+            'slug' => 'current-title',
+            'excerpt' => 'Current excerpt',
+            'body' => 'Current body',
+            'status' => 'draft',
+            'cover_image' => 'covers/current.jpg',
+        ]);
+
+        $currentCategory = BlogCategory::factory()->create();
+        $currentTag = BlogTag::factory()->create();
+        $blog->categories()->sync([$currentCategory->id]);
+        $blog->tags()->sync([$currentTag->id]);
+
+        $targetCategory = BlogCategory::factory()->create();
+        $targetTag = BlogTag::factory()->create();
+
+        $publishedAt = Carbon::now()->subDay();
+
+        $revision = BlogRevision::factory()
+            ->for($blog)
+            ->for($editor, 'editor')
+            ->create([
+                'title' => 'Archived Title',
+                'excerpt' => 'Archived excerpt',
+                'body' => 'Archived body',
+                'metadata' => [
+                    'slug' => 'archived-title',
+                    'status' => 'published',
+                    'cover_image' => 'covers/example.jpg',
+                    'published_at' => $publishedAt->toIso8601String(),
+                    'scheduled_for' => null,
+                    'category_ids' => [$targetCategory->id],
+                    'tag_ids' => [$targetTag->id],
+                ],
+            ]);
+
+        $response = $this->post(route('acp.blogs.revisions.restore', [
+            'blog' => $blog->id,
+            'revision' => $revision->id,
+        ]));
+
+        $response->assertRedirect(route('acp.blogs.edit', ['blog' => $blog->id]));
+
+        $blog->refresh();
+
+        $this->assertSame('Archived Title', $blog->title);
+        $this->assertSame('Archived excerpt', $blog->excerpt);
+        $this->assertSame('Archived body', $blog->body);
+        $this->assertSame('archived-title', $blog->slug);
+        $this->assertSame('published', $blog->status);
+        $this->assertSame('covers/example.jpg', $blog->cover_image);
+        $this->assertTrue($blog->published_at?->equalTo($publishedAt));
+        $this->assertNull($blog->scheduled_for);
+
+        $this->assertEqualsCanonicalizing(
+            [$targetCategory->id],
+            $blog->categories()->pluck('blog_categories.id')->all()
+        );
+        $this->assertEqualsCanonicalizing(
+            [$targetTag->id],
+            $blog->tags()->pluck('blog_tags.id')->all()
+        );
+
+        $latestRevision = $blog->revisions()->latest()->first();
+        $this->assertNotNull($latestRevision);
+        $this->assertNotSame($revision->id, $latestRevision->id);
+        $this->assertSame($blog->title, $latestRevision->title);
+        $this->assertSame('published', $latestRevision->metadata['status'] ?? null);
+
+        $this->assertSame(2, $blog->revisions()->count());
+    }
+
+    public function test_moderator_cannot_restore_revision(): void
+    {
+        $moderator = User::factory()->create();
+        $moderator->assignRole('moderator');
+        $this->actingAs($moderator);
+
+        $blog = Blog::factory()->create([
+            'title' => 'Initial Title',
+            'excerpt' => 'Initial excerpt',
+            'body' => 'Initial body',
+        ]);
+
+        $revision = BlogRevision::factory()->for($blog)->create([
+            'title' => 'Older Title',
+            'metadata' => [
+                'slug' => 'older-title',
+                'status' => 'draft',
+                'category_ids' => [],
+                'tag_ids' => [],
+            ],
+        ]);
+
+        $response = $this->post(route('acp.blogs.revisions.restore', [
+            'blog' => $blog->id,
+            'revision' => $revision->id,
+        ]));
+
+        $response->assertForbidden();
+
+        $blog->refresh();
+        $this->assertSame('Initial Title', $blog->title);
+    }
+}

--- a/tests/Feature/Blog/BlogFeedTest.php
+++ b/tests/Feature/Blog/BlogFeedTest.php
@@ -34,7 +34,7 @@ class BlogFeedTest extends TestCase
         $this->assertDatabaseHas('blogs', [
             'id' => $scheduledPost->id,
             'status' => 'published',
-            'published_at' => $expectedScheduledPublishedAt,
+            'published_at' => $expectedScheduledPublishedAt->format('Y-m-d H:i:s.u'),
         ]);
 
         $xml = simplexml_load_string($response->getContent());


### PR DESCRIPTION
## Summary
- add a blog_revisions table, model, factory, and policy wiring for revision snapshots
- record revisions from admin blog actions and expose a restore endpoint guarded by authorization
- surface revision history and restore UI in the ACP editor and cover the flow with feature tests

## Testing
- php artisan test --filter=BlogRevisionRestoreTest *(blocked: Composer could not download dependencies due to GitHub 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a058fbb4832ca3f6e4e3a3f58a67