### PR TITLE
Add forum post revision history

### DIFF
--- a/app/Http/Controllers/ForumPostController.php
+++ b/app/Http/Controllers/ForumPostController.php
@@ -119,6 +119,14 @@ class ForumPostController extends Controller
             ]);
         }
 
+        if ($body !== $post->body) {
+            $post->revisions()->create([
+                'body' => $post->body,
+                'edited_at' => $post->edited_at,
+                'edited_by_id' => $user->id,
+            ]);
+        }
+
         $post->forceFill([
             'body' => $body,
             'edited_at' => Carbon::now(),

--- a/app/Http/Controllers/ForumPostRevisionController.php
+++ b/app/Http/Controllers/ForumPostRevisionController.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ForumBoard;
+use App\Models\ForumPost;
+use App\Models\ForumPostRevision;
+use App\Models\ForumThread;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ForumPostRevisionController extends Controller
+{
+    public function index(Request $request, ForumBoard $board, ForumThread $thread, ForumPost $post): Response
+    {
+        $this->ensureHierarchy($board, $thread, $post);
+
+        $user = $request->user();
+        abort_if($user === null, 403);
+
+        Gate::authorize('viewHistory', $post);
+
+        $board->loadMissing('category:id,title,slug');
+        $post->loadMissing('author:id,nickname');
+        $thread->loadMissing('board:id,title,slug', 'board.category:id,title,slug');
+
+        $revisions = $post->revisions()
+            ->with('editor:id,nickname')
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(function (ForumPostRevision $revision) {
+                return [
+                    'id' => $revision->id,
+                    'body' => $revision->body,
+                    'edited_at' => optional($revision->edited_at)?->toIso8601String(),
+                    'created_at' => optional($revision->created_at)?->toIso8601String(),
+                    'editor' => $revision->editor?->only(['id', 'nickname']),
+                ];
+            })
+            ->values();
+
+        return Inertia::render('acp/ForumPostHistory', [
+            'board' => [
+                'id' => $board->id,
+                'title' => $board->title,
+                'slug' => $board->slug,
+                'category' => [
+                    'title' => $board->category?->title,
+                    'slug' => $board->category?->slug,
+                ],
+            ],
+            'thread' => [
+                'id' => $thread->id,
+                'title' => $thread->title,
+                'slug' => $thread->slug,
+            ],
+            'post' => [
+                'id' => $post->id,
+                'body' => $post->body,
+                'created_at' => optional($post->created_at)?->toIso8601String(),
+                'edited_at' => optional($post->edited_at)?->toIso8601String(),
+                'author' => $post->author?->only(['id', 'nickname']),
+                'permissions' => [
+                    'canRestore' => Gate::allows('restoreRevision', $post),
+                ],
+            ],
+            'revisions' => $revisions,
+        ]);
+    }
+
+    public function restore(Request $request, ForumBoard $board, ForumThread $thread, ForumPost $post, ForumPostRevision $revision): RedirectResponse
+    {
+        $this->ensureHierarchy($board, $thread, $post);
+
+        abort_if($revision->forum_post_id !== $post->id, 404);
+
+        $user = $request->user();
+        abort_if($user === null, 403);
+
+        Gate::authorize('restoreRevision', $post);
+
+        $post->revisions()->create([
+            'body' => $post->body,
+            'edited_at' => $post->edited_at,
+            'edited_by_id' => $user->id,
+        ]);
+
+        $post->forceFill([
+            'body' => $revision->body,
+            'edited_at' => Carbon::now(),
+        ])->save();
+
+        return redirect()
+            ->route('forum.posts.history', [$board, $thread, $post])
+            ->with('success', 'Revision restored successfully.');
+    }
+
+    private function ensureHierarchy(ForumBoard $board, ForumThread $thread, ForumPost $post): void
+    {
+        abort_if($thread->forum_board_id !== $board->id, 404);
+        abort_if($post->forum_thread_id !== $thread->id, 404);
+    }
+}

--- a/app/Models/ForumPost.php
+++ b/app/Models/ForumPost.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class ForumPost extends Model
@@ -31,5 +32,10 @@ class ForumPost extends Model
     public function author(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function revisions(): HasMany
+    {
+        return $this->hasMany(ForumPostRevision::class, 'forum_post_id');
     }
 }

--- a/app/Models/ForumPostRevision.php
+++ b/app/Models/ForumPostRevision.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ForumPostRevision extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'forum_post_id',
+        'edited_by_id',
+        'body',
+        'edited_at',
+    ];
+
+    protected $casts = [
+        'edited_at' => 'datetime',
+    ];
+
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(ForumPost::class, 'forum_post_id');
+    }
+
+    public function editor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'edited_by_id');
+    }
+}

