### PR TITLE
Fix mention suggestions response structure

### DIFF
--- a/app/Http/Controllers/ForumController.php
+++ b/app/Http/Controllers/ForumController.php
@@ -161,7 +161,11 @@ class ForumController extends Controller
             })
             ->values();
 
-        return MentionSuggestionResource::collection($users);
+        $suggestions = $users
+            ->map(fn (User $mentioned) => (new MentionSuggestionResource($mentioned))->toArray($request))
+            ->values();
+
+        return response()->json(['data' => $suggestions]);
     }
 
     public function showBoard(Request $request, ForumBoard $board): Response


### PR DESCRIPTION
## Summary
- ensure the forum mention suggestion endpoint returns an array of suggestion objects
- reuse the MentionSuggestionResource to build each suggestion payload

## Testing
- not run (composer install failed: GitHub 403 while cloning doctrine/lexer)


------
https://chatgpt.com/codex/tasks/task_e_68e0addd8974832ca73f61acaf3005df