### PR TITLE
Add polls/surveys system with admin UI, API endpoints, migrations and seeders

### DIFF
--- a/app/Http/Controllers/Admin/PollController.php
+++ b/app/Http/Controllers/Admin/PollController.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\PollRequest;
+use App\Models\Poll;
+use App\Models\PollOption;
+use App\Support\Localization\DateFormatter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use Inertia\Response;
+
+class PollController extends Controller
+{
+    public function index(Request $request): Response|JsonResponse
+    {
+        $formatter = DateFormatter::for($request->user());
+
+        $polls = Poll::query()
+            ->withCount(['options', 'votes'])
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(fn (Poll $poll) => [
+                'id' => $poll->id,
+                'title' => $poll->title,
+                'slug' => $poll->slug,
+                'status' => $poll->status,
+                'options_count' => $poll->options_count ?? 0,
+                'votes_count' => $poll->votes_count ?? 0,
+                'allow_multiple' => $poll->allow_multiple,
+                'starts_at' => $formatter->iso($poll->starts_at),
+                'ends_at' => $formatter->iso($poll->ends_at),
+                'created_at' => $formatter->iso($poll->created_at),
+                'updated_at' => $formatter->iso($poll->updated_at),
+            ])
+            ->values()
+            ->all();
+
+        if ($request->wantsJson()) {
+            return response()->json(['polls' => $polls]);
+        }
+
+        return inertia('acp/Polls', [
+            'polls' => $polls,
+        ]);
+    }
+
+    public function create(): Response
+    {
+        return inertia('acp/PollCreate');
+    }
+
+    public function store(PollRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        $poll = Poll::create([
+            'user_id' => $request->user()->id,
+            'title' => $validated['title'],
+            'slug' => $this->resolveSlug($validated['slug'] ?? null, $validated['title']),
+            'description' => $validated['description'] ?? null,
+            'status' => $validated['status'],
+            'allow_multiple' => $validated['allow_multiple'] ?? false,
+            'starts_at' => $validated['starts_at'] ?? null,
+            'ends_at' => $validated['ends_at'] ?? null,
+        ]);
+
+        $options = collect($validated['options'])->values();
+
+        $poll->options()->createMany(
+            $options->map(fn (array $option, int $index) => [
+                'label' => $option['label'],
+                'sort_order' => $index + 1,
+            ])->all()
+        );
+
+        return redirect()
+            ->route('acp.polls.index')
+            ->with('success', 'Poll created successfully.');
+    }
+
+    public function edit(Poll $poll): Response
+    {
+        $poll->load(['options' => fn ($query) => $query->withCount('votes')]);
+        $formatter = DateFormatter::for(request()->user());
+
+        $totalVotes = $poll->options->sum('votes_count');
+
+        return inertia('acp/PollEdit', [
+            'poll' => [
+                'id' => $poll->id,
+                'title' => $poll->title,
+                'slug' => $poll->slug,
+                'description' => $poll->description,
+                'status' => $poll->status,
+                'allow_multiple' => $poll->allow_multiple,
+                'starts_at' => $formatter->iso($poll->starts_at),
+                'ends_at' => $formatter->iso($poll->ends_at),
+                'created_at' => $formatter->iso($poll->created_at),
+                'updated_at' => $formatter->iso($poll->updated_at),
+                'total_votes' => $totalVotes,
+                'options' => $poll->options->map(fn (PollOption $option) => [
+                    'id' => $option->id,
+                    'label' => $option->label,
+                    'votes_count' => $option->votes_count ?? 0,
+                ])->values()->all(),
+            ],
+        ]);
+    }
+
+    public function update(PollRequest $request, Poll $poll): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        $poll->forceFill([
+            'title' => $validated['title'],
+            'slug' => $this->resolveSlug($validated['slug'] ?? null, $validated['title'], $poll->id),
+            'description' => $validated['description'] ?? null,
+            'status' => $validated['status'],
+            'allow_multiple' => $validated['allow_multiple'] ?? false,
+            'starts_at' => $validated['starts_at'] ?? null,
+            'ends_at' => $validated['ends_at'] ?? null,
+        ])->save();
+
+        $options = collect($validated['options'])->values();
+        $existingOptions = $poll->options()->get()->keyBy('id');
+        $incomingIds = $options->pluck('id')->filter()->values();
+
+        $invalidIds = $incomingIds->diff($existingOptions->keys());
+
+        if ($invalidIds->isNotEmpty()) {
+            throw ValidationException::withMessages([
+                'options' => 'One or more options are invalid.',
+            ]);
+        }
+
+        if ($incomingIds->isEmpty()) {
+            $poll->options()->delete();
+        } else {
+            $poll->options()->whereNotIn('id', $incomingIds)->delete();
+        }
+
+        $options->each(function (array $option, int $index) use ($poll, $existingOptions) {
+            if (isset($option['id']) && $existingOptions->has($option['id'])) {
+                $existingOptions[$option['id']]->forceFill([
+                    'label' => $option['label'],
+                    'sort_order' => $index + 1,
+                ])->save();
+
+                return;
+            }
+
+            $poll->options()->create([
+                'label' => $option['label'],
+                'sort_order' => $index + 1,
+            ]);
+        });
+
+        return redirect()
+            ->route('acp.polls.index')
+            ->with('success', 'Poll updated successfully.');
+    }
+
+    public function destroy(Poll $poll): RedirectResponse
+    {
+        $poll->delete();
+
+        return redirect()
+            ->route('acp.polls.index')
+            ->with('success', 'Poll deleted successfully.');
+    }
+
+    protected function resolveSlug(?string $slug, string $title, ?int $ignoreId = null): string
+    {
+        $candidate = Str::slug($slug ?: $title);
+
+        if ($candidate === '') {
+            $candidate = Str::random(8);
+        }
+
+        $original = $candidate;
+        $suffix = 1;
+
+        $query = Poll::query()->where('slug', $candidate);
+
+        if ($ignoreId) {
+            $query->where('id', '!=', $ignoreId);
+        }
+
+        while ($query->exists()) {
+            $candidate = $original.'-'.$suffix++;
+
+            $query = Poll::query()->where('slug', $candidate);
+
+            if ($ignoreId) {
+                $query->where('id', '!=', $ignoreId);
+            }
+        }
+
+        return $candidate;
+    }
+}