--- a/app/Policies/ForumPostPolicy.php
+++ b/app/Policies/ForumPostPolicy.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\ForumPost;
+use App\Models\ForumThread;
+use App\Models\User;
+
+class ForumPostPolicy
+{
+    /**
+     * Determine whether the user can view a post's revision history.
+     */
+    public function viewHistory(User $user, ForumPost $post): bool
+    {
+        if ($user->hasAnyRole(['admin', 'editor', 'moderator'])) {
+            return true;
+        }
+
+        return $user->id === $post->user_id;
+    }
+
+    /**
+     * Determine whether the user can restore a revision.
+     */
+    public function restoreRevision(User $user, ForumPost $post): bool
+    {
+        if ($user->hasAnyRole(['admin', 'editor', 'moderator'])) {
+            return true;
+        }
+
+        /** @var ForumThread|null $thread */
+        $thread = $post->thread;
+
+        if ($thread === null) {
+            return false;
+        }
+
+        return $user->id === $post->user_id
+            && $thread->is_published
+            && !$thread->is_locked;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,8 +2,11 @@
 
 namespace App\Providers;
 
+use App\Models\ForumPost;
 use App\Models\PersonalAccessToken;
+use App\Policies\ForumPostPolicy;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Sanctum\Sanctum;
 
@@ -29,6 +32,8 @@ class AppServiceProvider extends ServiceProvider
             //force DB timestamps to use 'UTC' timezone for more accurate dayjs conversion to local timezones
             DB::statement("SET time_zone = '+00:00'");
         }
+
+        Gate::policy(ForumPost::class, ForumPostPolicy::class);
 
         Sanctum::usePersonalAccessTokenModel(PersonalAccessToken::class);
     }

