### PR TITLE
Add blog revision history with restore controls

### DIFF
--- a/app/Models/Blog.php
+++ b/app/Models/Blog.php
@@ -75,4 +75,9 @@ class Blog extends Model
         return $this->belongsToMany(BlogTag::class, 'blog_blog_tag')
             ->withTimestamps();
     }
+
+    public function revisions(): HasMany
+    {
+        return $this->hasMany(BlogRevision::class);
+    }
 }

--- a/app/Models/BlogRevision.php
+++ b/app/Models/BlogRevision.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Arr;
+
+class BlogRevision extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'blog_id',
+        'edited_by_id',
+        'title',
+        'slug',
+        'excerpt',
+        'body',
+        'cover_image',
+        'status',
+        'published_at',
+        'scheduled_for',
+        'category_ids',
+        'tag_ids',
+        'metadata',
+        'edited_at',
+    ];
+
+    protected $casts = [
+        'published_at' => 'datetime',
+        'scheduled_for' => 'datetime',
+        'edited_at' => 'datetime',
+        'category_ids' => 'array',
+        'tag_ids' => 'array',
+        'metadata' => 'array',
+    ];
+
+    public function blog(): BelongsTo
+    {
+        return $this->belongsTo(Blog::class);
+    }
+
+    public function editor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'edited_by_id');
+    }
+
+    public static function recordSnapshot(Blog $blog, ?User $editor = null): self
+    {
+        $blog->loadMissing(['categories:id', 'tags:id']);
+
+        $metadata = [
+            'author_id' => $blog->user_id,
+            'preview_token' => $blog->preview_token,
+            'views' => $blog->views,
+            'last_viewed_at' => optional($blog->last_viewed_at)?->toIso8601String(),
+        ];
+
+        $metadata = Arr::where($metadata, fn ($value) => $value !== null);
+
+        return static::create([
+            'blog_id' => $blog->id,
+            'edited_by_id' => $editor?->getKey(),
+            'title' => $blog->title,
+            'slug' => $blog->slug,
+            'excerpt' => $blog->excerpt,
+            'body' => $blog->body,
+            'cover_image' => $blog->cover_image,
+            'status' => $blog->status,
+            'published_at' => $blog->published_at,
+            'scheduled_for' => $blog->scheduled_for,
+            'category_ids' => $blog->categories->pluck('id')->values()->all(),
+            'tag_ids' => $blog->tags->pluck('id')->values()->all(),
+            'metadata' => $metadata === [] ? null : $metadata,
+            'edited_at' => $blog->updated_at,
+        ]);
+    }
+}

--- a/app/Policies/BlogPolicy.php
+++ b/app/Policies/BlogPolicy.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Blog;
+use App\Models\User;
+
+class BlogPolicy
+{
+    public function viewRevisions(User $user, Blog $blog): bool
+    {
+        if ($user->id === $blog->user_id) {
+            return true;
+        }
+
+        return $user->hasAnyRole(['admin', 'moderator']);
+    }
+
+    public function restoreRevision(User $user, Blog $blog): bool
+    {
+        if ($user->id === $blog->user_id) {
+            return true;
+        }
+
+        return $user->hasAnyRole(['admin', 'moderator']);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace App\Providers;
 
+use App\Models\Blog;
 use App\Models\ForumPost;
 use App\Models\PersonalAccessToken;
+use App\Policies\BlogPolicy;
 use App\Policies\ForumPostPolicy;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
@@ -34,6 +36,7 @@ class AppServiceProvider extends ServiceProvider
         }
 
         Gate::policy(ForumPost::class, ForumPostPolicy::class);
+        Gate::policy(Blog::class, BlogPolicy::class);
 
         Sanctum::usePersonalAccessTokenModel(PersonalAccessToken::class);
     }