--- a/app/Http/Controllers/Api/V1/PollController.php
+++ b/app/Http/Controllers/Api/V1/PollController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\Poll;
+use App\Models\PollVote;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+
+class PollController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $polls = Poll::query()
+            ->whereIn('status', ['published', 'closed'])
+            ->with(['options' => fn ($query) => $query->withCount('votes')])
+            ->withCount('votes')
+            ->orderByDesc('created_at')
+            ->get();
+
+        $userVotes = $this->loadUserVotes($request->user(), $polls);
+
+        return response()->json([
+            'polls' => $polls->map(fn (Poll $poll) => $this->serializePoll($poll, $userVotes)),
+        ]);
+    }
+
+    public function show(Request $request, Poll $poll): JsonResponse
+    {
+        if (! in_array($poll->status, ['published', 'closed'], true)) {
+            abort(404);
+        }
+
+        $poll->load(['options' => fn ($query) => $query->withCount('votes')]);
+        $poll->loadCount('votes');
+
+        $userVotes = $this->loadUserVotes($request->user(), collect([$poll]));
+
+        return response()->json([
+            'poll' => $this->serializePoll($poll, $userVotes),
+        ]);
+    }
+
+    protected function loadUserVotes(?User $user, Collection $polls): Collection
+    {
+        if (! $user) {
+            return collect();
+        }
+
+        return PollVote::query()
+            ->where('user_id', $user->id)
+            ->whereIn('poll_id', $polls->pluck('id'))
+            ->get()
+            ->groupBy('poll_id');
+    }
+
+    protected function serializePoll(Poll $poll, Collection $userVotes): array
+    {
+        $totalVotes = $poll->votes_count ?? $poll->votes()->count();
+        $userVotesForPoll = $userVotes->get($poll->id, collect());
+        $userVoteOptionIds = $userVotesForPoll->pluck('poll_option_id')->values()->all();
+
+        return [
+            'id' => $poll->id,
+            'title' => $poll->title,
+            'slug' => $poll->slug,
+            'description' => $poll->description,
+            'status' => $poll->status,
+            'allow_multiple' => $poll->allow_multiple,
+            'starts_at' => $poll->starts_at?->toIso8601String(),
+            'ends_at' => $poll->ends_at?->toIso8601String(),
+            'total_votes' => $totalVotes,
+            'user_vote_option_ids' => $userVoteOptionIds,
+            'can_vote' => $poll->isOpen() && ($poll->allow_multiple || $userVoteOptionIds === []),
+            'options' => $poll->options->map(fn ($option) => [
+                'id' => $option->id,
+                'label' => $option->label,
+                'votes_count' => $option->votes_count ?? 0,
+                'vote_percent' => $totalVotes > 0
+                    ? round(($option->votes_count ?? 0) / $totalVotes * 100, 1)
+                    : 0,
+            ])->values()->all(),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/V1/PollVoteController.php
+++ b/app/Http/Controllers/Api/V1/PollVoteController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Poll;
 use App\Models\PollOption;
 use App\Models\PollVote;
+use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
@@ -47,11 +48,18 @@ class PollVoteController extends Controller
             ], 409);
         }
 
-        PollVote::create([
-            'poll_id' => $poll->id,
-            'poll_option_id' => $validated['option_id'],
-            'user_id' => $user->id,
-        ]);
+        try {
+            PollVote::create([
+                'poll_id' => $poll->id,
+                'poll_option_id' => $validated['option_id'],
+                'vote_key' => $poll->allow_multiple ? $validated['option_id'] : 0,
+                'user_id' => $user->id,
+            ]);
+        } catch (QueryException $exception) {
+            return response()->json([
+                'message' => 'You have already voted in this poll.',
+            ], 409);
+        }
 
         $poll->load(['options' => fn ($query) => $query->withCount('votes')]);
         $poll->loadCount('votes');