--- a/database/migrations/2025_05_25_000000_create_forum_post_revisions_table.php
+++ b/database/migrations/2025_05_25_000000_create_forum_post_revisions_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('forum_post_revisions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('forum_post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('edited_by_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->text('body');
+            $table->timestamp('edited_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('forum_post_revisions');
+    }
+};

--- a/resources/js/pages/acp/ForumPostHistory.vue
+++ b/resources/js/pages/acp/ForumPostHistory.vue
@@ -1,0 +1,227 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+import { type BreadcrumbItem } from '@/types';
+import Button from '@/components/ui/button/Button.vue';
+import { ArrowLeft, RotateCcw } from 'lucide-vue-next';
+import { useUserTimezone } from '@/composables/useUserTimezone';
+
+interface BoardSummary {
+    id: number;
+    title: string;
+    slug: string;
+    category: {
+        title: string | null;
+        slug: string | null;
+    } | null;
+}
+
+interface ThreadSummary {
+    id: number;
+    title: string;
+    slug: string;
+}
+
+interface PostAuthorSummary {
+    id: number;
+    nickname: string;
+}
+
+interface PostPermissions {
+    canRestore: boolean;
+}
+
+interface PostSummary {
+    id: number;
+    body: string;
+    created_at: string | null;
+    edited_at: string | null;
+    author: PostAuthorSummary | null;
+    permissions: PostPermissions;
+}
+
+interface RevisionSummary {
+    id: number;
+    body: string;
+    created_at: string | null;
+    edited_at: string | null;
+    editor: PostAuthorSummary | null;
+}
+
+const props = defineProps<{
+    board: BoardSummary;
+    thread: ThreadSummary;
+    post: PostSummary;
+    revisions: RevisionSummary[];
+}>();
+
+const { formatDate, fromNow } = useUserTimezone();
+
+const breadcrumbs = computed<BreadcrumbItem[]>(() => [
+    { title: 'Forum', href: route('forum.index') },
+    { title: props.board.title, href: route('forum.boards.show', { board: props.board.slug }) },
+    { title: props.thread.title, href: route('forum.threads.show', { board: props.board.slug, thread: props.thread.slug }) },
+    { title: 'Post History', href: '#' },
+]);
+
+const post = computed(() => props.post);
+const revisions = computed(() => props.revisions);
+const canRestore = computed(() => post.value.permissions.canRestore);
+
+const threadUrl = computed(() => route('forum.threads.show', {
+    board: props.board.slug,
+    thread: props.thread.slug,
+}));
+
+const formatExact = (value: string | null | undefined) => {
+    if (!value) {
+        return null;
+    }
+
+    return formatDate(value, 'MMM D, YYYY h:mm A');
+};
+
+const formatRelative = (value: string | null | undefined) => {
+    if (!value) {
+        return null;
+    }
+
+    return fromNow(value);
+};
+
+const requestRestore = (revisionId: number) => {
+    if (!canRestore.value) {
+        return;
+    }
+
+    if (!window.confirm('Restore this revision? The current content will be saved as a new revision.')) {
+        return;
+    }
+
+    router.put(
+        route('forum.posts.history.restore', {
+            board: props.board.slug,
+            thread: props.thread.slug,
+            post: props.post.id,
+            revision: revisionId,
+        }),
+        {},
+        {
+            preserveScroll: true,
+        },
+    );
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Post Revision History" />
+
+        <AdminLayout>
+            <div class="container mx-auto space-y-8 p-4">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div class="flex items-center gap-3">
+                        <Link :href="threadUrl">
+                            <Button variant="outline" size="icon">
+                                <ArrowLeft class="h-5 w-5" />
+                            </Button>
+                        </Link>
+                        <div>
+                            <h1 class="text-3xl font-bold">Post Revision History</h1>
+                            <p class="text-sm text-muted-foreground">
+                                Thread: {{ thread.title }} · Board: {{ board.title }}
+                            </p>
+                        </div>
+                    </div>
+                    <div class="text-sm text-muted-foreground md:text-right">
+                        <p v-if="post.author">
+                            Post by {{ post.author.nickname }}
+                        </p>
+                        <p v-if="formatExact(post.created_at)">
+                            Created {{ formatExact(post.created_at) }}
+                        </p>
+                        <p v-if="post.edited_at">
+                            Last edited {{ formatExact(post.edited_at) }}
+                            <span v-if="formatRelative(post.edited_at)">
+                                ({{ formatRelative(post.edited_at) }})
+                            </span>
+                        </p>
+                    </div>
+                </div>
+
+                <div class="grid gap-6">
+                    <div class="rounded-xl border p-6 shadow-sm">
+                        <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                            <div>
+                                <h2 class="text-xl font-semibold">Current Version</h2>
+                                <p class="text-sm text-muted-foreground">
+                                    Last updated {{ formatExact(post.edited_at ?? post.created_at) ?? 'Unknown' }}
+                                    <span v-if="formatRelative(post.edited_at ?? post.created_at)">
+                                        ({{ formatRelative(post.edited_at ?? post.created_at) }})
+                                    </span>
+                                </p>
+                            </div>
+                            <div class="text-sm text-muted-foreground md:text-right">
+                                <p v-if="!canRestore">You do not have permission to restore revisions.</p>
+                                <p v-else>Restoring a revision will archive this version automatically.</p>
+                            </div>
+                        </div>
+                        <div class="prose prose-sm mt-4 max-w-none" v-html="post.body" />
+                    </div>
+
+                    <div class="rounded-xl border p-6 shadow-sm">
+                        <div class="flex items-center justify-between gap-4">
+                            <h2 class="text-xl font-semibold">Revision History</h2>
+                            <span class="text-sm text-muted-foreground">
+                                {{ revisions.length }} {{ revisions.length === 1 ? 'revision' : 'revisions' }} stored
+                            </span>
+                        </div>
+
+                        <div v-if="revisions.length === 0" class="mt-6 rounded-lg border border-dashed p-6 text-center text-muted-foreground">
+                            No revisions recorded yet. Updates to this post will appear here automatically.
+                        </div>
+
+                        <div v-else class="mt-6 space-y-4">
+                            <div
+                                v-for="revision in revisions"
+                                :key="revision.id"
+                                class="rounded-lg border p-4 shadow-sm"
+                            >
+                                <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                                    <div>
+                                        <p class="font-semibold">
+                                            Saved {{ formatExact(revision.created_at) ?? 'Unknown time' }}
+                                        </p>
+                                        <p class="text-sm text-muted-foreground">
+                                            <span v-if="revision.editor">by {{ revision.editor.nickname }}</span>
+                                            <span v-else>by Unknown user</span>
+                                            <span v-if="revision.edited_at">
+                                                · Original edit timestamp {{ formatExact(revision.edited_at) ?? 'Unknown' }}
+                                            </span>
+                                        </p>
+                                        <p v-if="formatRelative(revision.created_at)" class="text-xs text-muted-foreground">
+                                            {{ formatRelative(revision.created_at) }}
+                                        </p>
+                                    </div>
+                                    <Button
+                                        v-if="canRestore"
+                                        variant="outline"
+                                        size="sm"
+                                        class="shrink-0"
+                                        @click="requestRestore(revision.id)"
+                                    >
+                                        <RotateCcw class="mr-2 h-4 w-4" />
+                                        Restore this version
+                                    </Button>
+                                </div>
+                                <div class="prose prose-sm mt-4 max-w-none rounded-lg border bg-muted/40 p-4" v-html="revision.body" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\ForumController;
 use App\Http\Controllers\ForumPostController;
 use App\Http\Controllers\ForumThreadActionController;
+use App\Http\Controllers\ForumPostRevisionController;
 use App\Http\Controllers\ForumThreadModerationController;
 use App\Http\Controllers\SearchController;
 use App\Http\Controllers\SupportCenterController;
@@ -82,6 +83,10 @@ Route::middleware('auth')->group(function () {
         ->name('forum.posts.destroy');
     Route::post('forum/{board:slug}/{thread:slug}/posts/{post}/report', [ForumPostController::class, 'report'])
         ->name('forum.posts.report');
+    Route::get('forum/{board:slug}/{thread:slug}/posts/{post}/history', [ForumPostRevisionController::class, 'index'])
+        ->name('forum.posts.history');
+    Route::put('forum/{board:slug}/{thread:slug}/posts/{post}/history/{revision}', [ForumPostRevisionController::class, 'restore'])
+        ->name('forum.posts.history.restore');
 });
 
 Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {

--- a/tests/Feature/Forum/PostRevisionTest.php
+++ b/tests/Feature/Forum/PostRevisionTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Tests\Feature\Forum;
+
+use App\Models\ForumBoard;
+use App\Models\ForumCategory;
+use App\Models\ForumPost;
+use App\Models\ForumPostRevision;
+use App\Models\ForumThread;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Inertia\Testing\AssertableInertia;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class PostRevisionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Role::create(['name' => 'moderator', 'guard_name' => 'web']);
+        Role::create(['name' => 'admin', 'guard_name' => 'web']);
+        Role::create(['name' => 'editor', 'guard_name' => 'web']);
+    }
+
+    public function test_updating_post_creates_revision_snapshot(): void
+    {
+        $author = User::factory()->create();
+        [$board, $thread, $post] = $this->createForumContext($author, '<p>Original content</p>');
+
+        $response = $this->actingAs($author)->put(route('forum.posts.update', [$board, $thread, $post]), [
+            'body' => '<p>Updated content</p>',
+        ]);
+
+        $response->assertRedirect();
+
+        $this->assertDatabaseHas('forum_post_revisions', [
+            'forum_post_id' => $post->id,
+            'body' => '<p>Original content</p>',
+            'edited_by_id' => $author->id,
+        ]);
+
+        $post->refresh();
+
+        $this->assertSame('<p>Updated content</p>', $post->body);
+        $this->assertNotNull($post->edited_at);
+    }
+
+    public function test_moderator_can_view_revision_history(): void
+    {
+        $author = User::factory()->create();
+        [$board, $thread, $post] = $this->createForumContext($author, '<p>First version</p>');
+
+        $this->actingAs($author)->put(route('forum.posts.update', [$board, $thread, $post]), [
+            'body' => '<p>Second version</p>',
+        ]);
+
+        $moderator = $this->createModerator();
+
+        $response = $this->actingAs($moderator)->get(route('forum.posts.history', [$board, $thread, $post]));
+
+        $response->assertOk();
+
+        $response->assertInertia(function (AssertableInertia $page) use ($post, $author) {
+            return $page
+                ->component('acp/ForumPostHistory')
+                ->where('post.id', $post->id)
+                ->where('revisions.0.body', '<p>First version</p>')
+                ->where('revisions.0.editor.id', $author->id);
+        });
+    }
+
+    public function test_non_author_cannot_view_revision_history(): void
+    {
+        $author = User::factory()->create();
+        [$board, $thread, $post] = $this->createForumContext($author, '<p>Initial post</p>');
+
+        $this->actingAs($author)->put(route('forum.posts.update', [$board, $thread, $post]), [
+            'body' => '<p>Changed content</p>',
+        ]);
+
+        $viewer = User::factory()->create();
+
+        $response = $this->actingAs($viewer)->get(route('forum.posts.history', [$board, $thread, $post]));
+
+        $response->assertForbidden();
+    }
+
+    public function test_author_can_restore_revision(): void
+    {
+        $author = User::factory()->create();
+        [$board, $thread, $post] = $this->createForumContext($author, '<p>Original body</p>');
+
+        $this->actingAs($author)->put(route('forum.posts.update', [$board, $thread, $post]), [
+            'body' => '<p>Edited body</p>',
+        ]);
+
+        $revision = ForumPostRevision::first();
+        $this->assertNotNull($revision);
+
+        $response = $this->actingAs($author)->put(route('forum.posts.history.restore', [$board, $thread, $post, $revision]));
+
+        $response->assertRedirect(route('forum.posts.history', [$board, $thread, $post]));
+        $response->assertSessionHas('success', 'Revision restored successfully.');
+
+        $post->refresh();
+
+        $this->assertSame('<p>Original body</p>', $post->body);
+        $this->assertNotNull($post->edited_at);
+
+        $this->assertDatabaseHas('forum_post_revisions', [
+            'forum_post_id' => $post->id,
+            'body' => '<p>Edited body</p>',
+        ]);
+
+        $this->assertSame(2, ForumPostRevision::query()->where('forum_post_id', $post->id)->count());
+    }
+
+    public function test_unauthorized_user_cannot_restore_revision(): void
+    {
+        $author = User::factory()->create();
+        [$board, $thread, $post] = $this->createForumContext($author, '<p>Original</p>');
+
+        $this->actingAs($author)->put(route('forum.posts.update', [$board, $thread, $post]), [
+            'body' => '<p>Modified</p>',
+        ]);
+
+        $revision = ForumPostRevision::firstOrFail();
+
+        $otherUser = User::factory()->create();
+
+        $response = $this->actingAs($otherUser)->put(route('forum.posts.history.restore', [$board, $thread, $post, $revision]));
+
+        $response->assertForbidden();
+    }
+
+    private function createForumContext(User $author, string $body): array
+    {
+        $category = ForumCategory::create([
+            'title' => 'General Discussion',
+            'slug' => 'general-discussion',
+            'description' => 'General chatter',
+            'position' => 1,
+        ]);
+
+        $board = ForumBoard::create([
+            'forum_category_id' => $category->id,
+            'title' => 'Announcements',
+            'slug' => 'announcements',
+            'description' => 'All announcements',
+            'position' => 1,
+        ]);
+
+        $thread = ForumThread::create([
+            'forum_board_id' => $board->id,
+            'user_id' => $author->id,
+            'title' => 'Thread Title',
+            'slug' => Str::slug('Thread Title-' . Str::random(5)),
+            'excerpt' => 'Summary',
+            'is_locked' => false,
+            'is_pinned' => false,
+            'is_published' => true,
+            'views' => 0,
+            'last_posted_at' => now(),
+            'last_post_user_id' => $author->id,
+        ]);
+
+        $post = ForumPost::create([
+            'forum_thread_id' => $thread->id,
+            'user_id' => $author->id,
+            'body' => $body,
+        ]);
+
+        return [$board, $thread, $post];
+    }
+
+    private function createModerator(): User
+    {
+        $user = User::factory()->create();
+
+        $role = Role::findByName('moderator');
+        $user->assignRole($role);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary
- add a forum_post_revisions table and Eloquent model to capture historic post content
- record revisions during post updates and restoration flows with dedicated controller endpoints and policy rules
- build an Inertia-based history view for moderators/authors and cover the feature with regression tests

## Testing
- Unable to run `php artisan test` (composer install prompts for a GitHub token in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0a05d9010832cb3b5a6af9ef9f818