--- a/database/migrations/2025_05_30_000000_create_blog_revisions_table.php
+++ b/database/migrations/2025_05_30_000000_create_blog_revisions_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('blog_revisions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('blog_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('edited_by_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('title');
+            $table->string('slug');
+            $table->text('excerpt')->nullable();
+            $table->longText('body');
+            $table->string('cover_image')->nullable();
+            $table->enum('status', ['draft', 'published', 'scheduled', 'archived']);
+            $table->timestamp('published_at')->nullable();
+            $table->timestamp('scheduled_for')->nullable();
+            $table->json('category_ids')->nullable();
+            $table->json('tag_ids')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamp('edited_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('blog_revisions');
+    }
+};

--- a/resources/js/pages/acp/BlogEdit.vue
+++ b/resources/js/pages/acp/BlogEdit.vue
@@ -38,6 +38,11 @@ type BlogAuthor = {
     social_links?: AuthorSocialLink[];
 };
 
+type BlogPermissions = {
+    canViewRevisions: boolean;
+    canRestoreRevisions: boolean;
+};
+
 type BlogPayload = {
     id: number;
     title: string;
@@ -77,6 +82,7 @@ const props = defineProps<{
     blog: BlogPayload;
     categories: BlogTaxonomyOption[];
     tags: BlogTaxonomyOption[];
+    permissions: BlogPermissions;
 }>();
 
 const breadcrumbs: BreadcrumbItem[] = [
@@ -315,6 +321,8 @@ const existingCoverImage = computed(() => coverImagePreview.value ?? props.blog.
 const previewOpen = ref(false);
 const previewCopied = ref(false);
 
+const canViewRevisions = computed(() => props.permissions?.canViewRevisions ?? false);
+
 const formatForInput = (date: Date) => {
     const pad = (value: number) => value.toString().padStart(2, '0');
     const year = date.getFullYear();
@@ -486,6 +494,11 @@ const handleSubmit = () => {
                     <div class="flex flex-wrap gap-2">
                         <Button variant="outline" as-child>
                             <Link :href="route('acp.blogs.index')">Back to blogs</Link>
+                        </Button>
+                        <Button v-if="canViewRevisions" variant="outline" as-child>
+                            <Link :href="route('acp.blogs.revisions.index', { blog: props.blog.id })">
+                                Revision history
+                            </Link>
                         </Button>
                         <Button
                             type="button"

--- a/resources/js/pages/acp/BlogRevisionHistory.vue
+++ b/resources/js/pages/acp/BlogRevisionHistory.vue
@@ -1,0 +1,458 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+import Button from '@/components/ui/button/Button.vue';
+import { type BreadcrumbItem } from '@/types';
+import { ArrowLeft, RotateCcw } from 'lucide-vue-next';
+import { useUserTimezone } from '@/composables/useUserTimezone';
+import ConfirmDialog from '@/components/ConfirmDialog.vue';
+import { useConfirmDialog } from '@/composables/useConfirmDialog';
+
+interface BlogCategorySummary {
+    id: number;
+    name: string;
+    slug: string;
+}
+
+interface BlogTagSummary {
+    id: number;
+    name: string;
+    slug: string;
+}
+
+interface BlogAuthorSummary {
+    id: number;
+    nickname: string;
+}
+
+interface BlogMetadataSummary {
+    views?: number | null;
+    last_viewed_at?: string | null;
+    preview_token?: string | null;
+    author_id?: number | null;
+}
+
+interface BlogSummary {
+    id: number;
+    title: string;
+    slug: string;
+    excerpt: string | null;
+    body: string;
+    status: string;
+    cover_image: string | null;
+    cover_image_url: string | null;
+    created_at: string | null;
+    updated_at: string | null;
+    published_at: string | null;
+    scheduled_for: string | null;
+    metadata: BlogMetadataSummary | null;
+    author: BlogAuthorSummary | null;
+    categories: BlogCategorySummary[];
+    tags: BlogTagSummary[];
+}
+
+interface RevisionSummary {
+    id: number;
+    title: string;
+    slug: string;
+    excerpt: string | null;
+    body: string;
+    cover_image: string | null;
+    cover_image_url: string | null;
+    status: string;
+    published_at: string | null;
+    scheduled_for: string | null;
+    edited_at: string | null;
+    created_at: string | null;
+    category_ids: number[];
+    tag_ids: number[];
+    categories: BlogCategorySummary[];
+    tags: BlogTagSummary[];
+    metadata: BlogMetadataSummary | null;
+    editor: BlogAuthorSummary | null;
+}
+
+interface RevisionPermissions {
+    canRestore: boolean;
+}
+
+const props = defineProps<{
+    blog: BlogSummary;
+    revisions: RevisionSummary[];
+    permissions: RevisionPermissions;
+}>();
+
+const { formatDate, fromNow } = useUserTimezone();
+
+const breadcrumbs = computed<BreadcrumbItem[]>(() => [
+    { title: 'Blogs ACP', href: route('acp.blogs.index') },
+    { title: props.blog.title, href: route('acp.blogs.edit', { blog: props.blog.id }) },
+    { title: 'Revision history', href: '#' },
+]);
+
+const canRestore = computed(() => props.permissions?.canRestore ?? false);
+const blog = computed(() => props.blog);
+const revisions = computed(() => props.revisions);
+const backUrl = computed(() => route('acp.blogs.edit', { blog: props.blog.id }));
+
+const formatExact = (value: string | null | undefined) => {
+    if (!value) {
+        return null;
+    }
+
+    return formatDate(value, 'MMM D, YYYY h:mm A');
+};
+
+const formatRelative = (value: string | null | undefined) => {
+    if (!value) {
+        return null;
+    }
+
+    return fromNow(value);
+};
+
+const metadataEntries = (metadata: BlogMetadataSummary | null | undefined) => {
+    if (!metadata || typeof metadata !== 'object') {
+        return [] as Array<{ label: string; value: string }>;
+    }
+
+    const entries: Array<{ label: string; value: string }> = [];
+
+    if (typeof metadata.views === 'number') {
+        entries.push({ label: 'Views at save', value: metadata.views.toLocaleString() });
+    }
+
+    if (typeof metadata.last_viewed_at === 'string' && metadata.last_viewed_at) {
+        const exact = formatExact(metadata.last_viewed_at) ?? metadata.last_viewed_at;
+        const relative = formatRelative(metadata.last_viewed_at);
+        entries.push({
+            label: 'Last viewed',
+            value: relative ? `${exact} (${relative})` : exact,
+        });
+    }
+
+    if (typeof metadata.preview_token === 'string' && metadata.preview_token) {
+        entries.push({
+            label: 'Preview token',
+            value: metadata.preview_token,
+        });
+    }
+
+    if (typeof metadata.author_id === 'number') {
+        entries.push({
+            label: 'Author ID',
+            value: metadata.author_id.toString(),
+        });
+    }
+
+    return entries;
+};
+
+const restoreRevision = (revisionId: number) => {
+    if (!canRestore.value) {
+        return;
+    }
+
+    router.put(
+        route('acp.blogs.revisions.restore', {
+            blog: props.blog.id,
+            revision: revisionId,
+        }),
+        {},
+        {
+            preserveScroll: true,
+        },
+    );
+};
+
+const {
+    confirmDialogState,
+    confirmDialogDescription,
+    openConfirmDialog,
+    handleConfirmDialogConfirm,
+    handleConfirmDialogCancel,
+} = useConfirmDialog();
+
+const requestRestore = (revisionId: number) => {
+    if (!canRestore.value) {
+        return;
+    }
+
+    openConfirmDialog({
+        title: 'Restore this revision?',
+        description: 'The current content will be stored as a new revision before restoring.',
+        confirmLabel: 'Restore revision',
+        confirmVariant: 'default',
+        onConfirm: () => restoreRevision(revisionId),
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Blog Revision History" />
+
+        <AdminLayout>
+            <div class="container mx-auto space-y-8 p-4">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div class="flex items-center gap-3">
+                        <Link :href="backUrl">
+                            <Button variant="outline" size="icon">
+                                <ArrowLeft class="h-5 w-5" />
+                            </Button>
+                        </Link>
+                        <div>
+                            <h1 class="text-3xl font-bold">Blog revision history</h1>
+                            <p class="text-sm text-muted-foreground">
+                                {{ blog.value.title }} · Status: {{ blog.value.status }}
+                            </p>
+                        </div>
+                    </div>
+                    <div class="text-sm text-muted-foreground md:text-right space-y-1">
+                        <p v-if="blog.value.author">Author: {{ blog.value.author.nickname }}</p>
+                        <p v-if="formatExact(blog.value.created_at)">
+                            Created {{ formatExact(blog.value.created_at) }}
+                        </p>
+                        <p v-if="formatExact(blog.value.updated_at)">
+                            Updated {{ formatExact(blog.value.updated_at) }}
+                            <span v-if="formatRelative(blog.value.updated_at)">
+                                ({{ formatRelative(blog.value.updated_at) }})
+                            </span>
+                        </p>
+                        <p v-if="formatExact(blog.value.published_at)">
+                            Published {{ formatExact(blog.value.published_at) }}
+                        </p>
+                        <p v-if="formatExact(blog.value.scheduled_for)">
+                            Scheduled for {{ formatExact(blog.value.scheduled_for) }}
+                        </p>
+                    </div>
+                </div>
+
+                <div class="grid gap-6 lg:grid-cols-[minmax(0,_1fr)_320px]">
+                    <div class="space-y-6">
+                        <div class="rounded-xl border p-6 shadow-sm">
+                            <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                                <div>
+                                    <h2 class="text-xl font-semibold">Current version</h2>
+                                    <p class="text-sm text-muted-foreground">
+                                        Last updated {{ formatExact(blog.value.updated_at ?? blog.value.created_at) ?? 'Unknown' }}
+                                        <span v-if="formatRelative(blog.value.updated_at ?? blog.value.created_at)">
+                                            ({{ formatRelative(blog.value.updated_at ?? blog.value.created_at) }})
+                                        </span>
+                                    </p>
+                                </div>
+                                <div class="text-sm text-muted-foreground md:text-right">
+                                    <p v-if="!canRestore">You do not have permission to restore revisions.</p>
+                                    <p v-else>Restoring a revision will archive this version automatically.</p>
+                                </div>
+                            </div>
+
+                            <div class="mt-4 space-y-4">
+                                <div class="rounded-lg border bg-muted/30 p-4">
+                                    <h3 class="font-semibold">Metadata</h3>
+                                    <ul class="mt-2 space-y-1 text-sm">
+                                        <li v-if="!metadataEntries(blog.value.metadata).length" class="text-muted-foreground">
+                                            No metadata captured for this version.
+                                        </li>
+                                        <li v-for="entry in metadataEntries(blog.value.metadata)" :key="entry.label">
+                                            <span class="font-medium">{{ entry.label }}:</span>
+                                            <span>{{ entry.value }}</span>
+                                        </li>
+                                    </ul>
+                                </div>
+
+                                <div v-if="blog.value.categories.length" class="rounded-lg border bg-muted/30 p-4">
+                                    <h3 class="font-semibold">Categories</h3>
+                                    <ul class="mt-2 flex flex-wrap gap-2 text-sm">
+                                        <li
+                                            v-for="category in blog.value.categories"
+                                            :key="category.id"
+                                            class="rounded-full bg-background px-3 py-1 shadow"
+                                        >
+                                            {{ category.name }}
+                                        </li>
+                                    </ul>
+                                </div>
+
+                                <div v-if="blog.value.tags.length" class="rounded-lg border bg-muted/30 p-4">
+                                    <h3 class="font-semibold">Tags</h3>
+                                    <ul class="mt-2 flex flex-wrap gap-2 text-sm">
+                                        <li
+                                            v-for="tag in blog.value.tags"
+                                            :key="tag.id"
+                                            class="rounded-full bg-background px-3 py-1 shadow"
+                                        >
+                                            {{ tag.name }}
+                                        </li>
+                                    </ul>
+                                </div>
+
+                                <div class="rounded-lg border bg-background p-4 shadow-sm">
+                                    <h3 class="font-semibold">Excerpt</h3>
+                                    <p class="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
+                                        {{ blog.value.excerpt ?? '—' }}
+                                    </p>
+                                </div>
+
+                                <div class="rounded-lg border bg-background p-4 shadow-sm">
+                                    <h3 class="font-semibold">Body</h3>
+                                    <div class="prose prose-sm mt-4 max-w-none" v-html="blog.value.body" />
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="rounded-xl border p-6 shadow-sm">
+                            <div class="flex items-center justify-between gap-4">
+                                <h2 class="text-xl font-semibold">Revision history</h2>
+                                <span class="text-sm text-muted-foreground">
+                                    {{ revisions.value.length }}
+                                    {{ revisions.value.length === 1 ? 'revision stored' : 'revisions stored' }}
+                                </span>
+                            </div>
+
+                            <div
+                                v-if="revisions.value.length === 0"
+                                class="mt-6 rounded-lg border border-dashed p-6 text-center text-muted-foreground"
+                            >
+                                No revisions recorded yet. Updates to this blog will appear here automatically.
+                            </div>
+
+                            <div v-else class="mt-6 space-y-4">
+                                <div
+                                    v-for="revision in revisions"
+                                    :key="revision.id"
+                                    class="rounded-lg border p-4 shadow-sm"
+                                >
+                                    <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                                        <div>
+                                            <p class="font-semibold">Saved {{ formatExact(revision.created_at) ?? 'Unknown time' }}</p>
+                                            <p class="text-sm text-muted-foreground">
+                                                <span v-if="revision.editor">by {{ revision.editor.nickname }}</span>
+                                                <span v-else>by Unknown user</span>
+                                                <span v-if="revision.edited_at">
+                                                    · Original edit timestamp {{ formatExact(revision.edited_at) ?? 'Unknown' }}
+                                                </span>
+                                            </p>
+                                            <p v-if="formatRelative(revision.created_at)" class="text-xs text-muted-foreground">
+                                                {{ formatRelative(revision.created_at) }}
+                                            </p>
+                                        </div>
+                                        <Button
+                                            v-if="canRestore"
+                                            variant="outline"
+                                            size="sm"
+                                            class="shrink-0"
+                                            @click="requestRestore(revision.id)"
+                                        >
+                                            <RotateCcw class="mr-2 h-4 w-4" />
+                                            Restore this version
+                                        </Button>
+                                    </div>
+
+                                    <div class="mt-4 grid gap-4 lg:grid-cols-2">
+                                        <div class="space-y-3">
+                                            <div class="rounded-lg border bg-muted/30 p-3 text-sm">
+                                                <p><span class="font-medium">Status:</span> {{ revision.status }}</p>
+                                                <p v-if="formatExact(revision.published_at)">
+                                                    <span class="font-medium">Published:</span>
+                                                    {{ formatExact(revision.published_at) }}
+                                                    <span v-if="formatRelative(revision.published_at)">
+                                                        ({{ formatRelative(revision.published_at) }})
+                                                    </span>
+                                                </p>
+                                                <p v-if="formatExact(revision.scheduled_for)">
+                                                    <span class="font-medium">Scheduled:</span>
+                                                    {{ formatExact(revision.scheduled_for) }}
+                                                    <span v-if="formatRelative(revision.scheduled_for)">
+                                                        ({{ formatRelative(revision.scheduled_for) }})
+                                                    </span>
+                                                </p>
+                                            </div>
+
+                                            <div class="rounded-lg border bg-muted/30 p-3 text-sm">
+                                                <h4 class="font-semibold">Metadata</h4>
+                                                <ul class="mt-2 space-y-1">
+                                                    <li v-if="!metadataEntries(revision.metadata).length" class="text-muted-foreground">
+                                                        No metadata recorded for this revision.
+                                                    </li>
+                                                    <li v-for="entry in metadataEntries(revision.metadata)" :key="entry.label">
+                                                        <span class="font-medium">{{ entry.label }}:</span>
+                                                        <span>{{ entry.value }}</span>
+                                                    </li>
+                                                </ul>
+                                            </div>
+
+                                            <div v-if="revision.categories.length" class="rounded-lg border bg-muted/30 p-3 text-sm">
+                                                <h4 class="font-semibold">Categories</h4>
+                                                <ul class="mt-2 flex flex-wrap gap-2">
+                                                    <li
+                                                        v-for="category in revision.categories"
+                                                        :key="category.id"
+                                                        class="rounded-full bg-background px-3 py-1 shadow"
+                                                    >
+                                                        {{ category.name }}
+                                                    </li>
+                                                </ul>
+                                            </div>
+
+                                            <div v-if="revision.tags.length" class="rounded-lg border bg-muted/30 p-3 text-sm">
+                                                <h4 class="font-semibold">Tags</h4>
+                                                <ul class="mt-2 flex flex-wrap gap-2">
+                                                    <li
+                                                        v-for="tag in revision.tags"
+                                                        :key="tag.id"
+                                                        class="rounded-full bg-background px-3 py-1 shadow"
+                                                    >
+                                                        {{ tag.name }}
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                        <div class="space-y-3">
+                                            <div class="rounded-lg border bg-background p-3 shadow-sm">
+                                                <h4 class="font-semibold">Excerpt</h4>
+                                                <p class="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
+                                                    {{ revision.excerpt ?? '—' }}
+                                                </p>
+                                            </div>
+                                            <div class="rounded-lg border bg-background p-3 shadow-sm">
+                                                <h4 class="font-semibold">Body</h4>
+                                                <div class="prose prose-sm mt-3 max-w-none" v-html="revision.body" />
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <aside class="space-y-4">
+                        <div v-if="blog.value.cover_image_url" class="overflow-hidden rounded-lg border shadow-sm">
+                            <img :src="blog.value.cover_image_url" alt="Blog cover" class="h-full w-full object-cover" />
+                        </div>
+                        <div class="rounded-lg border bg-muted/40 p-4 text-sm text-muted-foreground">
+                            <p>
+                                Need to investigate an older version? Use the restore button on any revision. We'll keep a
+                                copy of the current content so you can undo the change if needed.
+                            </p>
+                        </div>
+                    </aside>
+                </div>
+            </div>
+        </AdminLayout>
+
+        <ConfirmDialog
+            v-model:open="confirmDialogState.open"
+            :title="confirmDialogState.title"
+            :description="confirmDialogDescription"
+            :confirm-label="confirmDialogState.confirmLabel"
+            :cancel-label="confirmDialogState.cancelLabel"
+            :confirm-variant="confirmDialogState.confirmVariant"
+            :confirm-disabled="confirmDialogState.confirmDisabled"
+            @confirm="handleConfirmDialogConfirm"
+            @cancel="handleConfirmDialogCancel"
+        />
+    </AppLayout>
+</template>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -48,6 +48,8 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
     Route::post('acp/blogs', [AdminBlogController::class, 'store'])->name('acp.blogs.store');
     Route::get('acp/blogs/{blog}/edit', [AdminBlogController::class, 'edit'])->name('acp.blogs.edit');
     Route::put('acp/blogs/{blog}', [AdminBlogController::class, 'update'])->name('acp.blogs.update');
+    Route::get('acp/blogs/{blog}/revisions', [AdminBlogController::class, 'revisions'])->name('acp.blogs.revisions.index');
+    Route::put('acp/blogs/{blog}/revisions/{revision}', [AdminBlogController::class, 'restoreRevision'])->name('acp.blogs.revisions.restore');
     Route::delete('acp/blogs/{blog}', [AdminBlogController::class, 'destroy'])->name('acp.blogs.destroy');
     Route::put('acp/blogs/{blog}/publish', [AdminBlogController::class, 'publish'])->name('acp.blogs.publish');
     Route::put('acp/blogs/{blog}/unpublish', [AdminBlogController::class, 'unpublish'])->name('acp.blogs.unpublish');

--- a/tests/Feature/Admin/BlogRevisionHistoryTest.php
+++ b/tests/Feature/Admin/BlogRevisionHistoryTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Blog;
+use App\Models\BlogCategory;
+use App\Models\BlogRevision;
+use App\Models\BlogTag;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class BlogRevisionHistoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Role::firstOrCreate(['name' => 'admin']);
+        Role::firstOrCreate(['name' => 'moderator']);
+        Role::firstOrCreate(['name' => 'editor']);
+    }
+
+    private function actingAsAdmin(): User
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('admin');
+
+        $this->actingAs($admin);
+
+        return $admin;
+    }
+
+    private function actingAsModerator(): User
+    {
+        $moderator = User::factory()->create();
+        $moderator->assignRole('moderator');
+
+        $this->actingAs($moderator);
+
+        return $moderator;
+    }
+
+    private function actingAsEditor(): User
+    {
+        $editor = User::factory()->create();
+        $editor->assignRole('editor');
+
+        $this->actingAs($editor);
+
+        return $editor;
+    }
+
+    public function test_revision_snapshot_recorded_on_update(): void
+    {
+        $admin = $this->actingAsAdmin();
+
+        $blog = Blog::factory()->create([
+            'title' => 'Original Title',
+            'slug' => 'original-title',
+            'body' => '<p>Original body</p>',
+            'status' => 'draft',
+        ]);
+
+        $initialCategory = BlogCategory::factory()->create();
+        $initialTag = BlogTag::factory()->create();
+        $blog->categories()->sync([$initialCategory->id]);
+        $blog->tags()->sync([$initialTag->id]);
+
+        $newCategory = BlogCategory::factory()->create();
+        $newTag = BlogTag::factory()->create();
+
+        $response = $this->put(route('acp.blogs.update', $blog), [
+            'title' => 'Updated Title',
+            'excerpt' => 'Updated excerpt',
+            'body' => '<p>Updated body</p>',
+            'status' => 'draft',
+            'category_ids' => [$newCategory->id],
+            'tag_ids' => [$newTag->id],
+            'scheduled_for' => '',
+        ]);
+
+        $response->assertRedirect(route('acp.blogs.index'));
+
+        $revision = BlogRevision::query()->latest()->first();
+
+        $this->assertNotNull($revision, 'Expected a revision to be recorded after update.');
+        $this->assertSame($blog->id, $revision->blog_id);
+        $this->assertSame('Updated Title', $revision->title);
+        $this->assertSame(Str::slug('Updated Title'), $revision->slug);
+        $this->assertSame('<p>Updated body</p>', $revision->body);
+        $this->assertSame('Updated excerpt', $revision->excerpt);
+        $this->assertSame([$newCategory->id], $revision->category_ids);
+        $this->assertSame([$newTag->id], $revision->tag_ids);
+        $this->assertSame($admin->id, $revision->edited_by_id);
+    }
+
+    public function test_moderator_can_view_revision_history(): void
+    {
+        $moderator = $this->actingAsModerator();
+
+        $blog = Blog::factory()->create();
+        $blog->categories()->sync(BlogCategory::factory()->count(2)->create()->pluck('id'));
+        $blog->tags()->sync(BlogTag::factory()->count(2)->create()->pluck('id'));
+
+        BlogRevision::recordSnapshot($blog->fresh(['categories:id', 'tags:id']), $moderator);
+
+        $response = $this->get(route('acp.blogs.revisions.index', $blog));
+
+        $response->assertOk();
+        $response->assertInertia(fn ($page) => $page
+            ->component('acp/BlogRevisionHistory')
+            ->where('blog.id', $blog->id)
+            ->where('permissions.canRestore', true)
+        );
+    }
+
+    public function test_author_can_view_revision_history(): void
+    {
+        $author = User::factory()->create();
+        $blog = Blog::factory()->for($author)->create();
+
+        $this->actingAs($author);
+
+        BlogRevision::recordSnapshot($blog->fresh(['categories:id', 'tags:id']), $author);
+
+        $response = $this->get(route('acp.blogs.revisions.index', $blog));
+
+        $response->assertOk();
+        $response->assertInertia(fn ($page) => $page
+            ->component('acp/BlogRevisionHistory')
+            ->where('blog.id', $blog->id)
+            ->where('permissions.canRestore', true)
+        );
+    }
+
+    public function test_editor_cannot_view_revision_history_for_others(): void
+    {
+        $editor = $this->actingAsEditor();
+
+        $blog = Blog::factory()->create();
+
+        BlogRevision::recordSnapshot($blog->fresh(['categories:id', 'tags:id']), $editor);
+
+        $this->get(route('acp.blogs.revisions.index', $blog))->assertForbidden();
+    }
+
+    public function test_author_can_restore_revision(): void
+    {
+        $author = User::factory()->create();
+        $blog = Blog::factory()->for($author)->create([
+            'title' => 'Original Title',
+            'slug' => 'original-title',
+            'body' => '<p>Original body</p>',
+            'excerpt' => 'Original excerpt',
+            'status' => 'draft',
+        ]);
+
+        $originalCategory = BlogCategory::factory()->create();
+        $originalTag = BlogTag::factory()->create();
+        $blog->categories()->sync([$originalCategory->id]);
+        $blog->tags()->sync([$originalTag->id]);
+
+        $this->actingAs($author);
+
+        $originalSnapshot = BlogRevision::recordSnapshot($blog->fresh(['categories:id', 'tags:id']), $author);
+
+        $newCategory = BlogCategory::factory()->create();
+        $newTag = BlogTag::factory()->create();
+
+        $blog->forceFill([
+            'title' => 'New Title',
+            'slug' => 'new-title',
+            'body' => '<p>New body</p>',
+            'excerpt' => 'New excerpt',
+            'status' => 'published',
+        ])->save();
+        $blog->categories()->sync([$newCategory->id]);
+        $blog->tags()->sync([$newTag->id]);
+
+        $response = $this->put(route('acp.blogs.revisions.restore', [$blog, $originalSnapshot]));
+
+        $response->assertRedirect(route('acp.blogs.revisions.index', $blog));
+
+        $blog->refresh();
+
+        $this->assertSame('Original Title', $blog->title);
+        $this->assertSame('original-title', $blog->slug);
+        $this->assertSame('<p>Original body</p>', $blog->body);
+        $this->assertSame('Original excerpt', $blog->excerpt);
+        $this->assertSame('draft', $blog->status);
+        $this->assertEqualsCanonicalizing([$originalCategory->id], $blog->categories()->pluck('id')->all());
+        $this->assertEqualsCanonicalizing([$originalTag->id], $blog->tags()->pluck('id')->all());
+
+        $this->assertSame(3, BlogRevision::query()->count());
+        $this->assertSame('Original Title', BlogRevision::query()->latest()->first()->title);
+    }
+}


### PR DESCRIPTION
## Summary
- add a `blog_revisions` table/model to capture blog snapshots with metadata when posts change
- expose revision history and restore actions in the ACP with Inertia views and controller routes guarded by policy checks
- cover moderator/author access rules with a blog policy and feature tests for viewing and restoring revisions

## Testing
- `php artisan test --filter=BlogRevisionHistoryTest` *(fails: vendor dependencies unavailable in container and composer install requires a GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c5ec25d4832ca87f222e71363223