--- a/app/Http/Controllers/Api/V1/PollVoteController.php
+++ b/app/Http/Controllers/Api/V1/PollVoteController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\Poll;
+use App\Models\PollOption;
+use App\Models\PollVote;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class PollVoteController extends Controller
+{
+    public function store(Request $request, Poll $poll): JsonResponse
+    {
+        if (! $poll->isOpen()) {
+            return response()->json([
+                'message' => 'This poll is not open for voting.',
+            ], 422);
+        }
+
+        $validated = $request->validate([
+            'option_id' => [
+                'required',
+                'integer',
+                Rule::exists('poll_options', 'id')->where('poll_id', $poll->id),
+            ],
+        ]);
+
+        $user = $request->user();
+
+        $existingVotes = PollVote::query()
+            ->where('poll_id', $poll->id)
+            ->where('user_id', $user->id)
+            ->get();
+
+        if (! $poll->allow_multiple && $existingVotes->isNotEmpty()) {
+            return response()->json([
+                'message' => 'You have already voted in this poll.',
+            ], 409);
+        }
+
+        if ($poll->allow_multiple && $existingVotes->contains('poll_option_id', $validated['option_id'])) {
+            return response()->json([
+                'message' => 'You have already voted for this option.',
+            ], 409);
+        }
+
+        PollVote::create([
+            'poll_id' => $poll->id,
+            'poll_option_id' => $validated['option_id'],
+            'user_id' => $user->id,
+        ]);
+
+        $poll->load(['options' => fn ($query) => $query->withCount('votes')]);
+        $poll->loadCount('votes');
+
+        $totalVotes = $poll->votes_count ?? 0;
+
+        return response()->json([
+            'message' => 'Vote recorded successfully.',
+            'poll' => [
+                'id' => $poll->id,
+                'slug' => $poll->slug,
+                'status' => $poll->status,
+                'total_votes' => $totalVotes,
+                'options' => $poll->options->map(fn (PollOption $option) => [
+                    'id' => $option->id,
+                    'label' => $option->label,
+                    'votes_count' => $option->votes_count ?? 0,
+                    'vote_percent' => $totalVotes > 0
+                        ? round(($option->votes_count ?? 0) / $totalVotes * 100, 1)
+                        : 0,
+                ])->values()->all(),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Requests/Admin/PollRequest.php
+++ b/app/Http/Requests/Admin/PollRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class PollRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        foreach (['slug', 'starts_at', 'ends_at'] as $field) {
+            if ($this->has($field) && $this->input($field) === '') {
+                $this->merge([$field => null]);
+            }
+        }
+    }
+
+    public function rules(): array
+    {
+        $poll = $this->route('poll');
+
+        $pollId = $poll instanceof Model
+            ? $poll->getKey()
+            : (is_numeric($poll) ? (int) $poll : null);
+
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'nullable',
+                'string',
+                'max:255',
+                Rule::unique('polls', 'slug')->ignore($pollId),
+            ],
+            'description' => ['nullable', 'string'],
+            'status' => ['required', 'string', Rule::in(['draft', 'published', 'closed'])],
+            'allow_multiple' => ['sometimes', 'boolean'],
+            'starts_at' => ['nullable', 'date'],
+            'ends_at' => ['nullable', 'date', 'after:starts_at'],
+            'options' => ['required', 'array', 'min:2'],
+            'options.*.id' => ['nullable', 'integer', 'exists:poll_options,id'],
+            'options.*.label' => ['required', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Models/Poll.php
+++ b/app/Models/Poll.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Poll extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'title',
+        'slug',
+        'description',
+        'status',
+        'allow_multiple',
+        'starts_at',
+        'ends_at',
+    ];
+
+    protected $casts = [
+        'allow_multiple' => 'bool',
+        'starts_at' => 'datetime',
+        'ends_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function options(): HasMany
+    {
+        return $this->hasMany(PollOption::class)->orderBy('sort_order');
+    }
+
+    public function votes(): HasMany
+    {
+        return $this->hasMany(PollVote::class);
+    }
+
+    public function isOpen(): bool
+    {
+        if ($this->status !== 'published') {
+            return false;
+        }
+
+        if ($this->starts_at && $this->starts_at->isFuture()) {
+            return false;
+        }
+
+        if ($this->ends_at && $this->ends_at->isPast()) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/app/Models/PollOption.php
+++ b/app/Models/PollOption.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class PollOption extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'poll_id',
+        'label',
+        'sort_order',
+    ];
+
+    public function poll(): BelongsTo
+    {
+        return $this->belongsTo(Poll::class);
+    }
+
+    public function votes(): HasMany
+    {
+        return $this->hasMany(PollVote::class, 'poll_option_id');
+    }
+}

--- a/app/Models/PollVote.php
+++ b/app/Models/PollVote.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PollVote extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'poll_id',
+        'poll_option_id',
+        'user_id',
+    ];
+
+    public function poll(): BelongsTo
+    {
+        return $this->belongsTo(Poll::class);
+    }
+
+    public function option(): BelongsTo
+    {
+        return $this->belongsTo(PollOption::class, 'poll_option_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/PollVote.php
+++ b/app/Models/PollVote.php
@@ -13,6 +13,7 @@ class PollVote extends Model
     protected $fillable = [
         'poll_id',
         'poll_option_id',
+        'vote_key',
         'user_id',
     ];
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -170,6 +170,11 @@ class User extends Authenticatable implements MustVerifyEmail
         return $this->hasMany(BillingInvoice::class);
     }
 
+    public function pollVotes(): HasMany
+    {
+        return $this->hasMany(PollVote::class);
+    }
+
     /**
      * @param  list<string>|null  $candidateChannels
      * @return list<string>
@@ -294,4 +299,3 @@ class User extends Authenticatable implements MustVerifyEmail
         return $instance;
     }
 }
-

--- a/database/factories/PollFactory.php
+++ b/database/factories/PollFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Poll;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Poll>
+ */
+class PollFactory extends Factory
+{
+    protected $model = Poll::class;
+
+    public function definition(): array
+    {
+        $title = $this->faker->sentence(6);
+
+        return [
+            'user_id' => User::factory(),
+            'title' => $title,
+            'slug' => Str::slug($title).'-'.Str::random(5),
+            'description' => $this->faker->paragraph(),
+            'status' => 'draft',
+            'allow_multiple' => false,
+            'starts_at' => null,
+            'ends_at' => null,
+        ];
+    }
+
+    public function published(): self
+    {
+        return $this->state(fn () => [
+            'status' => 'published',
+            'starts_at' => null,
+            'ends_at' => null,
+        ]);
+    }
+
+    public function closed(): self
+    {
+        return $this->state(fn () => [
+            'status' => 'closed',
+        ]);
+    }
+
+    public function scheduled(): self
+    {
+        return $this->state(fn () => [
+            'status' => 'published',
+            'starts_at' => now()->addDay(),
+        ]);
+    }
+}

--- a/database/factories/PollOptionFactory.php
+++ b/database/factories/PollOptionFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Poll;
+use App\Models\PollOption;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PollOption>
+ */
+class PollOptionFactory extends Factory
+{
+    protected $model = PollOption::class;
+
+    public function definition(): array
+    {
+        return [
+            'poll_id' => Poll::factory(),
+            'label' => $this->faker->words(3, true),
+            'sort_order' => 1,
+        ];
+    }
+}

--- a/database/migrations/2025_02_14_000000_create_polls_table.php
+++ b/database/migrations/2025_02_14_000000_create_polls_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('polls', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->string('status')->default('draft');
+            $table->boolean('allow_multiple')->default(false);
+            $table->timestamp('starts_at')->nullable();
+            $table->timestamp('ends_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['status', 'starts_at', 'ends_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('polls');
+    }
+};

--- a/database/migrations/2025_02_14_000001_create_poll_options_table.php
+++ b/database/migrations/2025_02_14_000001_create_poll_options_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('poll_options', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('poll_id')->constrained()->cascadeOnDelete();
+            $table->string('label');
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->timestamps();
+
+            $table->index(['poll_id', 'sort_order']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('poll_options');
+    }
+};

--- a/database/migrations/2025_02_14_000002_create_poll_votes_table.php
+++ b/database/migrations/2025_02_14_000002_create_poll_votes_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('poll_votes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('poll_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('poll_option_id')->constrained('poll_options')->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['poll_id', 'user_id', 'poll_option_id']);
+            $table->index(['poll_id', 'user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('poll_votes');
+    }
+};

--- a/database/migrations/2025_02_14_000002_create_poll_votes_table.php
+++ b/database/migrations/2025_02_14_000002_create_poll_votes_table.php
@@ -12,10 +12,11 @@ return new class extends Migration
             $table->id();
             $table->foreignId('poll_id')->constrained()->cascadeOnDelete();
             $table->foreignId('poll_option_id')->constrained('poll_options')->cascadeOnDelete();
+            $table->unsignedBigInteger('vote_key')->default(0);
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->timestamps();
 
-            $table->unique(['poll_id', 'user_id', 'poll_option_id']);
+            $table->unique(['poll_id', 'user_id', 'vote_key']);
             $table->index(['poll_id', 'user_id']);
         });
     }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -28,6 +28,7 @@ class DatabaseSeeder extends Seeder
             TokenLogDemoSeeder::class,
             BadgeSeeder::class,
             CommerceDemoSeeder::class,
+            PollDemoSeeder::class,
         ]);
     }
 }

--- a/database/seeders/PollDemoSeeder.php
+++ b/database/seeders/PollDemoSeeder.php
@@ -57,6 +57,7 @@ class PollDemoSeeder extends Seeder
             PollVote::create([
                 'poll_id' => $poll->id,
                 'poll_option_id' => $option->id,
+                'vote_key' => $poll->allow_multiple ? $option->id : 0,
                 'user_id' => $voter->id,
             ]);
         }

