### PR TITLE
Fix mention suggestion endpoint return type

### DIFF
--- a/app/Http/Controllers/ForumController.php
+++ b/app/Http/Controllers/ForumController.php
@@ -161,11 +161,7 @@ class ForumController extends Controller
             })
             ->values();
 
-        $suggestions = $users
-            ->map(fn (User $mentioned) => (new MentionSuggestionResource($mentioned))->toArray($request))
-            ->values();
-
-        return response()->json(['data' => $suggestions]);
+        return MentionSuggestionResource::collection($users);
     }
 
     public function showBoard(Request $request, ForumBoard $board): Response


### PR DESCRIPTION
## Summary
- ensure the forum mention suggestions endpoint returns a resource collection so it matches the method signature

## Testing
- not run (composer install blocked by network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68e0b04cdc74832c8d61bc9b2831926b