### PR TITLE
Add FAQ feedback voting and analytics

### DIFF
--- a/app/Http/Controllers/SupportCenterController.php
+++ b/app/Http/Controllers/SupportCenterController.php
@@ -172,7 +172,7 @@ class SupportCenterController extends Controller
 
         $faqGroups = $faqCollection
             ->groupBy(fn (Faq $faq) => $faq->faq_category_id)
-            ->map(function ($items) {
+            ->map(function ($items) use ($userFeedbackByFaq) {
                 /** @var Faq $first */
                 $first = $items->first();
 

--- a/app/Http/Requests/StoreFaqFeedbackRequest.php
+++ b/app/Http/Requests/StoreFaqFeedbackRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreFaqFeedbackRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'value' => [
+                'required',
+                'string',
+                Rule::in(['helpful', 'not_helpful']),
+            ],
+        ];
+    }
+}

--- a/app/Models/Faq.php
+++ b/app/Models/Faq.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Faq extends Model
 {
@@ -24,5 +25,29 @@ class Faq extends Model
     public function category(): BelongsTo
     {
         return $this->belongsTo(FaqCategory::class, 'faq_category_id');
+    }
+
+    /**
+     * @return HasMany<FaqFeedback>
+     */
+    public function feedback(): HasMany
+    {
+        return $this->hasMany(FaqFeedback::class);
+    }
+
+    /**
+     * @return HasMany<FaqFeedback>
+     */
+    public function helpfulFeedback(): HasMany
+    {
+        return $this->feedback()->where('is_helpful', true);
+    }
+
+    /**
+     * @return HasMany<FaqFeedback>
+     */
+    public function notHelpfulFeedback(): HasMany
+    {
+        return $this->feedback()->where('is_helpful', false);
     }
 }

--- a/app/Models/FaqFeedback.php
+++ b/app/Models/FaqFeedback.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FaqFeedback extends Model
+{
+    use HasFactory;
+
+    protected $table = 'faq_feedback';
+
+    protected $fillable = [
+        'faq_id',
+        'user_id',
+        'is_helpful',
+    ];
+
+    protected $casts = [
+        'is_helpful' => 'boolean',
+    ];
+
+    /**
+     * @return BelongsTo<Faq, self>
+     */
+    public function faq(): BelongsTo
+    {
+        return $this->belongsTo(Faq::class);
+    }
+
+    /**
+     * @return BelongsTo<User, self>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2025_05_10_150000_create_faq_feedback_table.php
+++ b/database/migrations/2025_05_10_150000_create_faq_feedback_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('faq_feedback', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('faq_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->boolean('is_helpful');
+            $table->timestamps();
+
+            $table->unique(['faq_id', 'user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('faq_feedback');
+    }
+};

--- a/resources/js/pages/acp/Support.vue
+++ b/resources/js/pages/acp/Support.vue
@@ -39,7 +39,7 @@ import {
 import ConfirmDialog from '@/components/ConfirmDialog.vue';
 import {
     XCircle, HelpCircle, Ticket, TicketX, MessageSquare, CheckCircle, Ellipsis, UserPlus, SquareChevronUp,
-    Trash2, MoveUp, MoveDown, Pencil, Eye, EyeOff, X
+    Trash2, MoveUp, MoveDown, Pencil, Eye, EyeOff, X, ThumbsUp, ThumbsDown,
 } from 'lucide-vue-next';
 import { usePermissions } from '@/composables/usePermissions';
 import { useUserTimezone } from '@/composables/useUserTimezone';
@@ -117,6 +117,8 @@ const props = defineProps<{
             answer: string;
             order: number;
             published: boolean;
+            helpful_feedback_count: number;
+            not_helpful_feedback_count: number;
             category: {
                 id: number;
                 name: string;
@@ -131,6 +133,8 @@ const props = defineProps<{
         open: number;
         closed: number;
         faqs: number;
+        faq_helpful_feedback: number;
+        faq_not_helpful_feedback: number;
     };
     assignableAgents: Array<{
         id: number;
@@ -421,6 +425,9 @@ const ticketsMetaSource = computed(() => props.tickets.meta ?? null);
 const faqsMetaSource = computed(() => props.faqs.meta ?? null);
 const ticketItems = computed(() => props.tickets.data ?? []);
 const faqItems = computed(() => props.faqs.data ?? []);
+const totalFaqFeedback = computed(
+    () => props.supportStats.faq_helpful_feedback + props.supportStats.faq_not_helpful_feedback,
+);
 
 type TicketFilterChipKey = 'status' | 'priority' | 'assignee' | 'date_range';
 
@@ -833,7 +840,7 @@ const unpublishFaq = (faq: FaqItem) => {
         <AdminLayout>
             <div class="flex h-full flex-1 flex-col gap-4 rounded-xl pb-4">
                 <!-- Stats Cards -->
-                <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-6 gap-4">
                     <div class="relative overflow-hidden rounded-xl border p-4 flex items-center">
                         <MessageSquare class="h-8 w-8 mr-3 text-gray-600" />
                         <div>
@@ -863,6 +870,25 @@ const unpublishFaq = (faq: FaqItem) => {
                         <div>
                             <div class="text-sm text-gray-500">FAQs</div>
                             <div class="text-xl font-bold">{{ props.supportStats.faqs }}</div>
+                            <div class="text-xs text-gray-500">
+                                {{ totalFaqFeedback }} total votes
+                            </div>
+                        </div>
+                        <PlaceholderPattern />
+                    </div>
+                    <div class="relative overflow-hidden rounded-xl border p-4 flex items-center">
+                        <ThumbsUp class="h-8 w-8 mr-3 text-green-600" />
+                        <div>
+                            <div class="text-sm text-gray-500">Helpful votes</div>
+                            <div class="text-xl font-bold">{{ props.supportStats.faq_helpful_feedback }}</div>
+                        </div>
+                        <PlaceholderPattern />
+                    </div>
+                    <div class="relative overflow-hidden rounded-xl border p-4 flex items-center">
+                        <ThumbsDown class="h-8 w-8 mr-3 text-red-600" />
+                        <div>
+                            <div class="text-sm text-gray-500">Not helpful votes</div>
+                            <div class="text-xl font-bold">{{ props.supportStats.faq_not_helpful_feedback }}</div>
                         </div>
                         <PlaceholderPattern />
                     </div>
@@ -1225,6 +1251,8 @@ const unpublishFaq = (faq: FaqItem) => {
                                             <TableHead>Category</TableHead>
                                             <TableHead>Order</TableHead>
                                             <TableHead>Published</TableHead>
+                                            <TableHead class="text-center">Helpful</TableHead>
+                                            <TableHead class="text-center">Not helpful</TableHead>
                                             <TableHead>Actions</TableHead>
                                         </TableRow>
                                     </TableHeader>
@@ -1240,6 +1268,8 @@ const unpublishFaq = (faq: FaqItem) => {
                                             <TableCell>{{ f.category?.name ?? '—' }}</TableCell>
                                             <TableCell>{{ f.order }}</TableCell>
                                             <TableCell>{{ f.published ? 'Yes' : 'No' }}</TableCell>
+                                            <TableCell class="text-center">{{ f.helpful_feedback_count }}</TableCell>
+                                            <TableCell class="text-center">{{ f.not_helpful_feedback_count }}</TableCell>
                                             <TableCell class="text-center">
                                                 <DropdownMenu>
                                                     <DropdownMenuTrigger as-child>
@@ -1298,7 +1328,7 @@ const unpublishFaq = (faq: FaqItem) => {
                                             </TableCell>
                                         </TableRow>
                                         <TableRow v-if="!faqItems.length">
-                                        <TableCell colspan="7" class="text-center text-gray-500">
+                                        <TableCell colspan="9" class="text-center text-gray-500">
                                             No FAQs found.
                                         </TableCell>
                                         </TableRow>

--- a/routes/web.php
+++ b/routes/web.php
@@ -121,6 +121,10 @@ Route::middleware('auth')->group(function () {
 
     Route::patch('support/tickets/{ticket}/reopen', [SupportCenterController::class, 'reopen'])
         ->name('support.tickets.reopen');
+
+    Route::post('support/faqs/{faq}/feedback', [SupportCenterController::class, 'storeFaqFeedback'])
+        ->whereNumber('faq')
+        ->name('support.faqs.feedback.store');
 });
 
 //AUTH REQUIRED PAGES


### PR DESCRIPTION
## Summary
- add a faq_feedback table, model, and form request to track per-user FAQ votes
- expose helpful and not-helpful counts plus a feedback endpoint from the support center
- render voting controls on FAQ cards and surface aggregate metrics inside the ACP support analytics

## Testing
- php artisan test *(fails: missing vendor directory in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a06c8b20832ca028643e913fc394