### PR TITLE
Add security settings page with MFA and session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ resources/
   the public portal and Admin Control Panel automatically runs through the Support Assignment Rules engine.
 - **Blog previews** use signed tokens so editors can review drafts before publishing.
 
+### Account Security
+- **Security settings**: Manage active browser sessions, enable time-based one-time password (TOTP) multi-factor authentication,
+  and rotate recovery codes from `/settings/security`. Recovery codes are generated locally and encrypted before storage so
+  users must download them immediately after confirmation.
+- **Session management**: The sessions panel lists every active session stored in the database. Revoking a session removes it
+  from the table and invalidates its cookie, forcing re-authentication on that device. The current session is highlighted and
+  protected from accidental revocation.
+- **MFA enrollment flow**:
+  1. Generate a fresh secret which exposes a manual key and otpauth URL for QR creation.
+  2. Confirm the secret by submitting a 6-digit code from an authenticator app (e.g., 1Password, Google Authenticator).
+  3. Store the displayed recovery codes—each is single-use and can be regenerated on demand after confirmation.
+- **Disabling MFA**: Clearing multi-factor authentication wipes the stored secret and recovery codes immediately, returning the
+  account to password-only authentication.
+
 ### Support Operations (Assignment & SLA)
 - **Assignment Rules**: Configure agent routing with ordered rules stored in the `support_assignment_rules` table. Rules can
   target specific categories or priorities and are evaluated top-to-bottom until a match assigns the ticket.

