### PR TITLE
Ensure mention suggestions response preserves numeric keys

### DIFF
--- a/app/Http/Controllers/ForumController.php
+++ b/app/Http/Controllers/ForumController.php
@@ -167,6 +167,7 @@ class ForumController extends Controller
             ->map(function (User $mentioned) use ($request) {
                 return (new MentionSuggestionResource($mentioned))->toArray($request);
             })
+            ->values()
             ->all();
 
         return response()->json([


### PR DESCRIPTION
## Summary
- reindex the mention suggestion payload before returning JSON so the frontend and tests receive a sequential array structure

## Testing
- ./vendor/bin/phpunit --filter PostMentionTest *(fails: vendor dependencies not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b39fd730832ca982d68e5e26ac03