### PR TITLE
Add cascading cleanup for support ticket attachments

### DIFF
--- a/app/Models/SupportTicket.php
+++ b/app/Models/SupportTicket.php
@@ -49,4 +49,13 @@ class SupportTicket extends Model
     {
         return $this->belongsTo(SupportTicketCategory::class, 'support_ticket_category_id');
     }
+
+    protected static function booted(): void
+    {
+        static::deleting(function (self $ticket): void {
+            foreach ($ticket->messages()->cursor() as $message) {
+                $message->delete();
+            }
+        });
+    }
 }

--- a/app/Models/SupportTicketMessage.php
+++ b/app/Models/SupportTicketMessage.php
@@ -28,4 +28,13 @@ class SupportTicketMessage extends Model
     {
         return $this->hasMany(SupportTicketMessageAttachment::class);
     }
+
+    protected static function booted(): void
+    {
+        static::deleting(function (self $message): void {
+            foreach ($message->attachments()->cursor() as $attachment) {
+                $attachment->delete();
+            }
+        });
+    }
 }

--- a/app/Models/SupportTicketMessageAttachment.php
+++ b/app/Models/SupportTicketMessageAttachment.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Storage;
 
 class SupportTicketMessageAttachment extends Model
 {
@@ -19,6 +20,17 @@ class SupportTicketMessageAttachment extends Model
     protected $casts = [
         'size' => 'integer',
     ];
+
+    protected static function booted(): void
+    {
+        static::deleting(function (self $attachment): void {
+            if (! $attachment->disk || ! $attachment->path) {
+                return;
+            }
+
+            Storage::disk($attachment->disk)->delete($attachment->path);
+        });
+    }
 
     public function message(): BelongsTo
     {

--- a/tests/Feature/Support/SupportTicketAttachmentCleanupTest.php
+++ b/tests/Feature/Support/SupportTicketAttachmentCleanupTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature\Support;
+
+use App\Models\SupportTicket;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class SupportTicketAttachmentCleanupTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_deleting_message_removes_attachment_from_storage_and_database(): void
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create();
+
+        $ticket = SupportTicket::create([
+            'user_id' => $user->id,
+            'subject' => 'Login issue',
+            'body' => 'Cannot log in to my account.',
+            'status' => 'open',
+            'priority' => 'medium',
+        ]);
+
+        $message = $ticket->messages()->create([
+            'user_id' => $user->id,
+            'body' => 'Here are additional details.',
+        ]);
+
+        $path = "support-attachments/{$ticket->id}/details.txt";
+        Storage::disk('public')->put($path, 'stack trace contents');
+
+        $attachment = $message->attachments()->create([
+            'disk' => 'public',
+            'path' => $path,
+            'name' => 'details.txt',
+            'mime_type' => 'text/plain',
+            'size' => 128,
+        ]);
+
+        Storage::disk('public')->assertExists($path);
+
+        $message->delete();
+
+        Storage::disk('public')->assertMissing($path);
+
+        $this->assertDatabaseMissing('support_ticket_message_attachments', [
+            'id' => $attachment->id,
+        ]);
+    }
+
+    public function test_deleting_ticket_removes_nested_attachments_from_storage_and_database(): void
+    {
+        Storage::fake('public');
+
+        $requester = User::factory()->create();
+        $agent = User::factory()->create();
+
+        $ticket = SupportTicket::create([
+            'user_id' => $requester->id,
+            'subject' => 'API outage',
+            'body' => 'Our API endpoint is down.',
+            'status' => 'pending',
+            'priority' => 'high',
+        ]);
+
+        $customerMessage = $ticket->messages()->create([
+            'user_id' => $requester->id,
+            'body' => 'Received error 500 responses.',
+        ]);
+
+        $agentMessage = $ticket->messages()->create([
+            'user_id' => $agent->id,
+            'body' => 'We are investigating.',
+        ]);
+
+        $customerAttachmentPath = "support-attachments/{$ticket->id}/error.log";
+        $agentAttachmentPath = "support-attachments/{$ticket->id}/resolution.pdf";
+
+        Storage::disk('public')->put($customerAttachmentPath, 'error output');
+        Storage::disk('public')->put($agentAttachmentPath, 'resolution steps');
+
+        $customerAttachment = $customerMessage->attachments()->create([
+            'disk' => 'public',
+            'path' => $customerAttachmentPath,
+            'name' => 'error.log',
+            'mime_type' => 'text/plain',
+            'size' => 64,
+        ]);
+
+        $agentAttachment = $agentMessage->attachments()->create([
+            'disk' => 'public',
+            'path' => $agentAttachmentPath,
+            'name' => 'resolution.pdf',
+            'mime_type' => 'application/pdf',
+            'size' => 2048,
+        ]);
+
+        Storage::disk('public')->assertExists($customerAttachmentPath);
+        Storage::disk('public')->assertExists($agentAttachmentPath);
+
+        $ticket->delete();
+
+        Storage::disk('public')->assertMissing($customerAttachmentPath);
+        Storage::disk('public')->assertMissing($agentAttachmentPath);
+
+        $this->assertDatabaseMissing('support_ticket_message_attachments', [
+            'id' => $customerAttachment->id,
+        ]);
+
+        $this->assertDatabaseMissing('support_ticket_message_attachments', [
+            'id' => $agentAttachment->id,
+        ]);
+
+        $this->assertDatabaseMissing('support_ticket_messages', [
+            'id' => $customerMessage->id,
+        ]);
+
+        $this->assertDatabaseMissing('support_ticket_messages', [
+            'id' => $agentMessage->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add model hooks so support ticket messages cascade delete their attachments from both the database and filesystem
- ensure deleting a support ticket iterates over its messages so attachment cleanup runs before records are removed
- add feature coverage confirming attachments disappear from storage and the database after message and ticket deletions

## Testing
- ❌ `php artisan test --filter=SupportTicketAttachmentCleanupTest` *(blocked: vendor autoloader missing because composer install requires a GitHub token in this environment)*
- ❌ `composer install` *(blocked: GitHub 403 requires authentication token, preventing dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68e105262aa4832cb6f8d8138f1e5b43