### PR TITLE
Send verification email when profile email changes

### DIFF
--- a/resources/js/pages/settings/Profile.vue
+++ b/resources/js/pages/settings/Profile.vue
@@ -199,7 +199,7 @@ const removeSocialLink = (index: number) => {
                         </p>
 
                         <div v-if="status === 'verification-link-sent'" class="mt-2 text-sm font-medium text-green-600">
-                            A new verification link has been sent to your email address.
+                            We've sent a verification email to your new address. Please check your inbox.
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- send a verification email whenever the profile update changes the address and flash a status message
- update the profile settings UI copy to instruct users to check their inbox
- cover the new behaviour with a feature test that fakes the notification

## Testing
- `php artisan test tests/Feature/Settings/ProfileUpdateTest.php` *(fails: vendor dependencies unavailable because composer install was blocked by proxy 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e423882420832cb0379b2cd94e1282