--- a/database/seeders/PollDemoSeeder.php
+++ b/database/seeders/PollDemoSeeder.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Poll;
+use App\Models\PollOption;
+use App\Models\PollVote;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class PollDemoSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $user = User::query()->first();
+
+        if (! $user) {
+            return;
+        }
+
+        $poll = Poll::updateOrCreate(
+            ['slug' => 'favorite-product-update'],
+            [
+                'user_id' => $user->id,
+                'title' => 'Which product update excites you most?',
+                'description' => 'Help us prioritize upcoming releases by voting for the update you want to see next.',
+                'status' => 'published',
+                'allow_multiple' => false,
+                'starts_at' => now()->subDays(2),
+                'ends_at' => now()->addDays(5),
+            ]
+        );
+
+        $optionLabels = [
+            'Real-time collaboration',
+            'Advanced analytics dashboard',
+            'Mobile offline mode',
+            'New automation templates',
+        ];
+
+        $poll->options()->delete();
+
+        $options = collect($optionLabels)
+            ->map(fn (string $label, int $index) => PollOption::create([
+                'poll_id' => $poll->id,
+                'label' => $label,
+                'sort_order' => $index + 1,
+            ]));
+
+        $voters = User::query()->take(6)->get();
+
+        PollVote::query()->where('poll_id', $poll->id)->delete();
+
+        foreach ($voters as $voter) {
+            $option = $options->random();
+
+            PollVote::create([
+                'poll_id' => $poll->id,
+                'poll_option_id' => $option->id,
+                'user_id' => $voter->id,
+            ]);
+        }
+    }
+}

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -34,6 +34,7 @@ class RolePermissionSeeder extends Seeder
             'trust_safety',
             'search',
             'commerce',
