### PR TITLE
Enforce two-factor challenge during login

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -31,6 +31,17 @@ class AuthenticatedSessionController extends Controller
     {
         $request->authenticate();
 
+        $user = $request->user();
+
+        if ($user && $user->two_factor_confirmed_at) {
+            $request->session()->put('two_factor:id', $user->getKey());
+            $request->session()->put('two_factor:remember', $request->boolean('remember'));
+
+            Auth::logout();
+
+            return redirect()->route('two-factor.login');
+        }
+
         $request->session()->regenerate();
 
         return redirect()->intended(route('dashboard', absolute: false));

--- a/app/Http/Controllers/Auth/TwoFactorChallengeController.php
+++ b/app/Http/Controllers/Auth/TwoFactorChallengeController.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Support\Security\TwoFactorAuthenticator;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class TwoFactorChallengeController extends Controller
+{
+    /**
+     * Display the multi-factor authentication challenge screen.
+     */
+    public function create(Request $request): Response|RedirectResponse
+    {
+        if (! $request->session()->has('two_factor:id')) {
+            return redirect()->route('login');
+        }
+
+        return Inertia::render('auth/TwoFactorChallenge');
+    }
+
+    /**
+     * Handle an incoming multi-factor authentication challenge.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'code' => ['nullable', 'string'],
+            'recovery_code' => ['nullable', 'string'],
+        ]);
+
+        $userId = $request->session()->get('two_factor:id');
+
+        if (! $userId) {
+            $this->clearTwoFactorSession($request);
+
+            return redirect()->route('login');
+        }
+
+        $user = User::find($userId);
+
+        if (! $user || is_null($user->two_factor_confirmed_at)) {
+            $this->clearTwoFactorSession($request);
+
+            return redirect()->route('login');
+        }
+
+        $code = $request->string('code')->trim()->value();
+        $recoveryCode = Str::of($request->string('recovery_code')->value())
+            ->upper()
+            ->replace(' ', '')
+            ->value();
+
+        if ($code === '' && $recoveryCode === '') {
+            throw ValidationException::withMessages([
+                'code' => trans('auth.two_factor_code_required'),
+            ]);
+        }
+
+        if ($code !== '') {
+            $secret = TwoFactorAuthenticator::decryptSecret($user->two_factor_secret);
+
+            if (! $secret || ! TwoFactorAuthenticator::verify($secret, $code)) {
+                throw ValidationException::withMessages([
+                    'code' => trans('auth.two_factor_code_invalid'),
+                ]);
+            }
+        } else {
+            $recoveryCodes = TwoFactorAuthenticator::decryptRecoveryCodes($user->two_factor_recovery_codes);
+
+            if (! in_array($recoveryCode, $recoveryCodes, true)) {
+                throw ValidationException::withMessages([
+                    'recovery_code' => trans('auth.two_factor_recovery_code_invalid'),
+                ]);
+            }
+
+            $remainingCodes = array_values(array_diff($recoveryCodes, [$recoveryCode]));
+
+            $user->forceFill([
+                'two_factor_recovery_codes' => TwoFactorAuthenticator::encryptRecoveryCodes($remainingCodes),
+            ])->save();
+        }
+
+        $remember = (bool) $request->session()->pull('two_factor:remember', false);
+        $request->session()->forget('two_factor:id');
+
+        Auth::login($user, $remember);
+
+        $request->session()->regenerate();
+
+        return redirect()->intended(route('dashboard', absolute: false));
+    }
+
+    private function clearTwoFactorSession(Request $request): void
+    {
+        $request->session()->forget(['two_factor:id', 'two_factor:remember']);
+    }
+}

--- a/lang/en/auth.php
+++ b/lang/en/auth.php
@@ -5,4 +5,7 @@ return [
     'password' => 'The provided password is incorrect.',
     'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
     'banned' => 'Your account has been banned.',
+    'two_factor_code_required' => 'Please provide an authentication code or a recovery code.',
+    'two_factor_code_invalid' => 'The provided authentication code was invalid.',
+    'two_factor_recovery_code_invalid' => 'The recovery code is invalid or has already been used.',
 ];

--- a/resources/js/pages/auth/TwoFactorChallenge.vue
+++ b/resources/js/pages/auth/TwoFactorChallenge.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import InputError from '@/components/InputError.vue';
+import TextLink from '@/components/TextLink.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import AuthBase from '@/layouts/AuthLayout.vue';
+import { Head, useForm } from '@inertiajs/vue3';
+import { computed, ref } from 'vue';
+import { LoaderCircle } from 'lucide-vue-next';
+
+const useRecovery = ref(false);
+
+const form = useForm({
+    code: '',
+    recovery_code: '',
+});
+
+const title = computed(() => (useRecovery.value ? 'Use a recovery code' : 'Enter your authentication code'));
+const description = computed(() =>
+    useRecovery.value
+        ? 'Enter one of the recovery codes you saved when enabling multi-factor authentication.'
+        : 'Open your authenticator app (Authy, Google Authenticator, etc.) and enter the 6-digit verification code.'
+);
+
+const submit = () => {
+    if (useRecovery.value) {
+        form.code = '';
+    } else {
+        form.recovery_code = '';
+    }
+
+    form.post(route('two-factor.login'), {
+        preserveScroll: true,
+    });
+};
+
+const toggleMode = () => {
+    useRecovery.value = !useRecovery.value;
+    form.clearErrors();
+};
+</script>
+
+<template>
+    <AuthBase title="Two-factor authentication" description="Complete the challenge to access your account">
+        <Head title="Two-factor authentication" />
+
+        <form @submit.prevent="submit" class="flex flex-col gap-6">
+            <div class="grid gap-2">
+                <h2 class="text-lg font-semibold">{{ title }}</h2>
+                <p class="text-sm text-muted-foreground">{{ description }}</p>
+            </div>
+
+            <div v-if="!useRecovery" class="grid gap-2">
+                <Label for="code">Authentication code</Label>
+                <Input
+                    id="code"
+                    inputmode="numeric"
+                    autocomplete="one-time-code"
+                    placeholder="123456"
+                    maxlength="6"
+                    v-model="form.code"
+                    :disabled="form.processing"
+                    autofocus
+                />
+                <InputError :message="form.errors.code" />
+            </div>
+
+            <div v-else class="grid gap-2">
+                <Label for="recovery_code">Recovery code</Label>
+                <Input
+                    id="recovery_code"
+                    autocomplete="one-time-code"
+                    placeholder="ABCD-EFGH-IJKL"
+                    v-model="form.recovery_code"
+                    :disabled="form.processing"
+                    autofocus
+                />
+                <InputError :message="form.errors.recovery_code" />
+            </div>
+
+            <div class="space-y-2">
+                <Button type="submit" class="w-full" :disabled="form.processing">
+                    <LoaderCircle v-if="form.processing" class="h-4 w-4 animate-spin" />
+                    Continue
+                </Button>
+
+                <Button type="button" variant="link" class="w-full" @click="toggleMode">
+                    <span v-if="useRecovery">Use an authenticator code instead</span>
+                    <span v-else>Use a recovery code</span>
+                </Button>
+                <TextLink :href="route('login')" class="block text-center text-sm">Back to login</TextLink>
+            </div>
+        </form>
+    </AuthBase>
+</template>

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Auth\EmailVerificationPromptController;
 use App\Http\Controllers\Auth\NewPasswordController;
 use App\Http\Controllers\Auth\PasswordResetLinkController;
 use App\Http\Controllers\Auth\RegisteredUserController;
+use App\Http\Controllers\Auth\TwoFactorChallengeController;
 use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 
@@ -20,6 +21,11 @@ Route::middleware('guest')->group(function () {
         ->name('login');
 
     Route::post('login', [AuthenticatedSessionController::class, 'store']);
+
+    Route::get('two-factor-challenge', [TwoFactorChallengeController::class, 'create'])
+        ->name('two-factor.login');
+
+    Route::post('two-factor-challenge', [TwoFactorChallengeController::class, 'store']);
 
     Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
         ->name('password.request');

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\Auth;
 
 use App\Models\User;
+use App\Support\Security\TwoFactorAuthenticator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
 class AuthenticationTest extends TestCase
@@ -40,6 +42,98 @@ class AuthenticationTest extends TestCase
         ]);
 
         $this->assertGuest();
+    }
+
+    public function test_users_with_two_factor_enabled_are_redirected_to_the_challenge_screen()
+    {
+        $user = User::factory()->create();
+
+        $secret = TwoFactorAuthenticator::generateSecret();
+
+        $user->forceFill([
+            'two_factor_secret' => TwoFactorAuthenticator::encryptSecret($secret),
+            'two_factor_confirmed_at' => now(),
+            'two_factor_recovery_codes' => TwoFactorAuthenticator::encryptRecoveryCodes([
+                'TEST-ONE-USED',
+            ]),
+        ])->save();
+
+        $response = $this->post('/login', [
+            'email' => $user->email,
+            'password' => 'password',
+        ]);
+
+        $response->assertRedirect(route('two-factor.login'));
+        $response->assertSessionHas('two_factor:id', $user->id);
+        $this->assertGuest();
+    }
+
+    public function test_users_can_complete_two_factor_challenge_with_authenticator_code()
+    {
+        Carbon::setTestNow($now = Carbon::create(2024, 1, 1, 12));
+
+        $user = User::factory()->create();
+
+        $secret = TwoFactorAuthenticator::generateSecret();
+        $code = TwoFactorAuthenticator::code($secret, $now->timestamp);
+
+        $user->forceFill([
+            'two_factor_secret' => TwoFactorAuthenticator::encryptSecret($secret),
+            'two_factor_confirmed_at' => now(),
+            'two_factor_recovery_codes' => TwoFactorAuthenticator::encryptRecoveryCodes([
+                'TEST-RECOVERY-CODE',
+            ]),
+        ])->save();
+
+        $this->post('/login', [
+            'email' => $user->email,
+            'password' => 'password',
+        ])->assertRedirect(route('two-factor.login'));
+
+        $response = $this->post(route('two-factor.login'), [
+            'code' => $code,
+        ]);
+
+        $response->assertRedirect(route('dashboard', absolute: false));
+        $response->assertSessionMissing('two_factor:id');
+        $this->assertAuthenticatedAs($user);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_users_can_complete_two_factor_challenge_with_recovery_code()
+    {
+        $user = User::factory()->create();
+
+        $secret = TwoFactorAuthenticator::generateSecret();
+        $recoveryCode = 'ABCD-EFGH-IJKL';
+
+        $user->forceFill([
+            'two_factor_secret' => TwoFactorAuthenticator::encryptSecret($secret),
+            'two_factor_confirmed_at' => now(),
+            'two_factor_recovery_codes' => TwoFactorAuthenticator::encryptRecoveryCodes([
+                $recoveryCode,
+                'WXYZ-MNOP-QRST',
+            ]),
+        ])->save();
+
+        $this->post('/login', [
+            'email' => $user->email,
+            'password' => 'password',
+        ])->assertRedirect(route('two-factor.login'));
+
+        $response = $this->post(route('two-factor.login'), [
+            'recovery_code' => $recoveryCode,
+        ]);
+
+        $response->assertRedirect(route('dashboard', absolute: false));
+        $this->assertAuthenticatedAs($user);
+
+        $user->refresh();
+        $remainingCodes = TwoFactorAuthenticator::decryptRecoveryCodes($user->two_factor_recovery_codes);
+
+        $this->assertNotContains($recoveryCode, $remainingCodes);
+        $this->assertContains('WXYZ-MNOP-QRST', $remainingCodes);
     }
 
     public function test_users_can_logout()


### PR DESCRIPTION
## Summary
- redirect two-factor-enabled users to a dedicated challenge before completing the login session
- add the two-factor challenge controller, routes, translations, and Inertia view including recovery code handling
- expand authentication feature tests to cover the new challenge flow and recovery code consumption

## Testing
- Not run (composer install requires a GitHub token in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e485f5befc832cbe9e1748554aa15d