--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -31,6 +31,17 @@ class AuthenticatedSessionController extends Controller
     {
         $request->authenticate();
 
+        $user = $request->user();
+
+        if ($user && $user->two_factor_confirmed_at) {
+            $request->session()->put('two_factor:id', $user->getKey());
+            $request->session()->put('two_factor:remember', $request->boolean('remember'));
+
+            Auth::logout();
+
+            return redirect()->route('two-factor.login');
+        }
+
         $request->session()->regenerate();
 
         return redirect()->intended(route('dashboard', absolute: false));

--- a/app/Http/Controllers/Auth/TwoFactorChallengeController.php
+++ b/app/Http/Controllers/Auth/TwoFactorChallengeController.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Support\Security\TwoFactorAuthenticator;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class TwoFactorChallengeController extends Controller
+{
+    /**
+     * Display the multi-factor authentication challenge screen.
+     */
+    public function create(Request $request): Response|RedirectResponse
+    {
+        if (! $request->session()->has('two_factor:id')) {
+            return redirect()->route('login');
+        }
+
+        return Inertia::render('auth/TwoFactorChallenge');
+    }
+
+    /**
+     * Handle an incoming multi-factor authentication challenge.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'code' => ['nullable', 'string'],
+            'recovery_code' => ['nullable', 'string'],
+        ]);
+
+        $userId = $request->session()->get('two_factor:id');
+
+        if (! $userId) {
+            $this->clearTwoFactorSession($request);
+
+            return redirect()->route('login');
+        }
+
+        $user = User::find($userId);
+
+        if (! $user || is_null($user->two_factor_confirmed_at)) {
+            $this->clearTwoFactorSession($request);
+
+            return redirect()->route('login');
+        }
+
+        $code = $request->string('code')->trim()->value();
+        $recoveryCode = Str::of($request->string('recovery_code')->value())
+            ->upper()
+            ->replace(' ', '')
+            ->value();
+
+        if ($code === '' && $recoveryCode === '') {
+            throw ValidationException::withMessages([
+                'code' => trans('auth.two_factor_code_required'),
+            ]);
+        }
+
+        if ($code !== '') {
+            $secret = TwoFactorAuthenticator::decryptSecret($user->two_factor_secret);
+
+            if (! $secret || ! TwoFactorAuthenticator::verify($secret, $code)) {
+                throw ValidationException::withMessages([
+                    'code' => trans('auth.two_factor_code_invalid'),
+                ]);
+            }
+        } else {
+            $recoveryCodes = TwoFactorAuthenticator::decryptRecoveryCodes($user->two_factor_recovery_codes);
+
+            if (! in_array($recoveryCode, $recoveryCodes, true)) {
+                throw ValidationException::withMessages([
+                    'recovery_code' => trans('auth.two_factor_recovery_code_invalid'),
+                ]);
+            }
+
+            $remainingCodes = array_values(array_diff($recoveryCodes, [$recoveryCode]));
+
+            $user->forceFill([
+                'two_factor_recovery_codes' => TwoFactorAuthenticator::encryptRecoveryCodes($remainingCodes),
+            ])->save();
+        }
+
+        $remember = (bool) $request->session()->pull('two_factor:remember', false);
+        $request->session()->forget('two_factor:id');
+
+        Auth::login($user, $remember);
+
+        $request->session()->regenerate();
+
+        return redirect()->intended(route('dashboard', absolute: false));
+    }
+
+    private function clearTwoFactorSession(Request $request): void
+    {
+        $request->session()->forget(['two_factor:id', 'two_factor:remember']);
+    }
+}

--- a/app/Http/Controllers/Settings/SecurityController.php
+++ b/app/Http/Controllers/Settings/SecurityController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Support\Security\TwoFactorAuthenticator;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use JsonException;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class SecurityController extends Controller
+{
+    /**
+     * Display the security settings page.
+     */
+    public function edit(Request $request): Response
+    {
+        $user = $request->user();
+
+        $sessions = DB::table('sessions')
+            ->where('user_id', $user->id)
+            ->orderByDesc('last_activity')
+            ->get()
+            ->map(fn ($session) => [
+                'id' => $session->id,
+                'ip_address' => $session->ip_address,
+                'user_agent' => $session->user_agent,
+                'last_active_at' => Carbon::createFromTimestamp($session->last_activity)->toIso8601String(),
+                'last_active_for_humans' => Carbon::createFromTimestamp($session->last_activity)->diffForHumans(),
+                'is_current_device' => $session->id === $request->session()->getId(),
+            ])
+            ->values();
+
+        $pendingSecret = null;
+        $qrCodeUrl = null;
+
+        if ($user->two_factor_secret && is_null($user->two_factor_confirmed_at)) {
+            $pendingSecret = TwoFactorAuthenticator::decryptSecret($user->two_factor_secret);
+            $qrCodeUrl = $pendingSecret ? TwoFactorAuthenticator::makeQrCodeUrl($user, $pendingSecret) : null;
+        }
+
+        $recoveryCodes = [];
+
+        if ($user->two_factor_recovery_codes) {
+            try {
+                $recoveryCodes = TwoFactorAuthenticator::decryptRecoveryCodes($user->two_factor_recovery_codes);
+            } catch (JsonException) {
+                $recoveryCodes = [];
+            }
+        }
+
+        return Inertia::render('settings/Security', [
+            'sessions' => $sessions,
+            'twoFactorEnabled' => ! is_null($user->two_factor_secret),
+            'twoFactorConfirmed' => ! is_null($user->two_factor_confirmed_at),
+            'pendingSecret' => $pendingSecret,
+            'qrCodeUrl' => $qrCodeUrl,
+            'recoveryCodes' => $recoveryCodes,
+            'status' => $request->session()->get('status'),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Settings/SecuritySessionController.php
+++ b/app/Http/Controllers/Settings/SecuritySessionController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class SecuritySessionController extends Controller
+{
+    /**
+     * Revoke an active session.
+     */
+    public function destroy(Request $request, string $sessionId): RedirectResponse
+    {
+        $currentSessionId = $request->session()->getId();
+
+        if ($sessionId === $currentSessionId) {
+            return back()->with('status', 'current-session-retained');
+        }
+
+        DB::table('sessions')
+            ->where('id', $sessionId)
+            ->where('user_id', $request->user()->id)
+            ->delete();
+
+        return back()->with('status', 'session-revoked');
+    }
+}

--- a/app/Http/Controllers/Settings/TwoFactorController.php
+++ b/app/Http/Controllers/Settings/TwoFactorController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Support\Security\TwoFactorAuthenticator;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Validation\ValidationException;
+use JsonException;
+
+class TwoFactorController extends Controller
+{
+    /**
+     * Generate and persist a new two-factor secret.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        $secret = TwoFactorAuthenticator::generateSecret();
+
+        $user->forceFill([
+            'two_factor_secret' => TwoFactorAuthenticator::encryptSecret($secret),
+            'two_factor_confirmed_at' => null,
+            'two_factor_recovery_codes' => null,
+        ])->save();
+
+        return back()->with('status', 'two-factor-secret-generated');
+    }
+
+    /**
+     * Confirm two-factor authentication with the provided code.
+     */
+    public function confirm(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'code' => ['required', 'digits:6'],
+        ]);
+
+        $user = $request->user();
+
+        if (! $user->two_factor_secret) {
+            throw ValidationException::withMessages([
+                'code' => 'Two-factor authentication has not been initiated.',
+            ]);
+        }
+
+        $secret = TwoFactorAuthenticator::decryptSecret($user->two_factor_secret);
+
+        if (! $secret || ! TwoFactorAuthenticator::verify($secret, $request->string('code'), 1, now()->timestamp)) {
+            throw ValidationException::withMessages([
+                'code' => 'The provided authentication code is invalid.',
+            ]);
+        }
+
+        try {
+            $recoveryCodes = TwoFactorAuthenticator::generateRecoveryCodes();
+            $encryptedCodes = TwoFactorAuthenticator::encryptRecoveryCodes($recoveryCodes);
+
+            $user->forceFill([
+                'two_factor_confirmed_at' => Carbon::now(),
+                'two_factor_recovery_codes' => $encryptedCodes,
+            ])->save();
+        } catch (JsonException) {
+            throw ValidationException::withMessages([
+                'code' => 'Recovery codes could not be generated. Please try again.',
+            ]);
+        }
+
+        return back()->with('status', 'two-factor-confirmed');
+    }
+
+    /**
+     * Disable two-factor authentication for the user.
+     */
+    public function destroy(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        $user->forceFill([
+            'two_factor_secret' => null,
+            'two_factor_confirmed_at' => null,
+            'two_factor_recovery_codes' => null,
+        ])->save();
+
+        return back()->with('status', 'two-factor-disabled');
+    }
+}

--- a/app/Http/Controllers/Settings/TwoFactorRecoveryCodeController.php
+++ b/app/Http/Controllers/Settings/TwoFactorRecoveryCodeController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Support\Security\TwoFactorAuthenticator;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use JsonException;
+
+class TwoFactorRecoveryCodeController extends Controller
+{
+    /**
+     * Generate a fresh set of recovery codes.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        if (! $user->two_factor_secret || ! $user->two_factor_confirmed_at) {
+            throw ValidationException::withMessages([
+                'recovery' => 'Enable multi-factor authentication before generating recovery codes.',
+            ]);
+        }
+
+        try {
+            $recoveryCodes = TwoFactorAuthenticator::generateRecoveryCodes();
+            $encryptedCodes = TwoFactorAuthenticator::encryptRecoveryCodes($recoveryCodes);
+        } catch (JsonException) {
+            throw ValidationException::withMessages([
+                'recovery' => 'Recovery codes could not be generated. Please try again.',
+            ]);
+        }
+
+        $user->forceFill([
+            'two_factor_recovery_codes' => $encryptedCodes,
+        ])->save();
+
+        return back()->with('status', 'recovery-codes-generated');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -45,6 +45,8 @@ class User extends Authenticatable implements MustVerifyEmail
     protected $hidden = [
         'password',
         'remember_token',
+        'two_factor_secret',
+        'two_factor_recovery_codes',
     ];
 
     /**
@@ -60,6 +62,7 @@ class User extends Authenticatable implements MustVerifyEmail
             'last_activity_at' => 'datetime',
             'banned_at' => 'datetime',
             'social_links' => 'array',
+            'two_factor_confirmed_at' => 'datetime',
         ];
     }
 

--- a/app/Support/Security/TwoFactorAuthenticator.php
+++ b/app/Support/Security/TwoFactorAuthenticator.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace App\Support\Security;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Str;
+
+class TwoFactorAuthenticator
+{
+    private const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+    private const DEFAULT_DIGITS = 6;
+    private const DEFAULT_PERIOD = 30;
+
+    /**
+     * Generate a new base32-encoded secret for TOTP.
+     */
+    public static function generateSecret(int $length = 32): string
+    {
+        $randomBytes = random_bytes($length);
+
+        return self::base32Encode($randomBytes);
+    }
+
+    /**
+     * Generate recovery codes for the authenticated user.
+     *
+     * @return list<string>
+     */
+    public static function generateRecoveryCodes(int $count = 8): array
+    {
+        return collect(range(1, $count))
+            ->map(fn () => Str::upper(Str::random(4)).'-'.Str::upper(Str::random(4)).'-'.Str::upper(Str::random(4)))
+            ->all();
+    }
+
+    /**
+     * Create an otpauth URI that can be converted into a QR code.
+     */
+    public static function makeQrCodeUrl(User $user, string $secret): string
+    {
+        $issuer = rawurlencode(config('app.name'));
+        $accountName = rawurlencode($user->email ?? $user->nickname);
+
+        return sprintf('otpauth://totp/%s:%s?secret=%s&issuer=%s', $issuer, $accountName, $secret, $issuer);
+    }
+
+    /**
+     * Generate a TOTP code for the provided timestamp.
+     */
+    public static function code(string $secret, ?int $timestamp = null, int $digits = self::DEFAULT_DIGITS): string
+    {
+        $timestamp ??= time();
+        $timeSlice = (int) floor($timestamp / self::DEFAULT_PERIOD);
+
+        return self::generateCodeForSlice($secret, $timeSlice, $digits);
+    }
+
+    /**
+     * Verify a provided code against the secret.
+     */
+    public static function verify(string $secret, string $code, int $window = 1, ?int $timestamp = null): bool
+    {
+        $normalizedCode = preg_replace('/\s+/', '', $code ?? '');
+
+        if (!preg_match('/^\d{6}$/', $normalizedCode)) {
+            return false;
+        }
+
+        $timestamp ??= time();
+        $timeSlice = (int) floor($timestamp / self::DEFAULT_PERIOD);
+
+        for ($i = -$window; $i <= $window; $i++) {
+            $calculated = self::generateCodeForSlice($secret, $timeSlice + $i);
+
+            if (hash_equals($calculated, $normalizedCode)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Decrypt a stored secret.
+     */
+    public static function decryptSecret(?string $encryptedSecret): ?string
+    {
+        if (empty($encryptedSecret)) {
+            return null;
+        }
+
+        return Crypt::decryptString($encryptedSecret);
+    }
+
+    /**
+     * Decrypt stored recovery codes.
+     *
+     * @return list<string>
+     */
+    public static function decryptRecoveryCodes(?string $encryptedRecoveryCodes): array
+    {
+        if (empty($encryptedRecoveryCodes)) {
+            return [];
+        }
+
+        $decoded = Crypt::decryptString($encryptedRecoveryCodes);
+
+        return json_decode($decoded, true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Encrypt recovery codes for storage.
+     */
+    public static function encryptRecoveryCodes(array $recoveryCodes): string
+    {
+        return Crypt::encryptString(json_encode($recoveryCodes, JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * Encrypt a secret for storage.
+     */
+    public static function encryptSecret(string $secret): string
+    {
+        return Crypt::encryptString($secret);
+    }
+
+    private static function generateCodeForSlice(string $secret, int $timeSlice, int $digits = self::DEFAULT_DIGITS): string
+    {
+        $binarySecret = self::base32Decode($secret);
+        $time = pack('N*', 0).pack('N*', $timeSlice);
+        $hash = hash_hmac('sha1', $time, $binarySecret, true);
+        $offset = ord(substr($hash, -1)) & 0x0F;
+        $value = unpack('N', substr($hash, $offset, 4))[1] & 0x7FFFFFFF;
+        $mod = $value % (10 ** $digits);
+
+        return str_pad((string) $mod, $digits, '0', STR_PAD_LEFT);
+    }
+
+    private static function base32Encode(string $binary): string
+    {
+        $binaryLength = strlen($binary);
+        $bits = '';
+
+        for ($i = 0; $i < $binaryLength; $i++) {
+            $bits .= str_pad(decbin(ord($binary[$i])), 8, '0', STR_PAD_LEFT);
+        }
+
+        $chunks = str_split($bits, 5);
+        $encoded = '';
+
+        foreach ($chunks as $chunk) {
+            if (strlen($chunk) < 5) {
+                $chunk = str_pad($chunk, 5, '0', STR_PAD_RIGHT);
+            }
+
+            $index = bindec($chunk);
+            $encoded .= self::BASE32_ALPHABET[$index];
+        }
+
+        return $encoded;
+    }
+
+    private static function base32Decode(string $base32): string
+    {
+        $base32 = strtoupper(preg_replace('/[^A-Z2-7]/', '', $base32));
+        $bits = '';
+
+        foreach (str_split($base32) as $char) {
+            $position = strpos(self::BASE32_ALPHABET, $char);
+
+            if ($position === false) {
+                continue;
+            }
+
+            $bits .= str_pad(decbin($position), 5, '0', STR_PAD_LEFT);
+        }
+
+        $chunks = str_split($bits, 8);
+        $binary = '';
+
+        foreach ($chunks as $chunk) {
+            if (strlen($chunk) === 8) {
+                $binary .= chr(bindec($chunk));
+            }
+        }
+
+        return $binary;
+    }
+}

--- a/app/Support/Security/TwoFactorAuthenticator.php
+++ b/app/Support/Security/TwoFactorAuthenticator.php
@@ -3,6 +3,7 @@
 namespace App\Support\Security;
 
 use App\Models\User;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Str;
 
@@ -50,7 +51,7 @@ class TwoFactorAuthenticator
      */
     public static function code(string $secret, ?int $timestamp = null, int $digits = self::DEFAULT_DIGITS): string
     {
-        $timestamp ??= time();
+        $timestamp ??= Carbon::now()->getTimestamp();
         $timeSlice = (int) floor($timestamp / self::DEFAULT_PERIOD);
 
         return self::generateCodeForSlice($secret, $timeSlice, $digits);
@@ -67,7 +68,7 @@ class TwoFactorAuthenticator
             return false;
         }
 
-        $timestamp ??= time();
+        $timestamp ??= Carbon::now()->getTimestamp();
         $timeSlice = (int) floor($timestamp / self::DEFAULT_PERIOD);
 
         for ($i = -$window; $i <= $window; $i++) {

--- a/database/migrations/2025_06_01_000000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2025_06_01_000000_add_two_factor_columns_to_users_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->text('two_factor_secret')->nullable();
+            $table->text('two_factor_recovery_codes')->nullable();
+            $table->timestamp('two_factor_confirmed_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn([
+                'two_factor_secret',
+                'two_factor_recovery_codes',
+                'two_factor_confirmed_at',
+            ]);
+        });
+    }
+};

--- a/lang/en/auth.php
+++ b/lang/en/auth.php
@@ -5,4 +5,7 @@ return [
     'password' => 'The provided password is incorrect.',
     'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
     'banned' => 'Your account has been banned.',
+    'two_factor_code_required' => 'Please provide an authentication code or a recovery code.',
+    'two_factor_code_invalid' => 'The provided authentication code was invalid.',
+    'two_factor_recovery_code_invalid' => 'The recovery code is invalid or has already been used.',
 ];

--- a/resources/js/layouts/settings/SettingsLayout.vue
+++ b/resources/js/layouts/settings/SettingsLayout.vue
@@ -17,6 +17,11 @@ const sidebarNavItems: NavItem[] = [
         target: '_self'
     },
     {
+        title: 'Security',
+        href: '/settings/security',
+        target: '_self'
+    },
+    {
         title: 'Appearance',
         href: '/settings/appearance',
         target: '_self'

--- a/resources/js/layouts/settings/SettingsLayout.vue
+++ b/resources/js/layouts/settings/SettingsLayout.vue
@@ -56,8 +56,8 @@ const currentPath = page.props.ziggy?.location ? new URL(page.props.ziggy.locati
 
             <Separator class="my-6 md:hidden" />
 
-            <div class="flex-1 md:max-w-2xl">
-                <section class="max-w-xl space-y-12">
+            <div class="flex-1">
+                <section class="space-y-12">
                     <slot />
                 </section>
             </div>

--- a/resources/js/pages/auth/TwoFactorChallenge.vue
+++ b/resources/js/pages/auth/TwoFactorChallenge.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import InputError from '@/components/InputError.vue';
+import TextLink from '@/components/TextLink.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import AuthBase from '@/layouts/AuthLayout.vue';
+import { Head, useForm } from '@inertiajs/vue3';
+import { computed, ref } from 'vue';
+import { LoaderCircle } from 'lucide-vue-next';
+
+const useRecovery = ref(false);
+
+const form = useForm({
+    code: '',
+    recovery_code: '',
+});
+
+const title = computed(() => (useRecovery.value ? 'Use a recovery code' : 'Enter your authentication code'));
+const description = computed(() =>
+    useRecovery.value
+        ? 'Enter one of the recovery codes you saved when enabling multi-factor authentication.'
+        : 'Open your authenticator app (Authy, Google Authenticator, etc.) and enter the 6-digit verification code.'
+);
+
+const submit = () => {
+    if (useRecovery.value) {
+        form.code = '';
+    } else {
+        form.recovery_code = '';
+    }
+
+    form.post(route('two-factor.login'), {
+        preserveScroll: true,
+    });
+};
+
+const toggleMode = () => {
+    useRecovery.value = !useRecovery.value;
+    form.clearErrors();
+};
+</script>
+
+<template>
+    <AuthBase title="Two-factor authentication" description="Complete the challenge to access your account">
+        <Head title="Two-factor authentication" />
+
+        <form @submit.prevent="submit" class="flex flex-col gap-6">
+            <div class="grid gap-2">
+                <h2 class="text-lg font-semibold">{{ title }}</h2>
+                <p class="text-sm text-muted-foreground">{{ description }}</p>
+            </div>
+
+            <div v-if="!useRecovery" class="grid gap-2">
+                <Label for="code">Authentication code</Label>
+                <Input
+                    id="code"
+                    inputmode="numeric"
+                    autocomplete="one-time-code"
+                    placeholder="123456"
+                    maxlength="6"
+                    v-model="form.code"
+                    :disabled="form.processing"
+                    autofocus
+                />
+                <InputError :message="form.errors.code" />
+            </div>
+
+            <div v-else class="grid gap-2">
+                <Label for="recovery_code">Recovery code</Label>
+                <Input
+                    id="recovery_code"
+                    autocomplete="one-time-code"
+                    placeholder="ABCD-EFGH-IJKL"
+                    v-model="form.recovery_code"
+                    :disabled="form.processing"
+                    autofocus
+                />
+                <InputError :message="form.errors.recovery_code" />
+            </div>
+
+            <div class="space-y-2">
+                <Button type="submit" class="w-full" :disabled="form.processing">
+                    <LoaderCircle v-if="form.processing" class="h-4 w-4 animate-spin" />
+                    Continue
+                </Button>
+
+                <Button type="button" variant="link" class="w-full" @click="toggleMode">
+                    <span v-if="useRecovery">Use an authenticator code instead</span>
+                    <span v-else>Use a recovery code</span>
+                </Button>
+                <TextLink :href="route('login')" class="block text-center text-sm">Back to login</TextLink>
+            </div>
+        </form>
+    </AuthBase>
+</template>

--- a/resources/js/pages/settings/Security.vue
+++ b/resources/js/pages/settings/Security.vue
@@ -257,7 +257,7 @@ watch(hasRecoveryCodes, (value) => {
                         </div>
 
                         <div v-else>
-                            <Card>
+                            <Card class="mb-4">
                                 <CardHeader>
                                     <CardTitle>
                                         {{ twoFactorConfirmed ? 'Multi-factor authentication is enabled' : 'Finish setup' }}

--- a/resources/js/pages/settings/Security.vue
+++ b/resources/js/pages/settings/Security.vue
@@ -1,0 +1,354 @@
+<script setup lang="ts">
+import { computed, toRefs, watch } from 'vue';
+import { Head, useForm } from '@inertiajs/vue3';
+
+import HeadingSmall from '@/components/HeadingSmall.vue';
+import InputError from '@/components/InputError.vue';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Separator } from '@/components/ui/separator';
+import AppLayout from '@/layouts/AppLayout.vue';
+import SettingsLayout from '@/layouts/settings/SettingsLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+
+interface ActiveSession {
+    id: string;
+    ip_address: string | null;
+    user_agent: string | null;
+    last_active_at: string;
+    last_active_for_humans: string;
+    is_current_device: boolean;
+}
+
+interface Props {
+    sessions: ActiveSession[];
+    twoFactorEnabled: boolean;
+    twoFactorConfirmed: boolean;
+    pendingSecret: string | null;
+    qrCodeUrl: string | null;
+    recoveryCodes: string[];
+    status?: string | null;
+}
+
+const props = defineProps<Props>();
+const {
+    sessions,
+    twoFactorEnabled,
+    twoFactorConfirmed,
+    pendingSecret,
+    qrCodeUrl,
+    recoveryCodes,
+    status,
+} = toRefs(props);
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Security settings',
+        href: '/settings/security',
+    },
+];
+
+const enableForm = useForm({});
+const disableForm = useForm({});
+const recoveryForm = useForm({});
+const revokeForm = useForm({});
+const confirmForm = useForm({
+    code: '',
+});
+
+watch(
+    pendingSecret,
+    (value) => {
+        if (!value) {
+            confirmForm.reset();
+        }
+    }
+);
+
+const statusDetails = computed(() => {
+    switch (status.value) {
+        case 'session-revoked':
+            return {
+                title: 'Session revoked',
+                description: 'The selected session has been signed out.',
+            };
+        case 'current-session-retained':
+            return {
+                title: 'Active session preserved',
+                description: 'You cannot revoke the session currently in use.',
+            };
+        case 'two-factor-secret-generated':
+            return {
+                title: 'Verification required',
+                description:
+                    'Scan the secret with your authenticator app and confirm using a 6-digit code to finish enrolling.',
+            };
+        case 'two-factor-confirmed':
+            return {
+                title: 'Multi-factor authentication enabled',
+                description: 'Authenticator codes and recovery codes are now active for your account.',
+            };
+        case 'two-factor-disabled':
+            return {
+                title: 'Multi-factor authentication disabled',
+                description: 'Authenticator codes and existing recovery codes have been cleared.',
+            };
+        case 'recovery-codes-generated':
+            return {
+                title: 'Recovery codes refreshed',
+                description: 'Store the new recovery codes in a safe location.',
+            };
+        default:
+            return null;
+    }
+});
+
+const hasSessions = computed(() => sessions.value.length > 0);
+const hasPendingSecret = computed(() => Boolean(pendingSecret.value));
+const hasRecoveryCodes = computed(() => recoveryCodes.value && recoveryCodes.value.length > 0);
+
+const revokeSession = (sessionId: string) => {
+    revokeForm.delete(route('security.sessions.destroy', sessionId), {
+        preserveScroll: true,
+    });
+};
+
+const enableTwoFactor = () => {
+    enableForm.post(route('security.mfa.store'), {
+        preserveScroll: true,
+    });
+};
+
+const confirmTwoFactor = () => {
+    confirmForm.post(route('security.mfa.confirm'), {
+        preserveScroll: true,
+        onSuccess: () => confirmForm.reset('code'),
+    });
+};
+
+const disableTwoFactor = () => {
+    disableForm.delete(route('security.mfa.destroy'), {
+        preserveScroll: true,
+    });
+};
+
+const regenerateRecoveryCodes = () => {
+    recoveryForm.post(route('security.recovery-codes.store'), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Security settings" />
+
+        <SettingsLayout>
+            <div class="space-y-10">
+                <div class="space-y-4">
+                    <HeadingSmall
+                        title="Active sessions"
+                        description="Review and revoke devices currently authenticated with your account."
+                    />
+
+                    <Alert v-if="statusDetails" class="border-l-4 border-l-primary bg-muted/40">
+                        <AlertTitle class="font-semibold">{{ statusDetails.title }}</AlertTitle>
+                        <AlertDescription>{{ statusDetails.description }}</AlertDescription>
+                    </Alert>
+
+                    <div class="grid gap-4 lg:grid-cols-2">
+                        <Card v-for="session in sessions" :key="session.id">
+                            <CardHeader>
+                                <CardTitle class="flex flex-col space-y-1">
+                                    <span>{{ session.ip_address ?? 'Unknown location' }}</span>
+                                    <span
+                                        v-if="session.is_current_device"
+                                        class="text-sm font-normal text-primary"
+                                    >
+                                        Current device
+                                    </span>
+                                </CardTitle>
+                                <CardDescription>
+                                    Last active {{ session.last_active_for_humans }}
+                                </CardDescription>
+                            </CardHeader>
+                            <CardContent class="space-y-2">
+                                <p class="text-sm text-muted-foreground">
+                                    {{ session.user_agent ?? 'No user agent information recorded.' }}
+                                </p>
+                            </CardContent>
+                            <CardFooter class="flex items-center justify-between">
+                                <span class="text-xs text-muted-foreground">
+                                    Session ID: {{ session.id }}
+                                </span>
+                                <Button
+                                    v-if="!session.is_current_device"
+                                    variant="outline"
+                                    size="sm"
+                                    :disabled="revokeForm.processing"
+                                    @click="revokeSession(session.id)"
+                                >
+                                    Revoke
+                                </Button>
+                                <Button v-else variant="outline" size="sm" disabled>
+                                    Active
+                                </Button>
+                            </CardFooter>
+                        </Card>
+                        <Card v-if="!hasSessions" class="lg:col-span-2">
+                            <CardHeader>
+                                <CardTitle>No active sessions</CardTitle>
+                                <CardDescription>
+                                    When you sign in on additional devices, they will appear in this list for quick review.
+                                </CardDescription>
+                            </CardHeader>
+                        </Card>
+                    </div>
+                </div>
+
+                <Separator />
+
+                <div class="space-y-6">
+                    <HeadingSmall
+                        title="Multi-factor authentication"
+                        description="Add an extra layer of security using an authenticator app and recovery codes."
+                    />
+
+                    <div class="space-y-6">
+                        <div v-if="!twoFactorEnabled">
+                            <Card>
+                                <CardHeader>
+                                    <CardTitle>Protect your account</CardTitle>
+                                    <CardDescription>
+                                        Multi-factor authentication requires both your password and a rotating code from an
+                                        authenticator app to sign in.
+                                    </CardDescription>
+                                </CardHeader>
+                                <CardFooter>
+                                    <Button :disabled="enableForm.processing" @click="enableTwoFactor">
+                                        Enable multi-factor authentication
+                                    </Button>
+                                </CardFooter>
+                            </Card>
+                        </div>
+
+                        <div v-else>
+                            <Card>
+                                <CardHeader>
+                                    <CardTitle>
+                                        {{ twoFactorConfirmed ? 'Multi-factor authentication is enabled' : 'Finish setup' }}
+                                    </CardTitle>
+                                    <CardDescription>
+                                        {{
+                                            twoFactorConfirmed
+                                                ? 'Your authenticator app codes are required during sign-in. Store the recovery codes safely.'
+                                                : 'Scan the secret or enter it manually in your authenticator app, then confirm with a 6-digit code.'
+                                        }}
+                                    </CardDescription>
+                                </CardHeader>
+                                <CardContent class="space-y-4">
+                                    <div v-if="hasPendingSecret" class="space-y-3">
+                                        <div class="space-y-1">
+                                            <Label>Authenticator secret</Label>
+                                            <Input :value="pendingSecret ?? ''" readonly />
+                                            <p class="text-xs text-muted-foreground">
+                                                Manually add this key to your authenticator app if you cannot scan a QR code.
+                                            </p>
+                                        </div>
+                                        <div v-if="qrCodeUrl" class="space-y-1">
+                                            <Label>otpauth URL</Label>
+                                            <Input :value="qrCodeUrl" readonly />
+                                            <p class="text-xs text-muted-foreground">
+                                                Use this URL with any QR code generator to produce a scannable code for your authenticator.
+                                            </p>
+                                        </div>
+                                        <form @submit.prevent="confirmTwoFactor" class="space-y-3">
+                                            <div class="space-y-2">
+                                                <Label for="code">Verification code</Label>
+                                                <Input
+                                                    id="code"
+                                                    v-model="confirmForm.code"
+                                                    type="text"
+                                                    inputmode="numeric"
+                                                    autocomplete="one-time-code"
+                                                    placeholder="123456"
+                                                />
+                                                <InputError :message="confirmForm.errors.code" />
+                                            </div>
+                                            <div class="flex flex-wrap gap-2">
+                                                <Button type="submit" :disabled="confirmForm.processing">
+                                                    Confirm setup
+                                                </Button>
+                                                <Button
+                                                    type="button"
+                                                    variant="outline"
+                                                    :disabled="disableForm.processing"
+                                                    @click="disableTwoFactor"
+                                                >
+                                                    Cancel
+                                                </Button>
+                                            </div>
+                                        </form>
+                                    </div>
+
+                                    <div v-else class="flex flex-wrap gap-2">
+                                        <Button
+                                            type="button"
+                                            variant="destructive"
+                                            :disabled="disableForm.processing"
+                                            @click="disableTwoFactor"
+                                        >
+                                            Disable multi-factor authentication
+                                        </Button>
+                                    </div>
+                                </CardContent>
+                            </Card>
+
+                            <Card>
+                                <CardHeader>
+                                    <CardTitle>Recovery codes</CardTitle>
+                                    <CardDescription>
+                                        Use a recovery code if you lose access to your authenticator device.
+                                    </CardDescription>
+                                </CardHeader>
+                                <CardContent class="space-y-4">
+                                    <div v-if="hasRecoveryCodes">
+                                        <p class="text-sm text-muted-foreground">
+                                            Each recovery code can be used once. Print or store them securely before leaving this page.
+                                        </p>
+                                        <ul class="grid gap-2 sm:grid-cols-2">
+                                            <li
+                                                v-for="code in recoveryCodes"
+                                                :key="code"
+                                                class="rounded border bg-muted/40 px-3 py-2 font-mono text-sm"
+                                            >
+                                                {{ code }}
+                                            </li>
+                                        </ul>
+                                    </div>
+                                    <p v-else class="text-sm text-muted-foreground">
+                                        Recovery codes will appear after confirming multi-factor authentication.
+                                    </p>
+                                </CardContent>
+                                <CardFooter class="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        :disabled="recoveryForm.processing || !twoFactorConfirmed"
+                                        @click="regenerateRecoveryCodes"
+                                    >
+                                        Generate new recovery codes
+                                    </Button>
+                                    <InputError :message="recoveryForm.errors.recovery" />
+                                </CardFooter>
+                            </Card>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </SettingsLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/settings/Security.vue
+++ b/resources/js/pages/settings/Security.vue
@@ -255,14 +255,14 @@ const regenerateRecoveryCodes = () => {
                                     <div v-if="hasPendingSecret" class="space-y-3">
                                         <div class="space-y-1">
                                             <Label>Authenticator secret</Label>
-                                            <Input :value="pendingSecret ?? ''" readonly />
+                                            <Input :model-value="pendingSecret ?? ''" readonly />
                                             <p class="text-xs text-muted-foreground">
                                                 Manually add this key to your authenticator app if you cannot scan a QR code.
                                             </p>
                                         </div>
                                         <div v-if="qrCodeUrl" class="space-y-1">
                                             <Label>otpauth URL</Label>
-                                            <Input :value="qrCodeUrl" readonly />
+                                            <Input :model-value="qrCodeUrl" readonly />
                                             <p class="text-xs text-muted-foreground">
                                                 Use this URL with any QR code generator to produce a scannable code for your authenticator.
                                             </p>

--- a/resources/js/pages/settings/Security.vue
+++ b/resources/js/pages/settings/Security.vue
@@ -180,8 +180,10 @@ const regenerateRecoveryCodes = () => {
                                     {{ session.user_agent ?? 'No user agent information recorded.' }}
                                 </p>
                             </CardContent>
-                            <CardFooter class="flex items-center justify-between">
-                                <span class="text-xs text-muted-foreground">
+                            <CardFooter
+                                class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+                            >
+                                <span class="break-all text-xs text-muted-foreground">
                                     Session ID: {{ session.id }}
                                 </span>
                                 <Button

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Auth\EmailVerificationPromptController;
 use App\Http\Controllers\Auth\NewPasswordController;
 use App\Http\Controllers\Auth\PasswordResetLinkController;
 use App\Http\Controllers\Auth\RegisteredUserController;
+use App\Http\Controllers\Auth\TwoFactorChallengeController;
 use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 
@@ -20,6 +21,11 @@ Route::middleware('guest')->group(function () {
         ->name('login');
 
     Route::post('login', [AuthenticatedSessionController::class, 'store']);
+
+    Route::get('two-factor-challenge', [TwoFactorChallengeController::class, 'create'])
+        ->name('two-factor.login');
+
+    Route::post('two-factor-challenge', [TwoFactorChallengeController::class, 'store']);
 
     Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
         ->name('password.request');

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -2,6 +2,10 @@
 
 use App\Http\Controllers\Settings\PasswordController;
 use App\Http\Controllers\Settings\ProfileController;
+use App\Http\Controllers\Settings\SecurityController;
+use App\Http\Controllers\Settings\SecuritySessionController;
+use App\Http\Controllers\Settings\TwoFactorController;
+use App\Http\Controllers\Settings\TwoFactorRecoveryCodeController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -18,4 +22,16 @@ Route::middleware('auth')->group(function () {
     Route::get('settings/appearance', function () {
         return Inertia::render('settings/Appearance');
     })->name('appearance');
+
+    Route::get('settings/security', [SecurityController::class, 'edit'])->name('security.edit');
+
+    Route::delete('settings/security/sessions/{session}', [SecuritySessionController::class, 'destroy'])
+        ->name('security.sessions.destroy');
+
+    Route::post('settings/security/mfa', [TwoFactorController::class, 'store'])->name('security.mfa.store');
+    Route::post('settings/security/mfa/confirm', [TwoFactorController::class, 'confirm'])->name('security.mfa.confirm');
+    Route::delete('settings/security/mfa', [TwoFactorController::class, 'destroy'])->name('security.mfa.destroy');
+
+    Route::post('settings/security/recovery-codes', [TwoFactorRecoveryCodeController::class, 'store'])
+        ->name('security.recovery-codes.store');
 });

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\Auth;
 
 use App\Models\User;
+use App\Support\Security\TwoFactorAuthenticator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
 class AuthenticationTest extends TestCase
@@ -40,6 +42,98 @@ class AuthenticationTest extends TestCase
         ]);
 
         $this->assertGuest();
+    }
+
+    public function test_users_with_two_factor_enabled_are_redirected_to_the_challenge_screen()
+    {
+        $user = User::factory()->create();
+
+        $secret = TwoFactorAuthenticator::generateSecret();
+
+        $user->forceFill([
+            'two_factor_secret' => TwoFactorAuthenticator::encryptSecret($secret),
+            'two_factor_confirmed_at' => now(),
+            'two_factor_recovery_codes' => TwoFactorAuthenticator::encryptRecoveryCodes([
+                'TEST-ONE-USED',
+            ]),
+        ])->save();
+
+        $response = $this->post('/login', [
+            'email' => $user->email,
+            'password' => 'password',
+        ]);
+
+        $response->assertRedirect(route('two-factor.login'));
+        $response->assertSessionHas('two_factor:id', $user->id);
+        $this->assertGuest();
+    }
+
+    public function test_users_can_complete_two_factor_challenge_with_authenticator_code()
+    {
+        Carbon::setTestNow($now = Carbon::create(2024, 1, 1, 12));
+
+        $user = User::factory()->create();
+
+        $secret = TwoFactorAuthenticator::generateSecret();
+        $code = TwoFactorAuthenticator::code($secret, $now->timestamp);
+
+        $user->forceFill([
+            'two_factor_secret' => TwoFactorAuthenticator::encryptSecret($secret),
+            'two_factor_confirmed_at' => now(),
+            'two_factor_recovery_codes' => TwoFactorAuthenticator::encryptRecoveryCodes([
+                'TEST-RECOVERY-CODE',
+            ]),
+        ])->save();
+
+        $this->post('/login', [
+            'email' => $user->email,
+            'password' => 'password',
+        ])->assertRedirect(route('two-factor.login'));
+
+        $response = $this->post(route('two-factor.login'), [
+            'code' => $code,
+        ]);
+
+        $response->assertRedirect(route('dashboard', absolute: false));
+        $response->assertSessionMissing('two_factor:id');
+        $this->assertAuthenticatedAs($user);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_users_can_complete_two_factor_challenge_with_recovery_code()
+    {
+        $user = User::factory()->create();
+
+        $secret = TwoFactorAuthenticator::generateSecret();
+        $recoveryCode = 'ABCD-EFGH-IJKL';
+
+        $user->forceFill([
+            'two_factor_secret' => TwoFactorAuthenticator::encryptSecret($secret),
+            'two_factor_confirmed_at' => now(),
+            'two_factor_recovery_codes' => TwoFactorAuthenticator::encryptRecoveryCodes([
+                $recoveryCode,
+                'WXYZ-MNOP-QRST',
+            ]),
+        ])->save();
+
+        $this->post('/login', [
+            'email' => $user->email,
+            'password' => 'password',
+        ])->assertRedirect(route('two-factor.login'));
+
+        $response = $this->post(route('two-factor.login'), [
+            'recovery_code' => $recoveryCode,
+        ]);
+
+        $response->assertRedirect(route('dashboard', absolute: false));
+        $this->assertAuthenticatedAs($user);
+
+        $user->refresh();
+        $remainingCodes = TwoFactorAuthenticator::decryptRecoveryCodes($user->two_factor_recovery_codes);
+
+        $this->assertNotContains($recoveryCode, $remainingCodes);
+        $this->assertContains('WXYZ-MNOP-QRST', $remainingCodes);
     }
 
     public function test_users_can_logout()

--- a/tests/Feature/Settings/SecuritySettingsTest.php
+++ b/tests/Feature/Settings/SecuritySettingsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature\Settings;
+
+use App\Models\User;
+use App\Support\Security\TwoFactorAuthenticator;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class SecuritySettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function user_can_revoke_an_active_session(): void
+    {
+        $user = User::factory()->create();
+        $sessionId = Str::random(40);
+
+        DB::table('sessions')->insert([
+            'id' => $sessionId,
+            'user_id' => $user->id,
+            'ip_address' => '127.0.0.1',
+            'user_agent' => 'Laravel Test',
+            'payload' => '',
+            'last_activity' => now()->timestamp,
+        ]);
+
+        $response = $this->actingAs($user)->delete(route('security.sessions.destroy', $sessionId));
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('sessions', ['id' => $sessionId]);
+    }
+
+    /** @test */
+    public function user_can_enable_confirm_and_refresh_multi_factor_authentication(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->post(route('security.mfa.store'))
+            ->assertRedirect();
+
+        $user->refresh();
+
+        $this->assertNotNull($user->two_factor_secret);
+        $this->assertNull($user->two_factor_confirmed_at);
+
+        $secret = TwoFactorAuthenticator::decryptSecret($user->two_factor_secret);
+        $this->assertNotNull($secret);
+
+        $frozenNow = Carbon::now();
+        Carbon::setTestNow($frozenNow);
+
+        $code = TwoFactorAuthenticator::code($secret, $frozenNow->timestamp);
+
+        $this->actingAs($user)
+            ->post(route('security.mfa.confirm'), ['code' => $code])
+            ->assertRedirect();
+
+        $user->refresh();
+
+        $this->assertNotNull($user->two_factor_confirmed_at);
+        $this->assertNotNull($user->two_factor_recovery_codes);
+
+        $initialRecoveryCodes = TwoFactorAuthenticator::decryptRecoveryCodes($user->two_factor_recovery_codes);
+        $this->assertCount(8, $initialRecoveryCodes);
+
+        $this->actingAs($user)
+            ->post(route('security.recovery-codes.store'))
+            ->assertRedirect();
+
+        $user->refresh();
+
+        $rotatedCodes = TwoFactorAuthenticator::decryptRecoveryCodes($user->two_factor_recovery_codes);
+        $this->assertCount(8, $rotatedCodes);
+        $this->assertNotEquals($initialRecoveryCodes, $rotatedCodes);
+
+        Carbon::setTestNow();
+    }
+}


### PR DESCRIPTION
## Summary
- add security navigation entry and Inertia page for managing sessions, multi-factor auth and recovery codes
- implement controllers and support utilities for listing sessions, issuing recovery codes, and enrolling or disabling TOTP MFA
- persist MFA metadata via a new migration, update user model visibility, and document the end-to-end security flows
- cover session revocation and MFA setup in a new feature test suite

## Testing
- php artisan test *(fails: vendor dependencies are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e45c84c734832ca2f78184723935d8