+            'polls',
         ];
 
         foreach ($permissions as $permission) {
@@ -71,6 +72,16 @@ class RolePermissionSeeder extends Seeder
 
         // Optionally assign all permissions to admin
         $adminRole->syncPermissions(Permission::all());
+
+        $editorRole->givePermissionTo([
+            'polls.acp.view',
+            'polls.acp.create',
+            'polls.acp.edit',
+        ]);
+
+        $moderatorRole->givePermissionTo([
+            'polls.acp.view',
+        ]);
 
         // Assign the admin role to the user with ID 1, if the user exists
         $user = User::find(1);

--- a/resources/js/layouts/acp/AdminLayout.vue
+++ b/resources/js/layouts/acp/AdminLayout.vue
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { type NavItem, type SharedData } from '@/types';
 import { Link, usePage } from '@inertiajs/vue3';
-import { LayoutGrid, User, Shield, BookOpen, MessageSquare, LifeBuoy, Settings, Key, ShieldAlert, Award, CreditCard, Layers, ShieldCheck, Webhook, MessageCircle, Search, ShoppingBag } from 'lucide-vue-next';
+import { LayoutGrid, User, Shield, BookOpen, MessageSquare, LifeBuoy, Settings, Key, ShieldAlert, Award, CreditCard, Layers, ShieldCheck, Webhook, MessageCircle, Search, ShoppingBag, Vote } from 'lucide-vue-next';
 
 import { useRoles } from '@/composables/useRoles';
 import { usePermissions } from '@/composables/usePermissions';
@@ -19,6 +19,7 @@ const manageACL = computed(() => hasPermission('acl.acp.view'));
 const manageBlogs = computed(() => hasPermission('blogs.acp.view'));
 const manageForums = computed(() => hasPermission('forums.acp.view'));
 const manageSupport = computed(() => hasPermission('support.acp.view'));
+const managePolls = computed(() => hasPermission('polls.acp.view'));
 const manageTokens = computed(() => hasPermission('tokens.acp.view'));
 const manageBilling = computed(() => hasPermission('billing.acp.view'));
 const manageCommerce = computed(() => hasPermission('commerce.acp.view'));
@@ -87,6 +88,12 @@ const sidebarNavItems: NavItem[] = [
         href: '/acp/support',
         target: '_self',
         icon: LifeBuoy,
+    },
+    {
+        title: 'Polls',
+        href: '/acp/polls',
+        target: '_self',
+        icon: Vote,
     },
     {
         title: 'Commerce',
@@ -171,6 +178,8 @@ const filteredNavItems = computed(() => {
                 return manageReputation.value || isAdmin.value;
             case 'Support':
                 return manageSupport.value && websiteSections.value.support;
+            case 'Polls':
+                return managePolls.value;
             case 'Commerce':
                 return manageCommerce.value && websiteSections.value.commerce;
             case 'Trust & Safety':

--- a/resources/js/pages/acp/PollCreate.vue
+++ b/resources/js/pages/acp/PollCreate.vue
@@ -1,0 +1,197 @@
+<script setup lang="ts">
+import { Head, Link, useForm } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import InputError from '@/components/InputError.vue';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+import { PlusCircle, Trash2 } from 'lucide-vue-next';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Polls ACP', href: route('acp.polls.index') },
+    { title: 'Create poll', href: route('acp.polls.create') },
+];
+
+const form = useForm({
+    title: '',
+    slug: '',
+    description: '',
+    status: 'draft',
+    allow_multiple: false,
+    starts_at: '',
+    ends_at: '',
+    options: [
+        { label: '' },
+        { label: '' },
+    ],
+});
+
+const addOption = () => {
+    form.options.push({ label: '' });
+};
+
+const removeOption = (index: number) => {
+    if (form.options.length <= 2) {
+        return;
+    }
+
+    form.options.splice(index, 1);
+};
+
+const handleSubmit = () => {
+    form.post(route('acp.polls.store'), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Create poll" />
+
+        <AdminLayout>
+            <form class="flex flex-1 flex-col gap-6" @submit.prevent="handleSubmit">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">Create poll</h1>
+                        <p class="text-sm text-muted-foreground">
+                            Launch a poll or survey to capture quick feedback from your community.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2">
+                        <Button variant="outline" as-child>
+                            <Link :href="route('acp.polls.index')">Cancel</Link>
+                        </Button>
+                        <Button type="submit" :disabled="form.processing">Save poll</Button>
+                    </div>
+                </div>
+
+                <Card>
+                    <CardHeader class="relative overflow-hidden">
+                        <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                        <div class="relative space-y-1">
+                            <CardTitle>Poll details</CardTitle>
+                            <CardDescription>
+                                Provide the question, visibility settings, and schedule for the poll.
+                            </CardDescription>
+                        </div>
+                    </CardHeader>
+                    <CardContent class="space-y-6">
+                        <div class="grid gap-2">
+                            <Label for="title">Title</Label>
+                            <Input id="title" v-model="form.title" type="text" autocomplete="off" required />
+                            <InputError :message="form.errors.title" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="slug">Slug</Label>
+                            <Input
+                                id="slug"
+                                v-model="form.slug"
+                                type="text"
+                                autocomplete="off"
+                                placeholder="Leave blank to auto-generate"
+                            />
+                            <InputError :message="form.errors.slug" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="description">Description</Label>
+                            <Textarea
+                                id="description"
+                                v-model="form.description"
+                                rows="4"
+                                placeholder="Add context or additional instructions for voters."
+                            />
+                            <InputError :message="form.errors.description" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="status">Status</Label>
+                            <select
+                                id="status"
+                                v-model="form.status"
+                                class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                            >
+                                <option value="draft">Draft</option>
+                                <option value="published">Published</option>
+                                <option value="closed">Closed</option>
+                            </select>
+                            <InputError :message="form.errors.status" />
+                        </div>
+
+                        <div class="flex items-center justify-between rounded-lg border border-dashed border-muted-foreground/30 p-4">
+                            <div>
+                                <p class="text-sm font-medium">Allow multiple selections</p>
+                                <p class="text-xs text-muted-foreground">
+                                    Enable voters to select more than one option.
+                                </p>
+                            </div>
+                            <Switch v-model:checked="form.allow_multiple" />
+                        </div>
+
+                        <div class="grid gap-4 sm:grid-cols-2">
+                            <div class="grid gap-2">
+                                <Label for="starts_at">Starts at</Label>
+                                <Input id="starts_at" v-model="form.starts_at" type="datetime-local" />
+                                <InputError :message="form.errors.starts_at" />
+                            </div>
+                            <div class="grid gap-2">
+                                <Label for="ends_at">Ends at</Label>
+                                <Input id="ends_at" v-model="form.ends_at" type="datetime-local" />
+                                <InputError :message="form.errors.ends_at" />
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Answer options</CardTitle>
+                        <CardDescription>List at least two options for participants to choose from.</CardDescription>
+                    </CardHeader>
+                    <CardContent class="space-y-4">
+                        <div v-for="(option, index) in form.options" :key="index" class="flex flex-col gap-2 sm:flex-row sm:items-center">
+                            <div class="flex-1">
+                                <Label :for="`option-${index}`" class="sr-only">Option {{ index + 1 }}</Label>
+                                <Input
+                                    :id="`option-${index}`"
+                                    v-model="option.label"
+                                    type="text"
+                                    autocomplete="off"
+                                    placeholder="Option label"
+                                />
+                            </div>
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                :disabled="form.options.length <= 2"
+                                @click="removeOption(index)"
+                            >
+                                <Trash2 class="h-4 w-4" />
+                                Remove
+                            </Button>
+                        </div>
+                        <InputError :message="form.errors.options" />
+                        <Button type="button" variant="secondary" size="sm" @click="addOption">
+                            <PlusCircle class="h-4 w-4" />
+                            Add option
+                        </Button>
+                    </CardContent>
+                    <CardFooter class="justify-end gap-2">
+                        <Button type="submit" :disabled="form.processing">Save poll</Button>
+                    </CardFooter>
+                </Card>
+            </form>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/PollEdit.vue
+++ b/resources/js/pages/acp/PollEdit.vue
@@ -1,0 +1,257 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Head, Link, useForm } from '@inertiajs/vue3';
+import dayjs from 'dayjs';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import InputError from '@/components/InputError.vue';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+import { PlusCircle, Trash2 } from 'lucide-vue-next';
+
+interface PollOption {
+    id: number;
+    label: string;
+    votes_count: number;
+}
+
+interface PollPayload {
+    id: number;
+    title: string;
+    slug: string;
+    description: string | null;
+    status: string;
+    allow_multiple: boolean;
+    starts_at: string | null;
+    ends_at: string | null;
+    created_at: string | null;
+    updated_at: string | null;
+    total_votes: number;
+    options: PollOption[];
+}
+
+const props = defineProps<{
+    poll: PollPayload;
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Polls ACP', href: route('acp.polls.index') },
+    { title: props.poll.title, href: route('acp.polls.edit', { poll: props.poll.id }) },
+];
+
+const toLocalInput = (value: string | null) => {
+    if (!value) {
+        return '';
+    }
+
+    return dayjs(value).local().format('YYYY-MM-DDTHH:mm');
+};
+
+const form = useForm({
+    title: props.poll.title,
+    slug: props.poll.slug,
+    description: props.poll.description ?? '',
+    status: props.poll.status,
+    allow_multiple: props.poll.allow_multiple,
+    starts_at: toLocalInput(props.poll.starts_at),
+    ends_at: toLocalInput(props.poll.ends_at),
+    options: props.poll.options.map((option) => ({
+        id: option.id,
+        label: option.label,
+    })),
+});
+
+const totalVotes = computed(() => props.poll.total_votes);
+
+const optionPercent = (votes: number) => {
+    if (totalVotes.value === 0) {
+        return 0;
+    }
+
+    return Math.round((votes / totalVotes.value) * 1000) / 10;
+};
+
+const addOption = () => {
+    form.options.push({ label: '' });
+};
+
+const removeOption = (index: number) => {
+    if (form.options.length <= 2) {
+        return;
+    }
+
+    form.options.splice(index, 1);
+};
+
+const handleSubmit = () => {
+    form.put(route('acp.polls.update', { poll: props.poll.id }), {
+        preserveScroll: true,
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head :title="`Edit poll: ${poll.title}`" />
+
+        <AdminLayout>
+            <form class="flex flex-1 flex-col gap-6" @submit.prevent="handleSubmit">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">Edit poll</h1>
+                        <p class="text-sm text-muted-foreground">
+                            Update the poll details, refresh answer options, and monitor live responses.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2">
+                        <Button variant="outline" as-child>
+                            <Link :href="route('acp.polls.index')">Back to polls</Link>
+                        </Button>
+                        <Button type="submit" :disabled="form.processing">Save changes</Button>
+                    </div>
+                </div>
+
+                <Card>
+                    <CardHeader class="relative overflow-hidden">
+                        <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                        <div class="relative space-y-1">
+                            <CardTitle>Poll details</CardTitle>
+                            <CardDescription>Review the poll question, schedule, and visibility settings.</CardDescription>
+                        </div>
+                    </CardHeader>
+                    <CardContent class="space-y-6">
+                        <div class="grid gap-2">
+                            <Label for="title">Title</Label>
+                            <Input id="title" v-model="form.title" type="text" autocomplete="off" required />
+                            <InputError :message="form.errors.title" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="slug">Slug</Label>
+                            <Input id="slug" v-model="form.slug" type="text" autocomplete="off" />
+                            <InputError :message="form.errors.slug" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="description">Description</Label>
+                            <Textarea id="description" v-model="form.description" rows="4" />
+                            <InputError :message="form.errors.description" />
+                        </div>
+
+                        <div class="grid gap-2">
+                            <Label for="status">Status</Label>
+                            <select
+                                id="status"
+                                v-model="form.status"
+                                class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                            >
+                                <option value="draft">Draft</option>
+                                <option value="published">Published</option>
+                                <option value="closed">Closed</option>
+                            </select>
+                            <InputError :message="form.errors.status" />
+                        </div>
+
+                        <div class="flex items-center justify-between rounded-lg border border-dashed border-muted-foreground/30 p-4">
+                            <div>
+                                <p class="text-sm font-medium">Allow multiple selections</p>
+                                <p class="text-xs text-muted-foreground">
+                                    Enable voters to choose more than one option.
+                                </p>
+                            </div>
+                            <Switch v-model:checked="form.allow_multiple" />
+                        </div>
+
+                        <div class="grid gap-4 sm:grid-cols-2">
+                            <div class="grid gap-2">
+                                <Label for="starts_at">Starts at</Label>
+                                <Input id="starts_at" v-model="form.starts_at" type="datetime-local" />
+                                <InputError :message="form.errors.starts_at" />
+                            </div>
+                            <div class="grid gap-2">
+                                <Label for="ends_at">Ends at</Label>
+                                <Input id="ends_at" v-model="form.ends_at" type="datetime-local" />
+                                <InputError :message="form.errors.ends_at" />
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Answer options</CardTitle>
+                        <CardDescription>Maintain the options available to voters.</CardDescription>
+                    </CardHeader>
+                    <CardContent class="space-y-4">
+                        <div v-for="(option, index) in form.options" :key="option.id ?? index" class="flex flex-col gap-2 sm:flex-row sm:items-center">
+                            <div class="flex-1">
+                                <Label :for="`option-${index}`" class="sr-only">Option {{ index + 1 }}</Label>
+                                <Input
+                                    :id="`option-${index}`"
+                                    v-model="option.label"
+                                    type="text"
+                                    autocomplete="off"
+                                    placeholder="Option label"
+                                />
+                            </div>
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                :disabled="form.options.length <= 2"
+                                @click="removeOption(index)"
+                            >
+                                <Trash2 class="h-4 w-4" />
+                                Remove
+                            </Button>
+                        </div>
+                        <InputError :message="form.errors.options" />
+                        <Button type="button" variant="secondary" size="sm" @click="addOption">
+                            <PlusCircle class="h-4 w-4" />
+                            Add option
+                        </Button>
+                    </CardContent>
+                    <CardFooter class="justify-end">
+                        <Button type="submit" :disabled="form.processing">Save changes</Button>
+                    </CardFooter>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Live results</CardTitle>
+                        <CardDescription>Review current vote totals for this poll.</CardDescription>
+                    </CardHeader>
+                    <CardContent class="space-y-4">
+                        <div class="text-sm text-muted-foreground">
+                            Total votes: <span class="font-semibold text-foreground">{{ totalVotes }}</span>
+                        </div>
+                        <div class="space-y-3">
+                            <div v-for="option in props.poll.options" :key="option.id" class="space-y-1">
+                                <div class="flex items-center justify-between text-sm">
+                                    <span class="font-medium">{{ option.label }}</span>
+                                    <span class="text-xs text-muted-foreground">
+                                        {{ option.votes_count }} votes · {{ optionPercent(option.votes_count) }}%
+                                    </span>
+                                </div>
+                                <div class="h-2 w-full overflow-hidden rounded-full bg-muted">
+                                    <div
+                                        class="h-full rounded-full bg-primary"
+                                        :style="{ width: `${optionPercent(option.votes_count)}%` }"
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+            </form>
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/acp/Polls.vue
+++ b/resources/js/pages/acp/Polls.vue
@@ -1,0 +1,196 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+
+import AppLayout from '@/layouts/AppLayout.vue';
+import AdminLayout from '@/layouts/acp/AdminLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import ConfirmDialog from '@/components/ConfirmDialog.vue';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import PlaceholderPattern from '@/components/PlaceholderPattern.vue';
+import { useUserTimezone } from '@/composables/useUserTimezone';
+import { Pencil, PlusCircle, Trash2, Vote } from 'lucide-vue-next';
+
+type PollSummary = {
+    id: number;
+    title: string;
+    slug: string;
+    status: string;
+    options_count: number;
+    votes_count: number;
+    allow_multiple: boolean;
+    starts_at: string | null;
+    ends_at: string | null;
+    created_at: string | null;
+    updated_at: string | null;
+};
+
+const props = defineProps<{
+    polls: PollSummary[];
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Polls ACP', href: route('acp.polls.index') },
+];
+
+const hasPolls = computed(() => props.polls.length > 0);
+const { formatDate } = useUserTimezone();
+
+const deleteDialogOpen = ref(false);
+const pendingPoll = ref<PollSummary | null>(null);
+const deletingPollId = ref<number | null>(null);
+
+const deleteDialogTitle = computed(() => {
+    const target = pendingPoll.value;
+
+    if (!target) {
+        return 'Delete poll?';
+    }
+
+    return `Delete “${target.title}”?`;
+});
+
+watch(deleteDialogOpen, (open) => {
+    if (!open) {
+        pendingPoll.value = null;
+    }
+});
+
+const deletePoll = (poll: PollSummary) => {
+    pendingPoll.value = poll;
+    deleteDialogOpen.value = true;
+};
+
+const cancelDeletePoll = () => {
+    deleteDialogOpen.value = false;
+};
+
+const confirmDeletePoll = () => {
+    const target = pendingPoll.value;
+
+    if (!target) {
+        deleteDialogOpen.value = false;
+        return;
+    }
+
+    deletingPollId.value = target.id;
+    deleteDialogOpen.value = false;
+
+    router.delete(route('acp.polls.destroy', { poll: target.id }), {
+        preserveScroll: true,
+        onFinish: () => {
+            deletingPollId.value = null;
+        },
+    });
+};
+
+const statusBadge = (status: string) => {
+    switch (status) {
+        case 'published':
+            return 'default';
+        case 'closed':
+            return 'secondary';
+        default:
+            return 'outline';
+    }
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Manage polls" />
+
+        <AdminLayout>
+            <Card class="flex-1">
+                <CardHeader class="relative overflow-hidden">
+                    <PlaceholderPattern class="absolute inset-0 opacity-10" />
+                    <div class="relative flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <CardTitle class="flex items-center gap-2">
+                                <Vote class="h-5 w-5" />
+                                Polls & Surveys
+                            </CardTitle>
+                            <CardDescription>
+                                Create time-bound polls, track responses, and share live results with your community.
+                            </CardDescription>
+                        </div>
+                        <Button variant="secondary" as-child>
+                            <Link :href="route('acp.polls.create')">
+                                <PlusCircle class="h-4 w-4" />
+                                Create poll
+                            </Link>
+                        </Button>
+                    </div>
+                </CardHeader>
+                <CardContent>
+                    <div v-if="!hasPolls" class="rounded-lg border border-dashed border-muted-foreground/40 p-6 text-center text-sm text-muted-foreground">
+                        No polls have been created yet. Use the button above to add the first poll.
+                    </div>
+
+                    <div v-else class="overflow-x-auto">
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead class="w-1/3">Title</TableHead>
+                                    <TableHead>Status</TableHead>
+                                    <TableHead class="text-center">Options</TableHead>
+                                    <TableHead class="text-center">Votes</TableHead>
+                                    <TableHead class="text-center">Schedule</TableHead>
+                                    <TableHead class="text-right">Actions</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                <TableRow v-for="poll in props.polls" :key="poll.id">
+                                    <TableCell>
+                                        <div class="space-y-1">
+                                            <div class="font-medium">{{ poll.title }}</div>
+                                            <div class="text-xs text-muted-foreground">/{{ poll.slug }}</div>
+                                        </div>
+                                    </TableCell>
+                                    <TableCell>
+                                        <Badge :variant="statusBadge(poll.status)">{{ poll.status }}</Badge>
+                                    </TableCell>
+                                    <TableCell class="text-center font-semibold">{{ poll.options_count }}</TableCell>
+                                    <TableCell class="text-center font-semibold">{{ poll.votes_count }}</TableCell>
+                                    <TableCell class="text-center text-xs text-muted-foreground">
+                                        <div>
+                                            {{ poll.starts_at ? formatDate(poll.starts_at, 'MMM D, YYYY h:mm A') : 'Starts anytime' }}
+                                        </div>
+                                        <div>
+                                            {{ poll.ends_at ? formatDate(poll.ends_at, 'MMM D, YYYY h:mm A') : 'No end date' }}
+                                        </div>
+                                    </TableCell>
+                                    <TableCell class="flex justify-end gap-2">
+                                        <Button variant="outline" size="sm" as-child>
+                                            <Link :href="route('acp.polls.edit', { poll: poll.id })">
+                                                <Pencil class="h-4 w-4" />
+                                                Edit
+                                            </Link>
+                                        </Button>
+                                        <Button variant="destructive" size="sm" @click="deletePoll(poll)">
+                                            <Trash2 class="h-4 w-4" />
+                                            Delete
+                                        </Button>
+                                    </TableCell>
+                                </TableRow>
+                            </TableBody>
+                        </Table>
+                    </div>
+                </CardContent>
+            </Card>
+            <ConfirmDialog
+                v-model:open="deleteDialogOpen"
+                :title="deleteDialogTitle"
+                description="This action cannot be undone."
+                confirm-label="Delete"
+                cancel-label="Cancel"
+                :confirm-disabled="deletingPollId !== null"
+                @confirm="confirmDeletePoll"
+                @cancel="cancelDeletePoll"
+            />
+        </AdminLayout>
+    </AppLayout>
+</template>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\Admin\BillingWebhookCallController;
 use App\Http\Controllers\Admin\SubscriptionPlanController;
 use App\Http\Controllers\Admin\SearchAnalyticsController;
 use App\Http\Controllers\Admin\TrustSafetyController;
+use App\Http\Controllers\Admin\PollController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -238,6 +239,26 @@ Route::middleware(['auth', 'role:admin|editor|moderator'])->group(function () {
     Route::get('acp/reputation/badges/{badge}/edit', [BadgeController::class, 'edit'])->name('acp.reputation.badges.edit');
     Route::put('acp/reputation/badges/{badge}', [BadgeController::class, 'update'])->name('acp.reputation.badges.update');
     Route::delete('acp/reputation/badges/{badge}', [BadgeController::class, 'destroy'])->name('acp.reputation.badges.destroy');
+
+    // Polls
+    Route::get('acp/polls', [PollController::class, 'index'])
+        ->middleware('can:polls.acp.view')
+        ->name('acp.polls.index');
+    Route::get('acp/polls/create', [PollController::class, 'create'])
+        ->middleware('can:polls.acp.create')
+        ->name('acp.polls.create');
+    Route::post('acp/polls', [PollController::class, 'store'])
+        ->middleware('can:polls.acp.create')
+        ->name('acp.polls.store');
+    Route::get('acp/polls/{poll}/edit', [PollController::class, 'edit'])
+        ->middleware('can:polls.acp.edit')
+        ->name('acp.polls.edit');
+    Route::put('acp/polls/{poll}', [PollController::class, 'update'])
+        ->middleware('can:polls.acp.edit')
+        ->name('acp.polls.update');
+    Route::delete('acp/polls/{poll}', [PollController::class, 'destroy'])
+        ->middleware('can:polls.acp.delete')
+        ->name('acp.polls.destroy');
 
     // Tokens
     Route::get('acp/tokens', [TokenController::class,'index'])->name('acp.tokens.index');

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,8 @@ use App\Http\Controllers\Api\V1\ForumThreadController;
 use App\Http\Controllers\Api\V1\ForumThreadCommandController;
 use App\Http\Controllers\Api\V1\ForumThreadModerationController as ApiForumThreadModerationController;
 use App\Http\Controllers\Api\V1\ForumThreadSubscriptionController;
+use App\Http\Controllers\Api\V1\PollController;
+use App\Http\Controllers\Api\V1\PollVoteController;
 use App\Http\Controllers\Api\V1\Support\SupportTicketController;
 use App\Http\Controllers\Api\V1\Support\SupportTicketMessageController;
 use App\Http\Controllers\Api\V1\Support\SupportTicketRatingController;
@@ -72,6 +74,13 @@ Route::prefix('v1')->name('api.v1.')->group(function () {
                     ->name('blogs.comments.subscriptions.destroy');
             });
         });
+    });
+
+    Route::get('/polls', [PollController::class, 'index'])->name('polls.index');
+    Route::get('/polls/{poll:slug}', [PollController::class, 'show'])->name('polls.show');
+
+    Route::middleware(['auth:sanctum', 'token.throttle', 'token.activity', 'throttle:20,1'])->group(function () {
+        Route::post('/polls/{poll:slug}/vote', [PollVoteController::class, 'store'])->name('polls.vote');
     });
 
     Route::middleware('section.enabled:forum')->group(function () {

--- a/tests/Feature/Api/PollApiTest.php
+++ b/tests/Feature/Api/PollApiTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Poll;
+use App\Models\PollOption;
+use App\Models\PollVote;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PollApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function tokenHeaders(User $user): array
+    {
+        $token = $user->createToken('API Client')->plainTextToken;
+
+        return [
+            'Authorization' => 'Bearer '.$token,
+            'Accept' => 'application/json',
+        ];
+    }
+
+    public function test_it_lists_published_and_closed_polls(): void
+    {
+        Poll::factory()->published()->create(['title' => 'Published poll']);
+        Poll::factory()->closed()->create(['title' => 'Closed poll']);
+        Poll::factory()->create(['title' => 'Draft poll']);
+
+        $response = $this->getJson('/api/v1/polls');
+
+        $response->assertOk()
+            ->assertJsonCount(2, 'polls')
+            ->assertJsonFragment(['title' => 'Published poll'])
+            ->assertJsonFragment(['title' => 'Closed poll'])
+            ->assertJsonMissing(['title' => 'Draft poll']);
+    }
+
+    public function test_it_shows_poll_details(): void
+    {
+        $poll = Poll::factory()->published()->create();
+        PollOption::factory()->count(2)->create(['poll_id' => $poll->id]);
+
+        $this->getJson('/api/v1/polls/'.$poll->slug)
+            ->assertOk()
+            ->assertJsonPath('poll.id', $poll->id)
+            ->assertJsonCount(2, 'poll.options');
+    }
+
+    public function test_single_choice_poll_prevents_second_vote(): void
+    {
+        $user = User::factory()->create();
+        $poll = Poll::factory()->published()->create(['allow_multiple' => false]);
+        $options = PollOption::factory()->count(2)->create(['poll_id' => $poll->id]);
+        $headers = $this->tokenHeaders($user);
+
+        $this->withHeaders($headers)
+            ->postJson('/api/v1/polls/'.$poll->slug.'/vote', ['option_id' => $options[0]->id])
+            ->assertOk();
+
+        $this->withHeaders($headers)
+            ->postJson('/api/v1/polls/'.$poll->slug.'/vote', ['option_id' => $options[1]->id])
+            ->assertStatus(409);
+
+        $this->assertSame(1, PollVote::query()->count());
+    }
+
+    public function test_multi_choice_poll_allows_multiple_options(): void
+    {
+        $user = User::factory()->create();
+        $poll = Poll::factory()->published()->create(['allow_multiple' => true]);
+        $options = PollOption::factory()->count(2)->create(['poll_id' => $poll->id]);
+        $headers = $this->tokenHeaders($user);
+
+        $this->withHeaders($headers)
+            ->postJson('/api/v1/polls/'.$poll->slug.'/vote', ['option_id' => $options[0]->id])
+            ->assertOk();
+
+        $this->withHeaders($headers)
+            ->postJson('/api/v1/polls/'.$poll->slug.'/vote', ['option_id' => $options[1]->id])
+            ->assertOk();
+
+        $this->withHeaders($headers)
+            ->postJson('/api/v1/polls/'.$poll->slug.'/vote', ['option_id' => $options[0]->id])
+            ->assertStatus(409);
+
+        $this->assertSame(2, PollVote::query()->count());
+    }
+}

--- a/tests/Unit/PollTest.php
+++ b/tests/Unit/PollTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Poll;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PollTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_is_open_requires_published_status(): void
+    {
+        $poll = Poll::factory()->create(['status' => 'draft']);
+
+        $this->assertFalse($poll->isOpen());
+    }
+
+    public function test_is_open_respects_start_and_end_windows(): void
+    {
+        $futurePoll = Poll::factory()->published()->create(['starts_at' => now()->addHour()]);
+        $pastPoll = Poll::factory()->published()->create(['ends_at' => now()->subHour()]);
+        $openPoll = Poll::factory()->published()->create(['starts_at' => now()->subHour(), 'ends_at' => now()->addHour()]);
+
+        $this->assertFalse($futurePoll->isOpen());
+        $this->assertFalse($pastPoll->isOpen());
+        $this->assertTrue($openPoll->isOpen());
+    }
+
+    public function test_is_open_false_for_closed_polls(): void
+    {
+        $poll = Poll::factory()->closed()->create();
+
+        $this->assertFalse($poll->isOpen());
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a robust polling/survey feature so admins can create/manage polls and users can vote and view live results.
- Integrate polls into the existing ACP navigation and permission model so access is role-aware and consistent with other admin sections.
- Expose read and write APIs so frontend clients and third-party integrations can list polls, show details, and submit votes.
- Include demo data for quick verification and local development via the seeders.

### Description
- Added database migrations and Eloquent models for polls, poll options, and poll votes (`database/migrations/*_create_polls*.php`, `app/Models/Poll.php`, `app/Models/PollOption.php`, `app/Models/PollVote.php`).
- Implemented admin controller and request validation for ACP management (`app/Http/Controllers/Admin/PollController.php`, `app/Http/Requests/Admin/PollRequest.php`) and wired admin routes (`routes/admin.php`).
- Added API controllers and routes for listing/detail and voting (`app/Http/Controllers/Api/V1/PollController.php`, `app/Http/Controllers/Api/V1/PollVoteController.php`, `routes/api.php`) with user-vote loading and vote aggregation logic.
- Built Inertia/Vue admin pages for listing, creating, and editing polls (`resources/js/pages/acp/Polls.vue`, `PollCreate.vue`, `PollEdit.vue`) and added a `Polls` item to the admin sidebar (`resources/js/layouts/acp/AdminLayout.vue`).
- Extended permissions and seeders: added `polls` permissions to `database/seeders/RolePermissionSeeder.php`, assigned sensible rights to `editor`/`moderator`, and added `database/seeders/PollDemoSeeder.php` and included it in `DatabaseSeeder.php`.
- Updated `User` model to include a `pollVotes()` relation and added appropriate indexes/constraints on `poll_votes` (unique index and additional index adjustments) to support efficient queries.

### Testing
- No automated tests were executed in this change; please run `php artisan migrate` and `php artisan db:seed` (or the test suite) in your environment to validate behavior and run existing automated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978b14e4108832c86f550f5fe43d76b)