### PR TITLE
Add admin navigation to forum post history from thread view

### DIFF
--- a/resources/js/pages/ForumThreadView.vue
+++ b/resources/js/pages/ForumThreadView.vue
@@ -48,6 +48,7 @@ import {
     Bell,
     BellOff,
     Quote,
+    RotateCcw,
 } from 'lucide-vue-next';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { useInertiaPagination, type PaginationMeta } from '@/composables/useInertiaPagination';
@@ -872,6 +873,24 @@ const deletePost = (post: ThreadPost) => {
     deletePostDialogOpen.value = true;
 };
 
+const viewPostHistory = (post: ThreadPost) => {
+    if (!post.permissions.canModerate) {
+        return;
+    }
+
+    router.get(
+        route('forum.posts.history', {
+            board: props.board.slug,
+            thread: props.thread.slug,
+            post: post.id,
+        }),
+        {},
+        {
+            preserveState: false,
+        },
+    );
+};
+
 const confirmDeletePost = () => {
     const target = pendingDeletePost.value;
 
@@ -1619,6 +1638,23 @@ const submitReply = () => {
                                         >
                                             <Trash2 class="h-4 w-4" />
                                             <span>Delete</span>
+                                        </DropdownMenuItem>
+                                        <DropdownMenuSeparator
+                                            v-if="
+                                                post.permissions.canModerate &&
+                                                (threadPermissions.canReply ||
+                                                    post.permissions.canReport ||
+                                                    post.permissions.canEdit ||
+                                                    post.permissions.canDelete)
+                                            "
+                                        />
+                                        <DropdownMenuItem
+                                            v-if="post.permissions.canModerate"
+                                            class="text-purple-500"
+                                            @select="viewPostHistory(post)"
+                                        >
+                                            <RotateCcw class="h-4 w-4" />
+                                            <span>View Post History</span>
                                         </DropdownMenuItem>
                                     </DropdownMenuContent>
                                 </DropdownMenu>


### PR DESCRIPTION
## Summary
- add a new admin-only action in the forum thread post menu to open the ACP post history page
- wire the action to the forum post history route and include the needed icon import

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0c052c074832ca8af03c8363d3232