### PR TITLE
Ensure Inertia requests include CSRF token header

### DIFF
--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -1,6 +1,6 @@
 import '../css/app.css';
 
-import { createInertiaApp } from '@inertiajs/vue3';
+import { createInertiaApp, router } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import type { DefineComponent } from 'vue';
 import { createApp, h } from 'vue';
@@ -21,6 +21,14 @@ declare module 'vite/client' {
 }
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
+
+const csrfToken = document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content;
+
+if (csrfToken) {
+    router.on('before', (event) => {
+        event.detail.visit.headers['X-CSRF-TOKEN'] = csrfToken;
+    });
+}
 
 createInertiaApp({
     title: (title) => `${title} - ${appName}`,


### PR DESCRIPTION
## Summary
- add a global CSRF token lookup on app boot
- attach the token as an `X-CSRF-TOKEN` header for all Inertia visits to prevent 419 errors

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930b219a5ac832c8926cbc70f962e58)